### PR TITLE
fix: Fix build&push GH action.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,13 +13,22 @@ jobs:
     steps:
       - name: Checkout application-service source code
         uses: actions/checkout@v2
-      - name: Docker Build & Push - application-service Operator Image
-        uses: docker/build-push-action@v1.1.0
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
         with:
+          image: e2e-tests
+          tags: latest ${{ github.sha }}
+          dockerfiles: |
+            ./Dockerfile
+      - name: Push To quay.io
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/redhat-appstudio
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
-          registry: quay.io
-          repository: redhat-appstudio/e2e-test
-          dockerfile: Dockerfile
-          tags: next
-          tag_with_sha: true
+      - name: Print image url
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"


### PR DESCRIPTION
Switch from docker GH actions to RedHat github actions for building
and pushing the image to quay.io.

I've tried to run this in my fork (with my credentials pushing to my quay.io repository) - Proof it's working: 
* https://github.com/rhopp/e2e-tests/runs/4458369614?check_suite_focus=true <- job run
* https://quay.io/repository/rhopp/e2e-tests?tag=latest&tab=tags <- quay.io pushed image

Signed-off-by: Radim Hopp <rhopp@redhat.com>