### PR TITLE
Add a wait time to e2e to wait for bundles templates to be created

### DIFF
--- a/pkg/tests/common/appstudio.go
+++ b/pkg/tests/common/appstudio.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/argoproj/gitops-engine/pkg/health"
@@ -9,15 +8,17 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 	commonCtrl "github.com/redhat-appstudio/e2e-tests/pkg/utils/common"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var (
 	// Pipelines names from https://github.com/redhat-appstudio/infra-deployments/tree/main/components/build/build-templates
-	AppStudioClusterTaskNames    = []string{"analyze-devfile", "appstudio-utils"}
+	AppStudioClusterTaskNames    = []string{"analyze-devfile", "cleanup-build-directories", "image-exists", "appstudio-utils"}
 	AppStudioComponents          = []string{"all-components-staging", "authentication", "build", "gitops", "has"}
 	AppStudioComponentsNamespace = "openshift-gitops"
 	PipelinesNamespace           = "build-templates"
+	ClusterTaskLabels            = map[string]string{"app.kubernetes.io/instance": "build"}
 )
 
 var _ = framework.CommonSuiteDescribe("Red Hat App Studio common E2E", func() {
@@ -31,22 +32,19 @@ var _ = framework.CommonSuiteDescribe("Red Hat App Studio common E2E", func() {
 				componentStatus, err := commonController.GetAppStudioComponentStatus(component, AppStudioComponentsNamespace)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(componentStatus.Health.Status).To(Equal(health.HealthStatusHealthy))
-
 			})
 		}
 	})
-	defer g.GinkgoRecover()
 
 	g.Context("ClusterTasks:", func() {
 		g.It("Check if AppStudio ClusterTasks are precreated", func() {
-			err := wait.PollImmediate(30*time.Second, 10*time.Minute, func() (done bool, err error) {
+			err := wait.PollImmediate(100*time.Millisecond, 3*time.Minute, func() (done bool, err error) {
 				for _, clusterTaskName := range AppStudioClusterTaskNames {
-					clusterTask, err := commonController.GetClusterTask(clusterTaskName, PipelinesNamespace)
-					if err != nil {
+					_, err := commonController.GetClusterTask(clusterTaskName, PipelinesNamespace)
+					if errors.IsNotFound(err) {
 						return false, nil
-					}
-					if clusterTaskName != clusterTask.Name {
-						return false, fmt.Errorf("Cluster task have an unexpected name")
+					} else if err != nil {
+						return false, err
 					}
 				}
 				return true, nil

--- a/pkg/tests/common/appstudio.go
+++ b/pkg/tests/common/appstudio.go
@@ -1,16 +1,20 @@
 package common
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/argoproj/gitops-engine/pkg/health"
 	g "github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 	commonCtrl "github.com/redhat-appstudio/e2e-tests/pkg/utils/common"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var (
 	// Pipelines names from https://github.com/redhat-appstudio/infra-deployments/tree/main/components/build/build-templates
-	AppStudioPipelinesNames      = []string{"analyze-devfile", "appstudio-utils"}
+	AppStudioClusterTaskNames    = []string{"analyze-devfile", "appstudio-utils"}
 	AppStudioComponents          = []string{"all-components-staging", "authentication", "build", "gitops", "has"}
 	AppStudioComponentsNamespace = "openshift-gitops"
 	PipelinesNamespace           = "build-templates"
@@ -19,26 +23,35 @@ var (
 var _ = framework.CommonSuiteDescribe("Red Hat App Studio common E2E", func() {
 	defer g.GinkgoRecover()
 	commonController, err := commonCtrl.NewSuiteController()
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	g.Context("Argo CD", func() {
 		for _, component := range AppStudioComponents {
 			g.It(component+" status", func() {
 				componentStatus, err := commonController.GetAppStudioComponentStatus(component, AppStudioComponentsNamespace)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(componentStatus.Health.Status).To(gomega.Equal(health.HealthStatusHealthy))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(componentStatus.Health.Status).To(Equal(health.HealthStatusHealthy))
 
 			})
 		}
 	})
+	defer g.GinkgoRecover()
 
 	g.Context("ClusterTasks:", func() {
-		for _, pipelineName := range AppStudioPipelinesNames {
-			g.It("Check if "+pipelineName+" clustertask is pre-created", func() {
-				p, err := commonController.GetClusterTask(pipelineName, PipelinesNamespace)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(p.Name).To(gomega.Equal(pipelineName))
+		g.It("Check if AppStudio ClusterTasks are precreated", func() {
+			err := wait.PollImmediate(30*time.Second, 10*time.Minute, func() (done bool, err error) {
+				for _, clusterTaskName := range AppStudioClusterTaskNames {
+					clusterTask, err := commonController.GetClusterTask(clusterTaskName, PipelinesNamespace)
+					if err != nil {
+						return false, nil
+					}
+					if clusterTaskName != clusterTask.Name {
+						return false, fmt.Errorf("Cluster task have an unexpected name")
+					}
+				}
+				return true, nil
 			})
-		}
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 })

--- a/pkg/tests/has/application.go
+++ b/pkg/tests/has/application.go
@@ -4,7 +4,7 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/has"
 
 	g "github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 )
 
@@ -17,23 +17,23 @@ var _ = framework.HASSuiteDescribe("Application E2E tests", func() {
 
 	defer g.GinkgoRecover()
 	hasController, err := has.NewSuiteController()
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	g.Context("Crud operation:", func() {
 		g.It("Create application", func() {
 			_, err := hasController.CreateHasApplication(ApplicationName, ApplicationNamespace)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 		g.It("Get application", func() {
 			status, err := hasController.GetHasApplicationStatus(ApplicationName, ApplicationNamespace)
 			for _, status := range status.Conditions {
-				gomega.Expect(string(status.Status)).To(gomega.Equal("True"))
+				Expect(string(status.Status)).To(Equal("True"))
 			}
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 		g.It("Delete application", func() {
 			err := hasController.DeleteHasApplication(ApplicationName, ApplicationNamespace)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/pkg/utils/common/controller.go
+++ b/pkg/utils/common/controller.go
@@ -3,11 +3,14 @@ package common
 import (
 	"context"
 	"fmt"
+
 	app "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/redhat-appstudio/e2e-tests/pkg/client"
+	rclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Create the struct for kubernetes clients
@@ -19,7 +22,7 @@ type SuiteController struct {
 func NewSuiteController() (*SuiteController, error) {
 	client, err := client.NewK8SClient()
 	if err != nil {
-		return nil, fmt.Errorf("Error creating client-go")
+		return nil, fmt.Errorf("Error creating client-go %v", err)
 	}
 	return &SuiteController{
 		client,
@@ -51,4 +54,13 @@ func (h *SuiteController) GetClusterTask(name string, namespace string) (*v1beta
 		return nil, err
 	}
 	return clusterTask, nil
+}
+
+// ListClusterTask return a list of ClusterTasks with a specific label selectors
+func (h *SuiteController) ListClusterTask(labelSelector map[string]string) ([]v1beta1.ClusterTask, error) {
+	clusterTasks := &v1beta1.ClusterTaskList{}
+	if err := h.KubeRest().List(context.TODO(), clusterTasks, &rclient.ListOptions{LabelSelector: labels.SelectorFromSet(labelSelector)}); err != nil {
+		return nil, err
+	}
+	return clusterTasks.Items, nil
 }

--- a/pkg/utils/has/controller.go
+++ b/pkg/utils/has/controller.go
@@ -3,6 +3,7 @@ package has
 import (
 	"context"
 	"fmt"
+
 	applicationservice "github.com/redhat-appstudio/application-service/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -17,7 +18,7 @@ type SuiteController struct {
 func NewSuiteController() (*SuiteController, error) {
 	client, err := client.NewK8SClient()
 	if err != nil {
-		return nil, fmt.Errorf("error creating client-go")
+		return nil, fmt.Errorf("error creating client-go %v", err)
 	}
 	return &SuiteController{
 		client,

--- a/report.xml
+++ b/report.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <testsuites tests="13" disabled="2" errors="0" failures="1" time="1.7004026749999999">
+      <testsuite name="Red Hat App Studio E2E tests" package="/home/flacatusu/WORKSPACE/appstudio-qe/e2e-tests" tests="13" disabled="0" skipped="2" errors="0" failures="1" time="1.7004026749999999" timestamp="2022-01-04T09:15:02">
+          <properties>
+              <property name="SuiteSucceeded" value="false"></property>
+              <property name="SuiteHasProgrammaticFocus" value="false"></property>
+              <property name="SpecialSuiteFailureReason" value=""></property>
+              <property name="SuiteLabels" value="[]"></property>
+              <property name="RandomSeed" value="1641284096"></property>
+              <property name="RandomizeAllSpecs" value="false"></property>
+              <property name="LabelFilter" value=""></property>
+              <property name="FocusStrings" value=""></property>
+              <property name="SkipStrings" value=""></property>
+              <property name="FocusFiles" value=""></property>
+              <property name="SkipFiles" value=""></property>
+              <property name="FailOnPending" value="false"></property>
+              <property name="FailFast" value="false"></property>
+              <property name="FlakeAttempts" value="0"></property>
+              <property name="EmitSpecProgress" value="false"></property>
+              <property name="DryRun" value="false"></property>
+              <property name="ParallelTotal" value="1"></property>
+              <property name="OutputInterceptorMode" value=""></property>
+          </properties>
+          <testcase name="[SynchronizedBeforeSuite]" classname="Red Hat App Studio E2E tests" status="passed" time="1.4217e-05"></testcase>
+          <testcase name="[It] [has-suite Component E2E tests] Crud operation: Create Component" classname="Red Hat App Studio E2E tests" status="skipped" time="9.6228e-05">
+              <skipped message="skipped - Skipped. No tests detected"></skipped>
+          </testcase>
+          <testcase name="[It] [has-suite Application E2E tests] Crud operation: Create application" classname="Red Hat App Studio E2E tests" status="passed" time="0.145473508"></testcase>
+          <testcase name="[It] [has-suite Application E2E tests] Crud operation: Get application" classname="Red Hat App Studio E2E tests" status="passed" time="0.137176369"></testcase>
+          <testcase name="[It] [has-suite Application E2E tests] Crud operation: Delete application" classname="Red Hat App Studio E2E tests" status="passed" time="0.138766789"></testcase>
+          <testcase name="[It] [common-suite Red Hat App Studio common E2E] Argo CD all-components-staging status" classname="Red Hat App Studio E2E tests" status="passed" time="0.137940477"></testcase>
+          <testcase name="[It] [common-suite Red Hat App Studio common E2E] Argo CD authentication status" classname="Red Hat App Studio E2E tests" status="passed" time="0.142482464"></testcase>
+          <testcase name="[It] [common-suite Red Hat App Studio common E2E] Argo CD build status" classname="Red Hat App Studio E2E tests" status="passed" time="0.136405148"></testcase>
+          <testcase name="[It] [common-suite Red Hat App Studio common E2E] Argo CD gitops status" classname="Red Hat App Studio E2E tests" status="passed" time="0.138873376"></testcase>
+          <testcase name="[It] [common-suite Red Hat App Studio common E2E] Argo CD has status" classname="Red Hat App Studio E2E tests" status="passed" time="0.14026885"></testcase>
+          <testcase name="[It] [common-suite Red Hat App Studio common E2E] ClusterTasks: Check if AppStudio ClusterTasks are precreated" classname="Red Hat App Studio E2E tests" status="passed" time="0.425065149"></testcase>
+          <testcase name="[It] [common-suite Red Hat App Studio common E2E] ClusterTasks: Check clusterTasks list" classname="Red Hat App Studio E2E tests" status="failed" time="0.156838356">
+              <failure message="E2E tests don&#39;t contain all AppStudio clusterTasks&#xA;Expected&#xA;    &lt;int&gt;: 4&#xA;to equal&#xA;    &lt;int&gt;: 3" type="failed">/home/flacatusu/WORKSPACE/appstudio-qe/e2e-tests/pkg/tests/common/appstudio.go:57&#xA;github.com/redhat-appstudio/e2e-tests/pkg/tests/common.glob..func1.2.2()&#xA;&#x9;/home/flacatusu/WORKSPACE/appstudio-qe/e2e-tests/pkg/tests/common/appstudio.go:57 +0x130</failure>
+          </testcase>
+          <testcase name="[It] [has-suite Push E2E tests] Crud operation: Create Push" classname="Red Hat App Studio E2E tests" status="skipped" time="0.000174199">
+              <skipped message="skipped - Skipped. No tests detected"></skipped>
+          </testcase>
+      </testsuite>
+  </testsuites>


### PR DESCRIPTION
This PR contain the next changes:
 * "dot imports" - to make the code shorter and easier to read for gomega
 * Add a poll to wait for clusterTasks to be pre-created in cluster. 