### PR TITLE
Remove dependency on kustomize

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -2,13 +2,10 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.16
 
 SHELL ["/bin/bash", "-c"]
 
-# Install yq, kubectl, kustomize
+# Install yq, kubectl
 RUN yum install --assumeyes -d1 python3-pip  httpd-tools && \
     pip3 install --upgrade setuptools && \
     pip3 install yq && \
     curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
-    mv ./kubectl /usr/local/bin && \
-    curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash && \
-    cp kustomize /usr/bin/ && \
-    chmod ug+x /usr/bin/kustomize
+    mv ./kubectl /usr/local/bin

--- a/.ci/openshift-ci/oci-launch-e2e.sh
+++ b/.ci/openshift-ci/oci-launch-e2e.sh
@@ -11,7 +11,6 @@ export WORKSPACE=$(dirname $(dirname $(readlink -f "$0")));
 
 command -v yq >/dev/null 2>&1 || { echo "yq is not installed. Aborting."; exit 1; }
 command -v kubectl >/dev/null 2>&1 || { echo "kubectl is not installed. Aborting."; exit 1; }
-command -v kustomize >/dev/null 2>&1 || { echo "kustomize is not installed. Aborting."; exit 1; }
 
 # catch and stop execution on any error
 trap "catchFinishedCode" EXIT SIGINT


### PR DESCRIPTION
Infra-deployment switched to use integrated kustomize command in `oc`
and `kubectl`.

Can be merged after https://github.com/redhat-appstudio/infra-deployments/pull/134