### PR TITLE
Wait for signature and attestation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/gomega v1.18.1
 	github.com/openshift/api v0.0.0-20200930075302-db52bc4ef99f
 	github.com/redhat-appstudio/application-service v0.0.0-20220312031926-2976522a9052
+	github.com/stretchr/testify v1.7.1
 	github.com/tektoncd/pipeline v0.32.1
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.22.5

--- a/go.sum
+++ b/go.sum
@@ -1347,8 +1347,9 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/sylvia7788/contextcheck v1.0.4/go.mod h1:vuPKJMQ7MQ91ZTqfdyreNKwZjyUg6KO+IebVyQDedZQ=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/pkg/tests/build/chains.go
+++ b/pkg/tests/build/chains.go
@@ -1,6 +1,8 @@
 package build
 
 import (
+	"time"
+
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/common"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
 
@@ -46,6 +48,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 	g.Context("test creating and signing an image and task", func() {
 		image := "image-registry.openshift-image-registry.svc:5000/tekton-chains/buildah-demo"
 		taskTimeout := 180
+		attestationTimeout := time.Duration(60) * time.Second
 		kubeController := tekton.KubeController{
 			Commonctrl: *commonController,
 			Tektonctrl: *tektonController,
@@ -58,15 +61,17 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 			waitErr := kubeController.WatchTaskPod(tr.Name, taskTimeout)
 			Expect(waitErr).NotTo(HaveOccurred())
 		})
+		g.It("creates attestation", func() {
+			err := kubeController.AwaitAttestationAndSignature(image, attestationTimeout)
+			Expect(err).NotTo(HaveOccurred(), "Could not find .att or .sig ImageStreamTags within the %s timeout. Most likely the chains-controller did not create those in time. Look at the chains-controller and buildah task logs.", attestationTimeout.String())
+		})
 		g.It("verify image attestation", func() {
-			g.Skip("Temporarily disabling due to a race condition in the test")
 			tr, waitTrErr := kubeController.RunVerifyTask("cosign-verify-attestation", image, taskTimeout)
 			Expect(waitTrErr).NotTo(HaveOccurred())
 			waitErr := kubeController.WatchTaskPod(tr.Name, taskTimeout)
 			Expect(waitErr).NotTo(HaveOccurred())
 		})
 		g.It("cosign verify", func() {
-			g.Skip("Temporarily disabling due to a race condition in the test")
 			tr, waitTrErr := kubeController.RunVerifyTask("cosign-verify", image, taskTimeout)
 			Expect(waitTrErr).NotTo(HaveOccurred())
 			waitErr := kubeController.WatchTaskPod(tr.Name, taskTimeout)

--- a/pkg/tests/build/chains.go
+++ b/pkg/tests/build/chains.go
@@ -61,7 +61,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 			waitErr := kubeController.WatchTaskPod(tr.Name, taskTimeout)
 			Expect(waitErr).NotTo(HaveOccurred())
 		})
-		g.It("creates attestation", func() {
+		g.It("creates signature and attestation", func() {
 			err := kubeController.AwaitAttestationAndSignature(image, attestationTimeout)
 			Expect(err).NotTo(HaveOccurred(), "Could not find .att or .sig ImageStreamTags within the %s timeout. Most likely the chains-controller did not create those in time. Look at the chains-controller and buildah task logs.", attestationTimeout.String())
 		})

--- a/pkg/utils/tekton/controller.go
+++ b/pkg/utils/tekton/controller.go
@@ -116,8 +116,12 @@ func (k KubeController) RunVerifyTask(taskName, image string, taskTimeout int) (
 
 func (k KubeController) AwaitAttestationAndSignature(image string, timeout time.Duration) error {
 	return wait.PollImmediate(time.Second, timeout, func() (done bool, err error) {
-		if _, err := k.FindCosignResultsForImage(image); err != nil && !errors.IsNotFound(err) {
-			return false, err
+		if _, err := k.FindCosignResultsForImage(image); err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return true, err
 		}
 
 		return true, nil

--- a/pkg/utils/tekton/controller_test.go
+++ b/pkg/utils/tekton/controller_test.go
@@ -1,0 +1,114 @@
+package tekton
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCosignResultShouldPresence(t *testing.T) {
+	assert.False(t, CosignResult{}.IsPresent())
+
+	assert.False(t, CosignResult{
+		signatureImageRef: "something",
+	}.IsPresent())
+
+	assert.False(t, CosignResult{
+		attestationImageRef: "something",
+	}.IsPresent())
+
+	assert.True(t, CosignResult{
+		signatureImageRef:   "something",
+		attestationImageRef: "something",
+	}.IsPresent())
+}
+
+func TestCosignResultMissingFormat(t *testing.T) {
+	assert.Equal(t, "prefix.sig and prefix.att", CosignResult{}.Missing("prefix"))
+
+	assert.Equal(t, "prefix.att", CosignResult{
+		signatureImageRef: "something",
+	}.Missing("prefix"))
+
+	assert.Equal(t, "prefix.sig", CosignResult{
+		attestationImageRef: "something",
+	}.Missing("prefix"))
+
+	assert.Empty(t, CosignResult{
+		signatureImageRef:   "something",
+		attestationImageRef: "something",
+	}.Missing("prefix"))
+}
+
+func newTag(name string, hash string) unstructured.Unstructured {
+	tag := unstructured.Unstructured{}
+	tag.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "image.openshift.io",
+		Kind:    "ImageStreamTag",
+		Version: "v1",
+	})
+	tag.SetNamespace("test-namespace")
+	tag.SetName(name)
+
+	if hash != "" {
+		if err := unstructured.SetNestedField(tag.Object, hash, "image", "metadata", "name"); err != nil {
+			panic(err)
+		}
+	}
+
+	return tag
+}
+
+func TestFindingCosignResults(t *testing.T) {
+	cases := []struct {
+		Name          string
+		Tags          []unstructured.Unstructured
+		ExpectedError string
+		Result        *CosignResult
+	}{
+		{"happy day", []unstructured.Unstructured{
+			newTag("test-image:latest", "sha256:hash"),
+			newTag("test-image:sha256-hash.sig", ""),
+			newTag("test-image:sha256-hash.att", ""),
+		}, "", &CosignResult{
+			signatureImageRef:   "test-image:sha256-hash.sig",
+			attestationImageRef: "test-image:sha256-hash.att",
+		}},
+		{"missing signature", []unstructured.Unstructured{
+			newTag("test-image:latest", "sha256:hash"),
+			newTag("test-image:sha256-hash.att", ""),
+		}, "ImageStreamTag.image.openshift.io \"test-image:sha256-hash.sig\" not found", nil},
+		{"missing attestation", []unstructured.Unstructured{
+			newTag("test-image:latest", "sha256:hash"),
+			newTag("test-image:sha256-hash.sig", ""),
+		}, "ImageStreamTag.image.openshift.io \"test-image:sha256-hash.att\" not found", nil},
+		{"missing signature and attestation", []unstructured.Unstructured{
+			newTag("test-image:latest", "sha256:hash"),
+		}, "ImageStreamTag.image.openshift.io \"test-image:sha256-hash.sig and test-image:sha256-hash.att\" not found", nil},
+		{"everything missing", []unstructured.Unstructured{}, "ImageStreamTag.image.openshift.io \"test-image:latest\" not found", nil},
+	}
+
+	for _, cse := range cases {
+		t.Run(cse.Name, func(t *testing.T) {
+			tags := unstructured.UnstructuredList{
+				Items: cse.Tags,
+			}
+
+			client := fake.NewClientBuilder().WithLists(&tags).Build()
+
+			result, err := findCosignResultsForImage("image-registry.openshift-image-registry.svc:5000/test-namespace/test-image", client)
+
+			if err != nil || cse.ExpectedError != "" {
+				assert.EqualError(t, err, cse.ExpectedError)
+				assert.True(t, errors.IsNotFound(err))
+			}
+
+			assert.Equal(t, cse.Result, result)
+		})
+	}
+
+}


### PR DESCRIPTION
In the chains test we before we check the attestation and signature we
need to make sure that the chains-controller has had enough time to
create them. Otherwise we would fail the cosign* tasks due to the images
with the attestation and signature not pushed/tagged in the interlan
registry.

This adds a step to wait for a maximum of 60 seconds for the images to
be created by listing the ImageStreamTag and looking for the specific
`.att` and `.sig` image tags to be present there.

Fixes https://issues.redhat.com/browse/HACBS-278