### PR TITLE
fix mac export ROOT_E2E

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ vendor/
 bin/
 .idea/
 tmp/
+.DS_Store

--- a/scripts/install-appstudio-e2e-mode.sh
+++ b/scripts/install-appstudio-e2e-mode.sh
@@ -14,7 +14,7 @@ export MY_GIT_FORK_REMOTE="qe"
 export MY_GITHUB_ORG=${GITHUB_E2E_ORGANIZATION:-"redhat-appstudio-qe"}
 export MY_GITHUB_TOKEN="${GITHUB_TOKEN}"
 export TEST_BRANCH_ID=$(date +%s)
-export ROOT_E2E=$(dirname $(dirname $(readlink -f "$0")));
+export ROOT_E2E="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
 export WORKSPACE=${WORKSPACE:-${ROOT_E2E}}
 
 # Download gitops repository to install AppStudio in e2e mode.


### PR DESCRIPTION
Changed ROOT_E2E export to "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/.. to work on MacOS.