### PR TITLE
Increase the timeout value to avoid the pipelinerun test case fails

### DIFF
--- a/pkg/tests/has/devfile_source.go
+++ b/pkg/tests/has/devfile_source.go
@@ -105,7 +105,7 @@ var _ = framework.HASSuiteDescribe("devfile source", func() {
 	})
 
 	It("Wait for component pipeline to be completed", func() {
-		err := wait.PollImmediate(20*time.Second, 10*time.Minute, func() (done bool, err error) {
+		err := wait.PollImmediate(20*time.Second, 20*time.Minute, func() (done bool, err error) {
 			pipelineRun, _ := hasController.GetComponentPipeline(QuarkusComponentName, RedHatAppStudioApplicationName)
 
 			for _, condition := range pipelineRun.Status.Conditions {


### PR DESCRIPTION

Signed-off-by: Jing Qi <jinqi@redhat.com>

The pipelinerun test takes a long time in small environment, so increase 
the timeout value to avoid failure 