### PR TITLE
test: allow running e2e test suite in custom namespace

### DIFF
--- a/.ci/oci-launch-e2e.sh
+++ b/.ci/oci-launch-e2e.sh
@@ -45,7 +45,7 @@ function executeE2ETests() {
     "${WORKSPACE}"/bin/e2e-appstudio --ginkgo.junit-report="${ARTIFACTS_DIR}"/e2e-report.xml
 }
 
-curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/main/scripts/install-appstudio-e2e-mode.sh | bash -s install
+curl "https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/${PULL_PULL_SHA}/scripts/install-appstudio-e2e-mode.sh" | bash -s install
 
 export -f waitAppStudioToBeReady
 export -f waitBuildToBeReady

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -16,4 +16,14 @@ const (
 
 	//Cluster Registration namespace
 	CLUSTER_REG_NS string = "cluster-reg-config" // #nosec
+
+	// E2E test namespace where the app and component CRs will be created
+	E2E_APPLICATIONS_NAMESPACE_ENV string = "E2E_APPLICATIONS_NAMESPACE"
+
+	// Skip checking "ApplicationServiceGHTokenSecrName" secret
+	SKIP_HAS_SECRET_CHECK_ENV string = "SKIP_HAS_SECRET_CHECK"
+
+	// Test namespace's required labels
+	ArgoCDLabelKey   string = "argocd.argoproj.io/managed-by"
+	ArgoCDLabelValue string = "gitops-service-argocd"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -14,6 +14,6 @@ const (
 	//The Tekton namespace
 	TEKTON_CHAINS_NS string = "tekton-chains" // #nosec
 
-	//Cluster Registration namespace 
+	//Cluster Registration namespace
 	CLUSTER_REG_NS string = "cluster-reg-config" // #nosec
 )

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -17,7 +17,7 @@ type Framework struct {
 }
 
 // Initialize all test controllers and return them in a Framework
-func NewFramweork() (*Framework, error) {
+func NewFramework() (*Framework, error) {
 
 	// Initialize a common kubernetes client to be passed to the test controllers
 	kubeClient, err := kubeCl.NewK8SClient()

--- a/pkg/utils/has/controller.go
+++ b/pkg/utils/has/controller.go
@@ -203,11 +203,9 @@ func (h *SuiteController) CreateTestNamespace(name string) (*corev1.Namespace, e
 			return nil, fmt.Errorf("error when getting the '%s' namespace: %v", name, err)
 		}
 	} else {
-		// Check whether the test namespace contains correct labels
-		for k, v := range ns.Labels {
-			if k == constants.ArgoCDLabelKey && v == constants.ArgoCDLabelValue {
-				return ns, nil
-			}
+		// Check whether the test namespace contains correct label
+		if val, ok := ns.Labels[constants.ArgoCDLabelKey]; ok && val == constants.ArgoCDLabelValue {
+			return ns, nil
 		}
 		// Update test namespace labels in case they are missing argoCD label
 		ns.Labels[constants.ArgoCDLabelKey] = constants.ArgoCDLabelValue

--- a/pkg/utils/has/controller.go
+++ b/pkg/utils/has/controller.go
@@ -122,10 +122,10 @@ func (h *SuiteController) CreateComponent(applicationName string, componentName 
 }
 
 // GetComponentPipeline returns the pipeline for a given component labels
-func (h *SuiteController) GetComponentPipeline(componentName string, applicationName string) (v1beta1.PipelineRun, error) {
+func (h *SuiteController) GetComponentPipeline(componentName string, applicationName string, namespace string) (v1beta1.PipelineRun, error) {
 	pipelineRunLabels := map[string]string{"build.appstudio.openshift.io/component": componentName, "build.appstudio.openshift.io/application": applicationName}
 	list := &v1beta1.PipelineRunList{}
-	err := h.KubeRest().List(context.TODO(), list, &rclient.ListOptions{LabelSelector: labels.SelectorFromSet(pipelineRunLabels)})
+	err := h.KubeRest().List(context.TODO(), list, &rclient.ListOptions{LabelSelector: labels.SelectorFromSet(pipelineRunLabels), Namespace: namespace})
 
 	if len(list.Items) > 0 {
 		return list.Items[0], nil

--- a/scripts/Readme.md
+++ b/scripts/Readme.md
@@ -36,6 +36,7 @@ The following environments are used to launch the Red Hat AppStudio installation
 | `QUAY_TOKEN` | yes | A quay token to push components images to quay.io. Note the quay token must be in base 64 format `ewogI3dJhdXRocyI6I...` | '' |
 | `GITHUB_E2E_ORGANIZATION` | no | GitHub Organization where to create/push Red Hat AppStudio Applications  | `redhat-appstudio-qe`  |
 | `QUAY_E2E_ORGANIZATION` | no | Quay organization where to push components containers | `redhat-appstudio-qe` |
+| `E2E_APPLICATIONS_NAMESPACE` | no | Name of the namespace used for running HAS E2E tests | `appstudio-e2e-test` |
 
 * NOTE: Make sure that your Github Token have the following rights in the github organization where you will run the e2e tests.
     - `repo`

--- a/scripts/install-appstudio-e2e-mode.sh
+++ b/scripts/install-appstudio-e2e-mode.sh
@@ -16,6 +16,7 @@ export MY_GITHUB_TOKEN="${GITHUB_TOKEN}"
 export TEST_BRANCH_ID=$(date +%s)
 export ROOT_E2E="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
 export WORKSPACE=${WORKSPACE:-${ROOT_E2E}}
+export E2E_APPLICATIONS_NAMESPACE=${E2E_APPLICATIONS_NAMESPACE:-appstudio-e2e-test}
 
 # Download gitops repository to install AppStudio in e2e mode.
 function cloneInfraDeployments() {
@@ -34,12 +35,12 @@ function addQERemoteForkAndInstallAppstudio() {
 
 # Secrets used by pipelines to push component containers to quay.io
 function createApplicationServiceSecrets() {
-    echo -e "[INFO] Creating application-service related secrets"
+    echo -e "[INFO] Creating application-service related secrets in $E2E_APPLICATIONS_NAMESPACE namespace"
 
     echo "$QUAY_TOKEN" | base64 --decode > docker.config
-    oc create namespace application-service --dry-run=client -o yaml | oc apply -f - || true
-    kubectl create secret docker-registry redhat-appstudio-registry-pull-secret -n  application-service --from-file=.dockerconfigjson=docker.config || true
-    kubectl create secret docker-registry redhat-appstudio-staginguser-pull-secret -n  application-service --from-file=.dockerconfigjson=docker.config || true
+    oc create namespace "$E2E_APPLICATIONS_NAMESPACE" --dry-run=client -o yaml | oc apply -f - || true
+    kubectl create secret docker-registry redhat-appstudio-registry-pull-secret -n  "$E2E_APPLICATIONS_NAMESPACE" --from-file=.dockerconfigjson=docker.config || true
+    kubectl create secret docker-registry redhat-appstudio-staginguser-pull-secret -n "$E2E_APPLICATIONS_NAMESPACE" --from-file=.dockerconfigjson=docker.config || true
     rm docker.config
 }
 

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -15,7 +15,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 	defer g.GinkgoRecover()
 
 	// Initialize the tests controllers
-	framework, err := framework.NewFramweork()
+	framework, err := framework.NewFramework()
 	Expect(err).NotTo(HaveOccurred())
 
 	g.Context("infrastructure is running", func() {

--- a/tests/cluster-registration/clusters.go
+++ b/tests/cluster-registration/clusters.go
@@ -11,7 +11,7 @@ var _ = framework.ClusterRegistrationSuiteDescribe("Cluster Registration E2E tes
 	defer g.GinkgoRecover()
 
 	// Initialize the tests controllers
-	framework, err := framework.NewFramweork()
+	framework, err := framework.NewFramework()
 	Expect(err).NotTo(HaveOccurred())
 
 

--- a/tests/has/const.go
+++ b/tests/has/const.go
@@ -6,6 +6,9 @@ const (
 	// Argo CD Application service name: https://github.com/redhat-appstudio/infra-deployments/blob/main/argo-cd-apps/base/has.yaml#L4
 	HASArgoApplicationName string = "has"
 
+	// Application Service controller is deployed the namespace: https://github.com/redhat-appstudio/infra-deployments/blob/main/argo-cd-apps/base/has.yaml#L14
+	RedHatAppStudioApplicationNamespace string = "application-service"
+
 	// Red Hat AppStudio ArgoCD Applications are created in 'openshift-gitops' namespace. See: https://github.com/redhat-appstudio/infra-deployments/blob/main/argo-cd-apps/app-of-apps/all-applications-staging.yaml#L5
 	GitOpsNamespace string = "openshift-gitops"
 

--- a/tests/has/const.go
+++ b/tests/has/const.go
@@ -6,9 +6,6 @@ const (
 	// Argo CD Application service name: https://github.com/redhat-appstudio/infra-deployments/blob/main/argo-cd-apps/base/has.yaml#L4
 	HASArgoApplicationName string = "has"
 
-	// Application Service controller is deployed the namespace: https://github.com/redhat-appstudio/infra-deployments/blob/main/argo-cd-apps/base/has.yaml#L14
-	RedHatAppStudioApplicationNamespace string = "application-service"
-
 	// Red Hat AppStudio ArgoCD Applications are created in 'openshift-gitops' namespace. See: https://github.com/redhat-appstudio/infra-deployments/blob/main/argo-cd-apps/app-of-apps/all-applications-staging.yaml#L5
 	GitOpsNamespace string = "openshift-gitops"
 

--- a/tests/has/devfile_source.go
+++ b/tests/has/devfile_source.go
@@ -23,8 +23,8 @@ import (
 )
 
 var (
-	ComponentContainerImage             string = fmt.Sprintf("quay.io/%s/quarkus:%s", GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-	RedHatAppStudioApplicationNamespace string = utils.GetEnv(constants.HAS_BUILD_NAMESPACE_ENV, "application-service")
+	ComponentContainerImage           string = fmt.Sprintf("quay.io/%s/quarkus:%s", GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+	AppStudioE2EApplicationsNamespace string = utils.GetEnv(constants.E2E_APPLICATIONS_NAMESPACE_ENV, "appstudio-e2e-test")
 )
 
 /*
@@ -36,7 +36,7 @@ var _ = framework.HASSuiteDescribe("devfile source", func() {
 	defer GinkgoRecover()
 
 	// Initialize the tests controllers
-	framework, err := framework.NewFramweork()
+	framework, err := framework.NewFramework()
 	Expect(err).NotTo(HaveOccurred())
 
 	// Initialize the application struct
@@ -51,14 +51,16 @@ var _ = framework.HASSuiteDescribe("devfile source", func() {
 			Expect(err).NotTo(HaveOccurred(), "Error checking 'has-github-token' secret %s", err)
 		}
 
-		klog.Info("HAS Argo CD application is ready")
+		_, err := framework.HasController.CreateTestNamespace(AppStudioE2EApplicationsNamespace)
+		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", AppStudioE2EApplicationsNamespace, err)
+
 	})
 
 	AfterAll(func() {
-		err := framework.HasController.DeleteHasComponent(QuarkusComponentName, RedHatAppStudioApplicationNamespace)
+		err := framework.HasController.DeleteHasComponent(QuarkusComponentName, AppStudioE2EApplicationsNamespace)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = framework.HasController.DeleteHasApplication(RedHatAppStudioApplicationName, RedHatAppStudioApplicationNamespace)
+		err = framework.HasController.DeleteHasApplication(RedHatAppStudioApplicationName, AppStudioE2EApplicationsNamespace)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() bool {
@@ -70,15 +72,15 @@ var _ = framework.HASSuiteDescribe("devfile source", func() {
 	})
 
 	It("Create Red Hat AppStudio Application", func() {
-		createdApplication, err := framework.HasController.CreateHasApplication(RedHatAppStudioApplicationName, RedHatAppStudioApplicationNamespace)
+		createdApplication, err := framework.HasController.CreateHasApplication(RedHatAppStudioApplicationName, AppStudioE2EApplicationsNamespace)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createdApplication.Spec.DisplayName).To(Equal(RedHatAppStudioApplicationName))
-		Expect(createdApplication.Namespace).To(Equal(RedHatAppStudioApplicationNamespace))
+		Expect(createdApplication.Namespace).To(Equal(AppStudioE2EApplicationsNamespace))
 	})
 
 	It("Check Red Hat AppStudio Application health", func() {
 		Eventually(func() string {
-			application, err = framework.HasController.GetHasApplication(RedHatAppStudioApplicationName, RedHatAppStudioApplicationNamespace)
+			application, err = framework.HasController.GetHasApplication(RedHatAppStudioApplicationName, AppStudioE2EApplicationsNamespace)
 			Expect(err).NotTo(HaveOccurred())
 
 			return application.Status.Devfile
@@ -100,14 +102,14 @@ var _ = framework.HASSuiteDescribe("devfile source", func() {
 	})
 
 	It("Create Red Hat AppStudio Quarkus component", func() {
-		component, err := framework.HasController.CreateComponent(application.Name, QuarkusComponentName, RedHatAppStudioApplicationNamespace, QuarkusDevfileSource, ComponentContainerImage)
+		component, err := framework.HasController.CreateComponent(application.Name, QuarkusComponentName, AppStudioE2EApplicationsNamespace, QuarkusDevfileSource, ComponentContainerImage)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(component.Name).To(Equal(QuarkusComponentName))
 	})
 
 	It("Wait for component pipeline to be completed", func() {
 		err := wait.PollImmediate(20*time.Second, 10*time.Minute, func() (done bool, err error) {
-			pipelineRun, _ := framework.HasController.GetComponentPipeline(QuarkusComponentName, RedHatAppStudioApplicationName, RedHatAppStudioApplicationNamespace)
+			pipelineRun, _ := framework.HasController.GetComponentPipeline(QuarkusComponentName, RedHatAppStudioApplicationName, AppStudioE2EApplicationsNamespace)
 
 			for _, condition := range pipelineRun.Status.Conditions {
 				klog.Infof("PipelineRun %s reason: %s", pipelineRun.Name, condition.Reason)
@@ -127,7 +129,7 @@ var _ = framework.HASSuiteDescribe("devfile source", func() {
 
 	It("Check component deployment health", func() {
 		Eventually(func() bool {
-			deployment, _ := framework.HasController.GetComponentDeployment(QuarkusComponentName, RedHatAppStudioApplicationNamespace)
+			deployment, _ := framework.HasController.GetComponentDeployment(QuarkusComponentName, AppStudioE2EApplicationsNamespace)
 			if deployment.Status.AvailableReplicas == 1 {
 				klog.Infof("Deployment %s is ready", deployment.Name)
 				return true
@@ -139,14 +141,14 @@ var _ = framework.HASSuiteDescribe("devfile source", func() {
 	})
 
 	It("Check component service health", func() {
-		service, err := framework.HasController.GetComponentService(QuarkusComponentName, RedHatAppStudioApplicationNamespace)
+		service, err := framework.HasController.GetComponentService(QuarkusComponentName, AppStudioE2EApplicationsNamespace)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(service.Name).NotTo(BeEmpty())
 		klog.Infof("Service %s is ready", service.Name)
 	})
 
 	It("Verify component route health", func() {
-		route, err := framework.HasController.GetComponentRoute(QuarkusComponentName, RedHatAppStudioApplicationNamespace)
+		route, err := framework.HasController.GetComponentRoute(QuarkusComponentName, AppStudioE2EApplicationsNamespace)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(route.Spec.Host).To(Not(BeEmpty()))
 		klog.Infof("Component route host: %s", route.Spec.Host)


### PR DESCRIPTION
### JIRA link
https://issues.redhat.com/browse/PLNSRVCE-149

### What
* allow running the e2e test suite in the namespace provided via `E2E_APPLICATIONS_NAMESPACE` env var (otherwise use default namespace: 'appstudio-e2e-test')
* make sure the specified namespace has the required label: `argocd.argoproj.io/managed-by: gitops-service-argocd`, otherwise update the namespace with that label
* skip checking `has-github-token` secret in `application-service` namespace if `SKIP_HAS_SECRET_CHECK` env var is set
* with these changes, we are able to run the whole HAS test suite in custom namespace as a regular user
* follow-up PR: https://github.com/redhat-appstudio/infra-deployments/pull/298

### Verification steps
1. Run
```bash
export GITHUB_TOKEN=<YOUR_GITHUB_TOKEN> GITHUB_E2E_ORGANIZATION=<YOUR_GITHUB_ORG> QUAY_E2E_ORGANIZATION=<YOUR_QUAY_ORG> E2E_APPLICATIONS_NAMESPACE=test-e2e-custom-ns SKIP_HAS_SECRET_CHECK=true

make build && ./bin/e2e-appstudio --ginkgo.vv --ginkgo.progress --ginkgo.focus=has-suite
```
2. While the test is running, run this to create `redhat-appstudio-registry-pull-secret` secret in the new test namespace
```bash
oc create secret docker-registry redhat-appstudio-registry-pull-secret --from-file=.dockerconfigjson=<PATH_TO_YOUR_DOCKER_CONFIG> -n test-e2e-custom-ns
```
3. The test suite should finish successfully