### PR TITLE
fix: replace "scratch" base image with ubi-minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ USER root
 COPY . .
 RUN GOOS=linux make build
 
-FROM scratch
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 WORKDIR /root/
 COPY --from=builder /github.com/redhat-appstudio/e2e-tests/bin/e2e-appstudio ./

--- a/pkg/apis/github/repositories.go
+++ b/pkg/apis/github/repositories.go
@@ -9,6 +9,7 @@ import (
 func (g *API) CheckIfRepositoryExist(repository string) bool {
 	repoRequest, err := g.Get(context.TODO(), "application/json", nil, repository)
 	if err != nil {
+		klog.Errorf("Error when sending request to Github API: %v", err)
 		return false
 	}
 	klog.Infof("Repository %s status request to github: %d", repository, repoRequest.StatusCode)


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/PLNSRVCE-149

### Why
We were running e2e tests on a staging cluster and were getting the following error caused by missing certificates in the e2e-tests container image
```
E0427 13:43:41.065154      16 repositories.go:12] error when sending request to github API: Get "https://api.github.com/repos/redhat-appstudio-appdata/pet-clinic-e2e-build-templates-think-face": x509: certificate signed by unknown authority
```

Replacing the base image with ubi-minimal fixes the issue