### PR TITLE
fix: Remove unused checks

### DIFF
--- a/tests/has/devfile_source.go
+++ b/tests/has/devfile_source.go
@@ -12,7 +12,6 @@ import (
 	"github.com/redhat-appstudio/application-service/pkg/devfile"
 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
-	"k8s.io/klog/v2"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -103,33 +102,6 @@ var _ = framework.HASSuiteDescribe("devfile source", func() {
 		component, err := framework.HasController.CreateComponent(application.Name, QuarkusComponentName, AppStudioE2EApplicationsNamespace, QuarkusDevfileSource, ComponentContainerImage)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(component.Name).To(Equal(QuarkusComponentName))
-	})
-
-	It("Check component deployment health", func() {
-		Eventually(func() bool {
-			deployment, _ := framework.HasController.GetComponentDeployment(QuarkusComponentName, AppStudioE2EApplicationsNamespace)
-			if deployment.Status.AvailableReplicas == 1 {
-				klog.Infof("Deployment %s is ready", deployment.Name)
-				return true
-			}
-
-			return false
-		}, 3*time.Minute, 10*time.Second).Should(BeTrue(), "Component deployment didn't become ready")
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("Check component service health", func() {
-		service, err := framework.HasController.GetComponentService(QuarkusComponentName, AppStudioE2EApplicationsNamespace)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(service.Name).NotTo(BeEmpty())
-		klog.Infof("Service %s is ready", service.Name)
-	})
-
-	It("Verify component route health", func() {
-		route, err := framework.HasController.GetComponentRoute(QuarkusComponentName, AppStudioE2EApplicationsNamespace)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(route.Spec.Host).To(Not(BeEmpty()))
-		klog.Infof("Component route host: %s", route.Spec.Host)
 	})
 })
 


### PR DESCRIPTION
Removing this tests in favor of gitops deployments. Related [PR](https://github.com/redhat-appstudio/e2e-tests/pull/57) where gitops checks are added. This PR also fix some failures in CI like: https://github.com/redhat-appstudio/application-service/pull/104