### PR TITLE
test: Use Go 1.17 to build e2e-tests

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.16
+FROM registry.ci.openshift.org/openshift/release:golang-1.17
 
 SHELL ["/bin/bash", "-c"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12-4 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS builder
 
 WORKDIR /github.com/redhat-appstudio/e2e-tests
 USER root


### PR DESCRIPTION
To unblock https://github.com/redhat-appstudio/e2e-tests/pull/63 and https://github.com/redhat-appstudio/e2e-tests/pull/65 which both depend on Go 1.17