### PR TITLE
fix: unify output image name for all test suites

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -71,7 +71,7 @@ var _ = framework.BuildSuiteDescribe("Build Service E2E tests", func() {
 	When("component with git source is created", func() {
 		BeforeAll(func() {
 			componentName = "build-suite-test-component-git-source"
-			outputContainerImage = fmt.Sprintf("quay.io/%s/pipeline-build-test-image:%s", has.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", has.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
 			timeout = time.Second * 60
 			interval = time.Second * 1
 			// Create a component with Git Source URL being defined

--- a/tests/has/Readme.md
+++ b/tests/has/Readme.md
@@ -18,7 +18,7 @@ Simple tests where:
 * The framework create an `Application` CR.
 * Verify if the application was created successfully.
 * Create a Quarkus component. [See Quarkus devfile sample](https://github.com/redhat-appstudio-qe/devfile-sample-code-with-quarkus).
-* Wait for pipelinesRuns to build and push a container image to `https://quay.io/organization/redhat-appstudio-qe/quarkus:<sha1>`.
+* Wait for pipelinesRuns to build and push a container image to `https://quay.io/organization/redhat-appstudio-qe/test-images:<sha1>`.
 * Verify if HAS operator create gitops resources in the cluster(routes, deployments, services...).
 * Remove kubernetes objects created by the framework.
 

--- a/tests/has/devfile_source.go
+++ b/tests/has/devfile_source.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	ComponentContainerImage           string = fmt.Sprintf("quay.io/%s/quarkus:%s", GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+	ComponentContainerImage           string = fmt.Sprintf("quay.io/%s/test-images:%s", GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
 	AppStudioE2EApplicationsNamespace string = utils.GetEnv(constants.E2E_APPLICATIONS_NAMESPACE_ENV, "appstudio-e2e-test")
 )
 


### PR DESCRIPTION
### Description

This PR changes the output image name (used in `has` and `build-service` suites) to `quay.io/<org>/test-images` to get aligned with what we have in [redhat-appstudio quay org](https://quay.io/repository/redhat-appstudio/test-images) - we will be probably using this repo for storing images built by other tests too (not just from this repo).

(What is it good for currently? If we run the test with `QUAY_E2E_ORGANIZATION=redhat-appstudio`, the test will still pass since that repo exists and is managed by the redhat-appstudio robot account)

This repo was already created in [redhat-appstudio-qe quay org](https://quay.io/repository/redhat-appstudio-qe/test-images), so PR tests should not be failing because of that