### PR TITLE
docs: Developer focused e2e update

### DIFF
--- a/docs/DeveloperFocus.md
+++ b/docs/DeveloperFocus.md
@@ -1,0 +1,35 @@
+# Running the e2e suite from a developer perspective
+
+## Prerequisites
+
+For setting up your cluster to run the e2e tests locally against, follow the [Installation guide](./Installation.md).
+
+Note that it is recommended to install AppStudio in e2e mode, but the e2e suite should also be usable in development and preview modes.
+
+## Building the e2e suite
+
+Whenever changes are made to the underlying e2e code, a new e2e suite binary needs to be built. From the e2e-tests directory run:
+
+   ```bash
+      make build
+   ```
+
+The resulting e2e-appstudio binary is located in the bin folder.
+
+## Focused testing
+
+The e2e suite is written using the [Ginkgo test framework](https://onsi.github.io/ginkgo/) and, therefore, benefits from all the default flags Ginkgo provides.
+
+Running the following command will provide all the flags available when running the suite:
+
+   ```bash
+      ./bin/e2e-appstudio -h
+   ```
+
+Of interest to a developer are the `--ginkgo.focus` and `--ginkgo.focus-file` flags.
+
+`--ginkgo.focus` accepts a regular expression string to match against for any of the strings used in a test "descriptors" (such as Context, It, When, etc). Multiple `--ginkgo.focus` flags can be provided on the command line. When run with the focus flags the suite with OR the flags and run only the matching tests, skipping the rest.
+
+`--ginkgo.focus-file` can be used to specify a specific .go file (such as `tests/build/build.go`). Multiple `--ginkgo.focus-file` flags can be provided on the command line. When run with this flag the suite will only run the tests specified in that file, skipping the rest.
+
+By using these or the other flags that Ginkgo provides you can run e2e-appstudio (after rebuilding to include your changes) focused on the changes that you have made to ensure they are working before you commit your code.

--- a/docs/DeveloperFocus.md
+++ b/docs/DeveloperFocus.md
@@ -28,8 +28,8 @@ Running the following command will provide all the flags available when running 
 
 Of interest to a developer are the `--ginkgo.focus` and `--ginkgo.focus-file` flags.
 
-`--ginkgo.focus` accepts a regular expression string to match against for any of the strings used in a test "descriptors" (such as Context, It, When, etc). Multiple `--ginkgo.focus` flags can be provided on the command line. When run with the focus flags the suite with OR the flags and run only the matching tests, skipping the rest.
+`--ginkgo.focus` accepts a regular expression string to match against for any of the strings used in a test "descriptors" (such as Context, It, When, etc). Multiple `--ginkgo.focus` flags can be provided on the command line. When run with the focus flags the suite will OR the flags and only run the matching tests, skipping the rest.
 
-`--ginkgo.focus-file` can be used to specify a specific .go file (such as `tests/build/build.go`). Multiple `--ginkgo.focus-file` flags can be provided on the command line. When run with this flag the suite will only run the tests specified in that file, skipping the rest.
+`--ginkgo.focus-file` can be used to specify a specific .go file (such as `tests/build/build.go`). Multiple `--ginkgo.focus-file` flags can be provided on the command line. When run with these flags the suite will OR the flags and only run the tests specified in those files, skipping the rest.
 
 By using these or the other flags that Ginkgo provides you can run e2e-appstudio (after rebuilding to include your changes) focused on the changes that you have made to ensure they are working before you commit your code.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -29,7 +29,7 @@ Before starting the deployment steps of appstudio in e2e mode in Openshift CI yo
     oc login -u <user> -p <password> --server=<oc_api_url>
    ```
 
-3. Install Red Hat App Studio in e2e mode. The e2e framework by default will use the `redhat-appstudio-qe` github organization by default. If u want to change the github org you should define `GITHUB_E2E_ORGANIZATION` environment with your custom github organization
+3. Install Red Hat App Studio in e2e mode. The e2e framework by default will use the `redhat-appstudio-qe` github organization by default. If you want to change the github org you should define `GITHUB_E2E_ORGANIZATION` environment with your custom github organization
 
    ```bash
       # In Openshift CI there are some example about how to use the installation script. See infra-deployments script https://github.com/redhat-appstudio/application-service/blob/main/.ci/oci-e2e-has.sh#L59

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -62,6 +62,22 @@ The following environments are used to launch the Red Hat AppStudio installation
 | `QUAY_E2E_ORGANIZATION` | no | Quay organization where to push components containers | `redhat-appstudio-qe` |
 | `E2E_APPLICATIONS_NAMESPACE` | no | Name of the namespace used for running HAS E2E tests | `appstudio-e2e-test` |
 
+
+### Setting up the required tokens
+
+#### GitHub token
+
+[Instructions for creating a Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+
+Make sure to give the token the permissions listed in [Prerequisites](#prerequisites).
+
+Copy the resulting token (should look similar to `ghp_Iq...`) and save it off somewhere as you'll be using it for the GITHUB_TOKEN environment variable whenever you want to run the e2e suite.
+
+#### Quay token
+
+Go to your profile (in Quay click your username in the upper right, click Account Settings). From your profile, look for CLI Password and click the Generate Encrypted Password link. Click on Kubernetes Secret in the left pane. Click on the link for View username-secret.yml. Copy the string listed after `.dockerconfigjson` (should look similar to `ewogI3...`). Save the string off somewhere as you'll be using it for the QUAY_TOKEN environment variable whenever you want to run the e2e suite.
+
+
 ## Install e2e binary in openshift-ci and use pairing PRs feature
 
 The e2e tests are executed against almost all App Studio repositories.


### PR DESCRIPTION
Added some additional setup details and information for developers to use when creating e2e tests and running said tests before merging.