### PR TITLE
fix: adjust to the latest ec-policy output

### DIFF
--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -182,7 +182,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 				tr, err = kubeController.Tektonctrl.GetTaskRun(tr.Name, tr.Namespace)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(tr.Status.TaskRunResults).To(Equal([]v1beta1.TaskRunResult{
-					{Name: "OUTPUT", Value: "[\n  {\n    \"msg\": \"Empty test data provided\"\n  }\n]\n"},
+					{Name: "OUTPUT", Value: "[\n  {\n    \"code\": \"test_data_empty\",\n    \"msg\": \"Empty test data provided\"\n  }\n]\n"},
 					{Name: "PASSED", Value: "false\n"},
 				}))
 			})

--- a/tests/e2e-demos/const.go
+++ b/tests/e2e-demos/const.go
@@ -1,7 +1,7 @@
 package e2e
 
 const (
-	RedHatAppStudioApplicationName string = "pet-clinic-e2e"
+	RedHatAppStudioApplicationName string = "e2e-demo-application"
 
 	// Argo CD Application service name: https://github.com/redhat-appstudio/infra-deployments/blob/main/argo-cd-apps/base/has.yaml#L4
 	HASArgoApplicationName string = "has"


### PR DESCRIPTION
# Description

We changed the output in ec-policy Rego files with the effort to switch
to using `conftest` instead of `opa`. This adjusts the expected output
in the end to end test to match this.

Ref. https://github.com/redhat-appstudio/e2e-tests/pull/86
Ref. https://github.com/redhat-appstudio/infra-deployments/pull/387

## Issue ticket number and link

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run the chains test suite locally

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
