### PR TITLE
fix: remove duplicate SPI setup

### DIFF
--- a/.ci/oci-launch-e2e.sh
+++ b/.ci/oci-launch-e2e.sh
@@ -59,8 +59,7 @@ export KUBECONFIG_TEST="/tmp/kubeconfig"
 
 export KUBECONFIG="${KUBECONFIG_TEST}"
 
-/bin/bash "$WORKSPACE"/scripts/install-appstudio-e2e-mode.sh install 
-/bin/bash "$WORKSPACE"/scripts/spi-e2e-setup.sh
+/bin/bash "$WORKSPACE"/scripts/install-appstudio-e2e-mode.sh install
 
 export -f waitAppStudioToBeReady
 export -f waitBuildToBeReady

--- a/scripts/spi-e2e-setup.sh
+++ b/scripts/spi-e2e-setup.sh
@@ -9,7 +9,7 @@ set -u
 echo '[INFO] Deploying SPI OAuth2 config'
 
 export OAUTH_URL='spi-oauth-route-spi-system.'$( oc get ingresses.config/cluster -o jsonpath={.spec.domain})
-export tmpfile=tmp/config.yaml
+export tmpfile=$(mktemp -d)/config.yaml
 
 # We are injecting the token manually for the e2e. No need a real secret for now
 export SPI_GITHUB_CLIENT_ID="app-client-id"


### PR DESCRIPTION
# Description

spi-e2e-setup.sh script was being [executed twice](https://github.com/redhat-appstudio/e2e-tests/blob/75ce8e726b6ac842c31970fbd329f4496aee0235/scripts/install-appstudio-e2e-mode.sh#L60) in openshift-ci

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
