### PR TITLE
fix: Unskip and fix failing EC tests

### DIFF
--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -17,7 +17,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 	defer g.GinkgoRecover()
 
 	// Set this to true to skip contract tests
-	var skipContract bool = true
+	var skipContract bool = false
 	var skipContractMsg string = "Temporarily disabling until the EC task definition is updated"
 
 	// Initialize the tests controllers
@@ -181,8 +181,8 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 					tekton.MatchTaskRunResultWithJSONValue("OUTPUT", `[
 						{
 							"filename": "/shared/ec-work-dir/input/input.json",
-							"namespace": "main",
-							"successes": 1
+							"namespace": "release.main",
+							"successes": 2
 						}
 					]`),
 					tekton.MatchTaskRunResult("PASSED", "true"),
@@ -207,14 +207,15 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 					tekton.MatchTaskRunResultWithJSONValue("OUTPUT", `[
 						{
 							"filename": "/shared/ec-work-dir/input/input.json",
-							"namespace": "main",
-							"successes": 0,
+							"namespace": "release.main",
+							"successes": 1,
 							"failures": [
 								{
 									"msg": "No test data found",
 									"metadata": {
-										"code": "test_data_missing"
-									}					
+										"code": "test_data_missing",
+										"effective_on": "2022-01-01T00:00:00Z"
+									}
 								}
 							]
 						}


### PR DESCRIPTION
Update the assertions to match the new conftest output produced by
https://github.com/hacbs-contract/ec-policies/pull/40 so the tests
pass.

Note: This requires that
https://github.com/redhat-appstudio/build-definitions/pull/124 is merged and
visible in the task bundle being used by the e2e tests. I'm not sure what the process is to make that happen.