### PR TITLE
fix: Less brittle contract task result assertions

### DIFF
--- a/pkg/utils/tekton/matchers_test.go
+++ b/pkg/utils/tekton/matchers_test.go
@@ -26,3 +26,31 @@ func TestTaskRunResultMatcherJSONValue(t *testing.T) {
 	assert.True(t, match)
 	assert.Nil(t, err)
 }
+
+func TestApplyTemplateToJson(t *testing.T) {
+	input := `{"words": {"greetings": ["hola", "bonjour"]}}`
+	template := "{{ index .words.greetings 1 }} {{ .notThere }}"
+	output, err := applyTemplateToJson(input, template)
+
+	assert.Equal(t, output, "bonjour <no value>")
+	assert.Nil(t, err)
+}
+
+func TestApplyTemplateToJsonWithList(t *testing.T) {
+	input := `[{"result":"ok", "score": 42 }]`
+	template := "{{ (index . 0).result }} {{ (index . 0).score }}"
+	output, err := applyTemplateToJson(input, template)
+
+	assert.Equal(t, output, "ok 42")
+	assert.Nil(t, err)
+}
+
+func TestTaskRunResultWithTemplate(t *testing.T) {
+	match, err := MatchTaskRunResultWithTemplate("a", "{{.b}}", "c").Match(v1beta1.TaskRunResult{
+		Name:  "a",
+		Value: `{ "b" : "c" }`,
+	})
+
+	assert.True(t, match)
+	assert.Nil(t, err)
+}

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -17,7 +17,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 	defer g.GinkgoRecover()
 
 	// Set this to true to skip contract tests
-	var skipContract bool = true
+	var skipContract bool = false
 	var skipContractMsg string = "Temporarily disabling until the EC task definition is updated"
 
 	// Initialize the tests controllers
@@ -181,8 +181,8 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 					tekton.MatchTaskRunResultWithJSONValue("OUTPUT", `[
 						{
 							"filename": "/shared/ec-work-dir/input/input.json",
-							"namespace": "main",
-							"successes": 1
+							"namespace": "release.main",
+							"successes": 2
 						}
 					]`),
 					tekton.MatchTaskRunResult("PASSED", "true"),
@@ -207,14 +207,15 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 					tekton.MatchTaskRunResultWithJSONValue("OUTPUT", `[
 						{
 							"filename": "/shared/ec-work-dir/input/input.json",
-							"namespace": "main",
-							"successes": 0,
+							"namespace": "release.main",
+							"successes": 1,
 							"failures": [
 								{
 									"msg": "No test data found",
 									"metadata": {
-										"code": "test_data_missing"
-									}					
+										"code": "test_data_missing",
+										"effective_on": "2022-01-01T00:00:00Z"
+									}
 								}
 							]
 						}


### PR DESCRIPTION
Introduce a way to do less brittle assertions about task result json, then use it for some Enterprise Contract tests.

WIP - actually this isn't working for me currently, and on top of that I'm having problems running e2e in my local cluster. Will try again later, but for now I'm just sharing the concept of using go templates with assertions about the json.

Actually I'm not sure it's a good idea since I think there ought to be a cleaner way to access the parsed task result output.