### PR TITLE
refactor: add debug info for chain e2e test

### DIFF
--- a/pkg/utils/tekton/controller.go
+++ b/pkg/utils/tekton/controller.go
@@ -20,6 +20,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	g "github.com/onsi/ginkgo/v2"
 )
 
 type KubeController struct {
@@ -149,6 +151,7 @@ func (s *SuiteController) ListTaskRuns(ns string, labelKey string, labelValue st
 }
 
 func (k KubeController) WatchPipelineRun(pipelineRunName string, taskTimeout int) error {
+	g.GinkgoWriter.Printf("Waiting for pipeline %q to finish\n", pipelineRunName)
 	return k.Commonctrl.WaitUntil(k.Tektonctrl.CheckPipelineRunFinished(pipelineRunName, k.Namespace), time.Duration(taskTimeout)*time.Second)
 }
 
@@ -244,6 +247,7 @@ func (k KubeController) createAndWait(pr *v1beta1.PipelineRun, taskTimeout int) 
 	if err != nil {
 		return nil, err
 	}
+	g.GinkgoWriter.Printf("Creating Pipeline %q\n", pipelineRun.Name)
 	return pipelineRun, k.Commonctrl.WaitUntil(k.Tektonctrl.CheckPipelineRunStarted(pipelineRun.Name, k.Namespace), time.Duration(taskTimeout)*time.Second)
 }
 


### PR DESCRIPTION
# Description

When running the chains e2e suite it would be useful to have extra details get output to the logs to make troubleshooting failures easier. Currently we just get error strings on failure with none of the underlying state data written to the log.

## Issue ticket number and link
https://issues.redhat.com/browse/HACBS-573


# How Has This Been Tested?
$ ./bin/e2e-appstudio --ginkgo.focus-file tests/build/chains.go --ginkgo.vv
 logs:

```
[chains-suite Tekton Chains E2E tests] infrastructure is running
  verify the chains controller is running
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:28
•
------------------------------
[chains-suite Tekton Chains E2E tests] infrastructure is running
  verify the correct secrets have been created
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:32
•
------------------------------
[chains-suite Tekton Chains E2E tests] infrastructure is running
  verify the correct roles are created
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:36
•
------------------------------
[chains-suite Tekton Chains E2E tests] infrastructure is running
  verify the correct rolebindings are created
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:42
•
------------------------------
[chains-suite Tekton Chains E2E tests] infrastructure is running
  verify the correct service account is created
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:48
•
------------------------------
[chains-suite Tekton Chains E2E tests] test creating and signing an image and task
  creates signature and attestation
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:97
------------------------------
• [SLOW TEST] [63.311 seconds]
[chains-suite Tekton Chains E2E tests]
/home/chuo/gitsrc/hacbs/e2e-tests/pkg/framework/describe.go:23
  test creating and signing an image and task
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:53
    creates signature and attestation
    /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:97

  Begin Captured GinkgoWriter Output >>
    Creating Pipeline "buildah-demo-jnknvluntg"
    Waiting for pipeline "buildah-demo-jnknvluntg" to finish
    The pipeline run is "buildah-demo-jnknvluntg" under namespace "tekton-chains"
    The image signed by Tekton Chains is image-registry.openshift-image-registry.svc:5000/tekton-chains/buildah-demo-jnknvluntg@sha256:d5000275ba6fc83ad6f5d6c3c2f2edad8636270ef785c77dad082ce3bee8c280
    Cosign verify pass with .att and .sig ImageStreamTags found
  << End Captured GinkgoWriter Output
------------------------------
[chains-suite Tekton Chains E2E tests] test creating and signing an image and task
  verify image attestation
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:108
------------------------------
• [SLOW TEST] [20.307 seconds]
[chains-suite Tekton Chains E2E tests]
/home/chuo/gitsrc/hacbs/e2e-tests/pkg/framework/describe.go:23
  test creating and signing an image and task
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:53
    verify image attestation
    /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:108

  Begin Captured GinkgoWriter Output >>
    Creating Pipeline "cosign-verify-attestation-w48nk"
    Waiting for pipeline "cosign-verify-attestation-w48nk" to finish
  << End Captured GinkgoWriter Output
------------------------------
[chains-suite Tekton Chains E2E tests] test creating and signing an image and task
  cosign verify
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:119
------------------------------
• [SLOW TEST] [21.202 seconds]
[chains-suite Tekton Chains E2E tests]
/home/chuo/gitsrc/hacbs/e2e-tests/pkg/framework/describe.go:23
  test creating and signing an image and task
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:53
    cosign verify
    /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:119

  Begin Captured GinkgoWriter Output >>
    Creating Pipeline "cosign-verify-zcljn"
    Waiting for pipeline "cosign-verify-zcljn" to finish
  << End Captured GinkgoWriter Output
------------------------------
[chains-suite Tekton Chains E2E tests] test creating and signing an image and task verify-enterprise-contract task
  succeeds when policy is met
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:170
------------------------------
• [SLOW TEST] [19.338 seconds]
[chains-suite Tekton Chains E2E tests]
/home/chuo/gitsrc/hacbs/e2e-tests/pkg/framework/describe.go:23
  test creating and signing an image and task
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:53
    verify-enterprise-contract task
    /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:131
      succeeds when policy is met
      /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:170

  Begin Captured GinkgoWriter Output >>
    Copy public key from tekton-chains/signing-secrets to a new secret
    Set the non-blocking checks to baseline policies: {"non_blocking_checks":["not_useful"]}
    Set the non-blocking checks to policies: {"non_blocking_checks":["not_useful", "test"]}
    Creating Pipeline "verify-enterprise-contract-hfclf"
    Waiting for pipeline "verify-enterprise-contract-hfclf" to finish
    Make sure task "verify-enterprise-contract-hfclf" has passed
  << End Captured GinkgoWriter Output
------------------------------
[chains-suite Tekton Chains E2E tests] test creating and signing an image and task verify-enterprise-contract task
  does not pass when tests are not satisfied on non-strict mode
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:201
------------------------------
• [SLOW TEST] [22.399 seconds]
[chains-suite Tekton Chains E2E tests]
/home/chuo/gitsrc/hacbs/e2e-tests/pkg/framework/describe.go:23
  test creating and signing an image and task
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:53
    verify-enterprise-contract task
    /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:131
      does not pass when tests are not satisfied on non-strict mode
      /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:201

  Begin Captured GinkgoWriter Output >>
    Set the non-blocking checks to baseline policies: {"non_blocking_checks":["not_useful"]}
    Creating Pipeline "verify-enterprise-contract-sdffg"
    Waiting for pipeline "verify-enterprise-contract-sdffg" to finish
    Make sure pipeline "verify-enterprise-contract-sdffg" has failed
  << End Captured GinkgoWriter Output
------------------------------
[chains-suite Tekton Chains E2E tests] test creating and signing an image and task verify-enterprise-contract task
  fails when tests are not satisfied on strict mode
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:237
------------------------------
• [SLOW TEST] [20.276 seconds]
[chains-suite Tekton Chains E2E tests]
/home/chuo/gitsrc/hacbs/e2e-tests/pkg/framework/describe.go:23
  test creating and signing an image and task
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:53
    verify-enterprise-contract task
    /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:131
      fails when tests are not satisfied on strict mode
      /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:237

  Begin Captured GinkgoWriter Output >>
    Set the non-blocking checks to baseline policies: {"non_blocking_checks":["not_useful"]}
    Creating Pipeline "verify-enterprise-contract-2r2gc"
    Waiting for pipeline "verify-enterprise-contract-2r2gc" to finish
    Make sure pipeline "verify-enterprise-contract-2r2gc" has failed
  << End Captured GinkgoWriter Output
------------------------------
[chains-suite Tekton Chains E2E tests] test creating and signing an image and task verify-enterprise-contract task
  fails when unexpected signature is used
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:256
------------------------------
• [SLOW TEST] [15.502 seconds]
[chains-suite Tekton Chains E2E tests]
/home/chuo/gitsrc/hacbs/e2e-tests/pkg/framework/describe.go:23
  test creating and signing an image and task
  /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:53
    verify-enterprise-contract task
    /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:131
      fails when unexpected signature is used
      /home/chuo/gitsrc/hacbs/e2e-tests/tests/build/chains.go:256

  Begin Captured GinkgoWriter Output >>
    Set the non-blocking checks to baseline policies: {"non_blocking_checks":["not_useful"]}
    Create an unexpected public signing key
    Creating Pipeline "verify-enterprise-contract-8s2bq"
    Waiting for pipeline "verify-enterprise-contract-8s2bq" to finish
    Make sure pipeline "verify-enterprise-contract-8s2bq" has failed
  << End Captured GinkgoWriter Output

```
