### PR TITLE
test: build multiple components from input

### DIFF
--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          args: --timeout=3m
+          args: --timeout=5m
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:

--- a/pkg/framework/describe.go
+++ b/pkg/framework/describe.go
@@ -24,7 +24,7 @@ func ChainsSuiteDescribe(text string, body func()) bool {
 }
 
 func BuildSuiteDescribe(text string, body func()) bool {
-	return Describe("[build-service-suite "+text+"]", Ordered, body)
+	return Describe("[build-service-suite "+text+"]", body)
 }
 
 func ClusterRegistrationSuiteDescribe(text string, body func()) bool {

--- a/pkg/utils/common/controller.go
+++ b/pkg/utils/common/controller.go
@@ -222,6 +222,10 @@ func (s *SuiteController) CreateConfigMap(cm *corev1.ConfigMap, namespace string
 	return s.KubeInterface().CoreV1().ConfigMaps(namespace).Create(context.TODO(), cm, metav1.CreateOptions{})
 }
 
+func (s *SuiteController) UpdateConfigMap(cm *corev1.ConfigMap, namespace string) (*corev1.ConfigMap, error) {
+	return s.KubeInterface().CoreV1().ConfigMaps(namespace).Update(context.TODO(), cm, metav1.UpdateOptions{})
+}
+
 func (s *SuiteController) GetConfigMap(name, namespace string) (*corev1.ConfigMap, error) {
 	return s.KubeInterface().CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }

--- a/tests/build/README.md
+++ b/tests/build/README.md
@@ -7,6 +7,8 @@ Steps to run tests within `build` directory:
 1. Follow the instructions from the [Readme](../../docs/Installation.md) scripts to install AppStudio in e2e mode
 2. Run the tekton chains suite: `./bin/e2e-appstudio --ginkgo.focus="chains-suite"`
 3. Run the build-service suite: `./bin/e2e-appstudio --ginkgo.focus="build-service-suite"`
+   1. To test the build of multiple components (from multiple Github repositories), export the environment variable `COMPONENT_REPO_URLS` with value that points
+      to multiple Github repo URLs, separated by a comma, e.g.: `export COMPONENT_REPO_URLS=https://github.com/redhat-appstudio-qe/devfile-sample-hello-world,https://github.com/devfile-samples/devfile-sample-python-basic`
 
 ## Build service suite specs
 

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -5,499 +5,623 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/devfile/library/pkg/util"
 	"github.com/google/uuid"
-	appservice "github.com/redhat-appstudio/application-service/api/v1alpha1"
 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/build"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	klog "k8s.io/klog/v2"
 
 	routev1 "github.com/openshift/api/route/v1"
 )
 
 const (
-	containerImageSource   = "quay.io/redhat-appstudio-qe/busybox-loop:latest"
-	gitSourceRepoName      = "devfile-sample-hello-world"
-	gitSourceURL           = "https://github.com/redhat-appstudio-qe/" + gitSourceRepoName
-	dummyPipelineBundleRef = "quay.io/redhat-appstudio-qe/dummy-pipeline-bundle:latest"
+	containerImageSource     = "quay.io/redhat-appstudio-qe/busybox-loop:latest"
+	defaultGitSourceRepoName = "devfile-sample-hello-world"
+	defaultGitSourceURL      = "https://github.com/redhat-appstudio-qe/" + defaultGitSourceRepoName
+	dummyPipelineBundleRef   = "quay.io/redhat-appstudio-qe/dummy-pipeline-bundle:latest"
 )
 
-var _ = framework.BuildSuiteDescribe("Build Service E2E tests", func() {
+var (
+	componentUrls  = strings.Split(utils.GetEnv(COMPONENT_REPO_URLS_ENV, defaultGitSourceURL), ",") //multiple urls
+	componentNames []string
+)
 
-	defer GinkgoRecover()
+var _ = framework.BuildSuiteDescribe("Component with git source is created", func() {
+	var f *framework.Framework
+	var err error
 
-	var applicationName, componentName, appStudioE2EApplicationsNamespace, outputContainerImage string
-	var pipelineRun v1beta1.PipelineRun
-	var component *appservice.Component
+	var applicationName, componentName, testNamespace, outputContainerImage string
+
 	var timeout, interval time.Duration
-
-	var customBundleConfigMap, defaultBundleConfigMap *v1.ConfigMap
-	var defaultBundleRef, customBundleRef string
 
 	var webhookRoute *routev1.Route
 	var webhookURL string
 
-	// Initialize the tests controllers
-	f, err := framework.NewFramework()
-	Expect(err).NotTo(HaveOccurred())
-
 	BeforeAll(func() {
-		applicationName = fmt.Sprintf("build-suite-test-application-%s", util.GenerateRandomString(4))
-		appStudioE2EApplicationsNamespace = utils.GetEnv(constants.E2E_APPLICATIONS_NAMESPACE_ENV, "appstudio-e2e-test")
-
-		_, err := f.CommonController.CreateTestNamespace(appStudioE2EApplicationsNamespace)
-		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", appStudioE2EApplicationsNamespace, err)
-
-		_, err = f.HasController.CreateHasApplication(applicationName, appStudioE2EApplicationsNamespace)
+		f, err = framework.NewFramework()
 		Expect(err).NotTo(HaveOccurred())
-		DeferCleanup(f.HasController.DeleteHasApplication, applicationName, appStudioE2EApplicationsNamespace)
 
+		applicationName = fmt.Sprintf("build-suite-test-application-%s", util.GenerateRandomString(4))
+		testNamespace = fmt.Sprintf("e2e-test-%s", util.GenerateRandomString(4))
+
+		_, err = f.CommonController.CreateTestNamespace(testNamespace)
+		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+
+		_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		componentName = fmt.Sprintf("build-suite-test-component-git-source-%s", util.GenerateRandomString(4))
+		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+		timeout = time.Second * 120
+		interval = time.Second * 1
+		// Create a component with Git Source URL being defined
+		_, err := f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
 	})
 
-	When("component with container image source is created", func() {
-		BeforeAll(func() {
-			componentName = fmt.Sprintf("build-suite-test-component-image-source-%s", util.GenerateRandomString(4))
-			outputContainerImage = ""
-			timeout = time.Second * 10
-			interval = time.Second * 1
-			// Create a component with containerImageSource being defined
-			component, err = f.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, "", containerImageSource, outputContainerImage, "")
-			Expect(err).ShouldNot(HaveOccurred())
-
-			DeferCleanup(f.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace)
-		})
-		It("should not trigger a PipelineRun", func() {
-			Consistently(func() bool {
-				pipelineRun, err = f.HasController.GetComponentPipelineRun(component.Name, applicationName, appStudioE2EApplicationsNamespace, false)
-				Expect(pipelineRun.Name).To(BeEmpty())
-
-				return strings.Contains(err.Error(), "no pipelinerun found")
-			}, timeout, interval).Should(BeTrue(), "expected the PipelineRun not to be triggered")
-		})
-	})
-	When("component with git source is created", Label("slow"), func() {
-
-		BeforeAll(func() {
-			componentName = fmt.Sprintf("build-suite-test-component-git-source-%s", util.GenerateRandomString(4))
-			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-			timeout = time.Second * 60
-			interval = time.Second * 1
-			// Create a component with Git Source URL being defined
-			component, err = f.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, defaultGitSourceURL, "", outputContainerImage, "")
-			Expect(err).ShouldNot(HaveOccurred())
-			DeferCleanup(f.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace)
-
-			for _, comp := range createdComponents { //multiple urls
-				componentName = fmt.Sprintf("%s-%s", comp.Name, util.GenerateRandomString(10))
-				outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-				timeout = time.Second * 60
-				interval = time.Second * 1
-				// Create a component with Git Source URL being defined
-				component, err = f.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, defaultGitSourceURL, "", outputContainerImage, "")
-				Expect(err).ShouldNot(HaveOccurred())
-				DeferCleanup(f.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace)
-
-				customBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, appStudioE2EApplicationsNamespace)
-				if err != nil {
-					if errors.IsNotFound(err) {
-						klog.Infof("configmap with custom pipeline bundle not found in %s namespace\n", appStudioE2EApplicationsNamespace)
-					} else {
-						Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, appStudioE2EApplicationsNamespace, err))
-					}
-				} else {
-					customBundleRef = customBundleConfigMap.Data["default_build_bundle"]
-				}
-
-				defaultBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
-				if err != nil {
-					if errors.IsForbidden(err) {
-						klog.Infof("don't have enough permissions to get a configmap with default pipeline in %s namespace\n", constants.BuildPipelinesConfigMapDefaultNamespace)
-					} else {
-						Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace, err))
-					}
-				} else {
-					defaultBundleRef = defaultBundleConfigMap.Data["default_build_bundle"]
-				}
-				createdComponents = append(createdComponents, component) //collected created components
-			}
-
-			Expect(createdComponents).ShouldNot(BeEmpty())
-
-		})
-		It("triggers a PipelineRun", Label("build-templates-e2e"), func() {
-			Eventually(func() bool {
-				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false)
-				if err != nil {
-					klog.Infoln("PipelineRun has not been created yet")
-					return false
-				}
-				return pipelineRun.HasStarted()
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
-		})
-
-		It("should reference the custom pipeline bundle in a PipelineRun", Label("build-templates-e2e"), func() {
-			if customBundleRef == "" {
-				Skip("skipping the specs - custom pipeline bundle is not defined")
-			}
-			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false)
-			Expect(err).ShouldNot(HaveOccurred())
-
-					pipelineRun, err := f.HasController.GetComponentPipeline(comp.Name, applicationName, appStudioE2EApplicationsNamespace)
-					if err != nil {
-						klog.Infoln("PipelineRun has not been created yet")
-						return false
-					}
-					return pipelineRun.HasStarted()
-				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the %s PipelineRun to start", comp.Name)
-
-			}
-			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(defaultBundleRef))
-		})
-
-		When("the PipelineRun has started", Label("build-templates-e2e"), func() {
-			BeforeAll(func() {
-				timeout = time.Second * 600
-				interval = time.Second * 10
-			})
-			It("should eventually finish successfully", func() {
-				Eventually(func() bool {
-					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false)
-					Expect(err).ShouldNot(HaveOccurred())
-
-			It("should reference the default pipeline bundle in a PipelineRun", func() {
-				if customBundleRef != "" {
-					Skip("skipping - custom pipeline bundle bundle (that overrides the default one) is defined")
-				}
-				if defaultBundleRef == "" {
-					Skip("skipping - default pipeline bundle cannot be fetched")
-				}
-				pipelineRun, err := f.HasController.GetComponentPipeline(comp.Name, applicationName, appStudioE2EApplicationsNamespace)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(defaultBundleRef))
-			})
-
-			When("the PipelineRun has started", func() {
-				BeforeAll(func() {
-					timeout = time.Second * 600
-					interval = time.Second * 10
-				})
-				It("should eventually finish successfully", func() {
-					Eventually(func() bool {
-						pipelineRun, err := f.HasController.GetComponentPipeline(comp.Name, applicationName, appStudioE2EApplicationsNamespace)
-						Expect(err).ShouldNot(HaveOccurred())
-
-						for _, condition := range pipelineRun.Status.Conditions {
-							klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
-
-							if condition.Reason == "Failed" {
-								Fail(fmt.Sprintf("Pipelinerun %s has failed", pipelineRun.Name))
-							}
-						}
-						return pipelineRun.IsDone()
-					}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to finish")
-				})
-
-			})
-		})
-
-		When("the PipelineRun is finished", func() {
-			var webhookName string
-
-			BeforeAll(func() {
-				timeout = time.Minute * 5
-				interval = time.Second * 10
-				webhookName = "el" + componentName
-
-			})
-
-			It("eventually leads to a creation of a component webhook (event listener)", Label("webhook", "slow"), func() {
-				Eventually(func() bool {
-					_, err := f.HasController.GetEventListenerRoute(componentName, appStudioE2EApplicationsNamespace)
-					if err != nil {
-						klog.Infof("component webhook %s has not been created yet in %s namespace\n", webhookName, appStudioE2EApplicationsNamespace)
-						return false
-					}
-					return true
-
-				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the component webhook to be created")
-			})
-		})
-
-		When("the container image is created and pushed to container registry", func() {
-			It("contains non-empty sbom files", Label("build-templates-e2e", "sbom", "slow"), func() {
-				component, err := f.HasController.GetHasComponent(componentName, appStudioE2EApplicationsNamespace)
-				Expect(err).ShouldNot(HaveOccurred())
-				purl, cyclonedx, err := build.GetParsedSbomFilesContentFromImage(component.Spec.ContainerImage)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(purl.ImageContents.Dependencies).ToNot(BeEmpty())
-				Expect(cyclonedx.Components).ToNot(BeEmpty())
-			})
-		})
-		When("the component event listener is created", Label("webhook", "slow"), func() {
-			BeforeAll(func() {
-				timeout = time.Minute * 1
-				interval = time.Second * 1
-
-				webhookRoute, err = f.HasController.GetEventListenerRoute(componentName, appStudioE2EApplicationsNamespace)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(webhookRoute.Spec.Host).ShouldNot(BeEmpty())
-
-				if webhookRoute.Spec.TLS != nil {
-					webhookURL = fmt.Sprintf("https://%s", webhookRoute.Spec.Host)
-				} else {
-					webhookURL = fmt.Sprintf("http://%s", webhookRoute.Spec.Host)
-				}
-			})
-
-			It("should be eventually ready to receive events from Github", func() {
-				Eventually(func() bool {
-					c := http.Client{}
-					req, err := http.NewRequestWithContext(context.Background(), "GET", webhookURL, bytes.NewReader([]byte("{}")))
-					if err != nil {
-						return false
-					}
-					resp, err := c.Do(req)
-					if err != nil || resp.StatusCode > 299 {
-						return false
-					}
-					return true
-				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the event listener to be ready")
-			})
-		})
-
-		When("the component webhook is configured on Github repository for 'push' events and a change is pushed", Label("webhook", "slow"), func() {
-			var initialContainerImageURL, newContainerImageURL string
-			var webhookID int64
-
-			BeforeAll(func() {
-				if utils.IsPrivateHostname(webhookRoute.Spec.Host) {
-					Skip("Using private cluster (not reachable from Github), skipping...")
-				}
-
-				timeout = time.Minute * 2
-				interval = time.Second * 5
-
-				// Get Component CR to check the current value of Container Image
-				component, err := f.HasController.GetHasComponent(componentName, appStudioE2EApplicationsNamespace)
-				Expect(err).ShouldNot(HaveOccurred())
-				initialContainerImageURL = component.Spec.ContainerImage
-
-				webhookID, err = f.CommonController.Github.CreateWebhook(gitSourceRepoName, webhookURL)
-				Expect(err).ShouldNot(HaveOccurred())
-				DeferCleanup(f.CommonController.Github.DeleteWebhook, gitSourceRepoName, webhookID)
-
-				// Wait until EventListener's pod is ready to receive events
-				err = f.CommonController.WaitForPodSelector(f.CommonController.IsPodRunning, appStudioE2EApplicationsNamespace, "eventlistener", componentName, 60, 100)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Update a file in Component source Github repo to trigger a push event
-				updatedFile, err := f.CommonController.Github.UpdateFile(gitSourceRepoName, "README.md", "test")
-				Expect(err).NotTo(HaveOccurred())
-
-				// A new output container image URL should contain the suffix with the latest commit SHA
-				newContainerImageURL = fmt.Sprintf("%s-%s", initialContainerImageURL, updatedFile.GetSHA())
-			})
-
-			It("eventually leads to triggering another PipelineRun", func() {
-				Eventually(func() bool {
-					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, true)
-					if err != nil {
-						klog.Infoln("PipelineRun has not been created yet")
-						return false
-					}
-					return pipelineRun.HasStarted()
-				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
-			})
-			It("PipelineRun should eventually finish", func() {
-				timeout = time.Minute * 5
-				Eventually(func() bool {
-					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, true)
-					Expect(err).ShouldNot(HaveOccurred())
-
-					for _, condition := range pipelineRun.Status.Conditions {
-						klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
-
-						if condition.Reason == "Failed" {
-							Fail(fmt.Sprintf("Pipelinerun %s has failed", pipelineRun.Name))
-						}
-					}
-					return pipelineRun.IsDone()
-				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to finish")
-			})
-			It("ContainerImage field should be updated with the SHA of the commit that was pushed to the Component source repo", func() {
-				Eventually(func() bool {
-					component, err := f.HasController.GetHasComponent(componentName, appStudioE2EApplicationsNamespace)
-					if err != nil {
-						klog.Infoln("component was not updated yet")
-						return false
-					}
-					return component.Spec.ContainerImage == newContainerImageURL
-				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the Component CR to get updated with a new container image URL")
-			})
-		})
-
-	})
-
-	When("a configmap with 'dummy' custom pipeline bundle is created in the testing namespace", func() {
-		BeforeAll(func() {
-			if customBundleRef != "" {
-				Skip("skipping the specs - a custom pipeline bundle (that overrides the default one) is defined")
-			}
-			cm := &v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
-				Data:       map[string]string{"default_build_bundle": dummyPipelineBundleRef},
-			}
-			_, err = f.CommonController.CreateConfigMap(cm, appStudioE2EApplicationsNamespace)
-			Expect(err).ToNot(HaveOccurred())
-
-			componentName = "build-suite-test-component-pipeline-reference"
-			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-			component, err = f.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, gitSourceURL, "", outputContainerImage, "")
-			Expect(err).ShouldNot(HaveOccurred())
-
-			DeferCleanup(f.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace)
-			DeferCleanup(f.CommonController.DeleteConfigMap, constants.BuildPipelinesConfigMapName, appStudioE2EApplicationsNamespace)
-		})
-		It("should be referenced in another PipelineRun", func() {
-			Eventually(func() bool {
-				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false)
-				if err != nil {
-					klog.Infoln("PipelineRun has not been created yet")
-					return false
-				}
-				return pipelineRun.HasStarted()
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
-
-			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(dummyPipelineBundleRef))
-		})
-	})
-
-	When("a secret with dummy quay.io credentials is created in the testing namespace", Label("build-secret", "slow"), func() {
-		BeforeAll(func() {
-
-			_, err := f.CommonController.GetSecret(appStudioE2EApplicationsNamespace, constants.RegistryAuthSecretName)
+	It("triggers a PipelineRun", func() {
+		Eventually(func() bool {
+			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
 			if err != nil {
-				// If we have an error when getting RegistryAuthSecretName, it should be IsNotFound err
-				Expect(errors.IsNotFound(err)).To(BeTrue())
-			} else {
-				Skip("a registry auth secret is already created in testing namespace - skipping....")
+				klog.Infoln("PipelineRun has not been created yet")
+				return false
 			}
+			return pipelineRun.HasStarted()
+		}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
+	})
 
-			timeout = time.Minute * 1
-			interval = time.Second * 5
-
-			dummySecret := &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{Name: constants.RegistryAuthSecretName},
-				Type:       v1.SecretTypeDockerConfigJson,
-				Data:       map[string][]byte{".dockerconfigjson": []byte("{\"auths\":{\"quay.io\":{\"username\":\"test\",\"password\":\"test\",\"auth\":\"dGVzdDp0ZXN0\",\"email\":\"\"}}}")},
-			}
-
-			_, err = f.CommonController.CreateSecret(appStudioE2EApplicationsNamespace, dummySecret)
-			Expect(err).ToNot(HaveOccurred())
-
-			componentName = "build-suite-test-secret-overriding"
-			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-			component, err = f.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, gitSourceURL, "", outputContainerImage, "")
-			Expect(err).ShouldNot(HaveOccurred())
-
-			DeferCleanup(f.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace)
-			DeferCleanup(f.CommonController.DeleteSecret, appStudioE2EApplicationsNamespace, constants.RegistryAuthSecretName)
+	When("the PipelineRun has started", func() {
+		BeforeAll(func() {
+			timeout = time.Second * 600
+			interval = time.Second * 10
 		})
-
-		It("should override the shared secret", func() {
+		It("should eventually finish successfully", func() {
 			Eventually(func() bool {
-				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false)
-				if err != nil {
-					klog.Infoln("PipelineRun has not been created yet")
-					return false
-				}
-				return pipelineRun.HasStarted()
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
-
-			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(pipelineRun.Spec.Workspaces).To(HaveLen(2))
-			registryAuthWorkspace := &v1beta1.WorkspaceBinding{
-				Name: "registry-auth",
-				Secret: &v1.SecretVolumeSource{
-					SecretName: "redhat-appstudio-registry-pull-secret",
-				},
-			}
-			Expect(pipelineRun.Spec.Workspaces).To(ContainElement(*registryAuthWorkspace))
-		})
-
-		It("should not be possible to push to quay.io repo (PipelineRun should fail)", func() {
-			timeout = time.Minute * 5
-			interval = time.Second * 5
-			Eventually(func() bool {
-				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false)
+				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				for _, condition := range pipelineRun.Status.Conditions {
 					klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
-					return condition.Reason == "Failed"
+
+					if condition.Reason == "Failed" {
+						Fail(fmt.Sprintf("Pipelinerun %s has failed", pipelineRun.Name))
+					}
 				}
-				return false
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to fail")
+				return pipelineRun.IsDone()
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to finish")
 		})
 	})
 
-	When("creating a component with a specific container image URL", Label("image repository protection"), func() {
-		BeforeEach(func() {
-			componentName = fmt.Sprintf("build-suite-test-component-image-url-%s", util.GenerateRandomString(4))
-			timeout = time.Second * 10
+	When("the PipelineRun is finished", func() {
+		var webhookName string
 
-			DeferCleanup(f.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace)
-		})
-		It("should fail for ContainerImage field set to a protected repository (without an image tag)", func() {
-			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected", utils.GetQuayIOOrganization())
-			component, err = f.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, gitSourceURL, "", outputContainerImage, "")
-			Expect(err).ShouldNot(HaveOccurred())
-			Eventually(func() (string, error) {
-				return f.HasController.GetHasComponentConditionStatusMessage(componentName, appStudioE2EApplicationsNamespace)
-			}, timeout).Should(ContainSubstring("create failed"), "timed out waiting for the component creation to fail")
+		BeforeAll(func() {
+			timeout = time.Minute * 5
+			interval = time.Second * 10
+			webhookName = "el" + componentName
 
 		})
-		It("should fail for ContainerImage field set to a protected repository followed by a random tag", func() {
-			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-			component, err = f.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, gitSourceURL, "", outputContainerImage, "")
-			Expect(err).ShouldNot(HaveOccurred())
-			Eventually(func() (string, error) {
-				return f.HasController.GetHasComponentConditionStatusMessage(componentName, appStudioE2EApplicationsNamespace)
-			}, timeout).Should(ContainSubstring("create failed"), "timed out waiting for the component creation to fail")
+
+		It("eventually leads to a creation of a component webhook (event listener)", Label("webhook", "slow"), func() {
+			Eventually(func() bool {
+				_, err := f.HasController.GetEventListenerRoute(componentName, testNamespace)
+				if err != nil {
+					klog.Infof("component webhook %s has not been created yet in %s namespace\n", webhookName, testNamespace)
+					return false
+				}
+				return true
+
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the component webhook to be created")
 		})
-		It("should succeed for ContainerImage field set to a protected repository followed by a namespace prefix + dash + string", func() {
-			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected:%s-%s", utils.GetQuayIOOrganization(), appStudioE2EApplicationsNamespace, strings.Replace(uuid.New().String(), "-", "", -1))
-			component, err = f.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, gitSourceURL, "", outputContainerImage, "")
+	})
+
+	When("the container image is created and pushed to container registry", func() {
+		It("contains non-empty sbom files", Label("build-templates-e2e", "sbom", "slow"), func() {
+			component, err := f.HasController.GetHasComponent(componentName, testNamespace)
 			Expect(err).ShouldNot(HaveOccurred())
-			Eventually(func() (string, error) {
-				return f.HasController.GetHasComponentConditionStatusMessage(componentName, appStudioE2EApplicationsNamespace)
-			}, timeout).Should(ContainSubstring("successfully created"), "timed out waiting for the component creation to succeed")
+			purl, cyclonedx, err := build.GetParsedSbomFilesContentFromImage(component.Spec.ContainerImage)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(purl.ImageContents.Dependencies).ToNot(BeEmpty())
+			Expect(cyclonedx.Components).ToNot(BeEmpty())
 		})
-		It("should succeed for ContainerImage field set to a custom (unprotected) repository without a tag being specified", func() {
-			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images", utils.GetQuayIOOrganization())
-			component, err = f.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, gitSourceURL, "", outputContainerImage, "")
+	})
+	When("the component event listener is created", Label("webhook", "slow"), func() {
+		BeforeAll(func() {
+			timeout = time.Minute * 1
+			interval = time.Second * 1
+
+			webhookRoute, err = f.HasController.GetEventListenerRoute(componentName, testNamespace)
 			Expect(err).ShouldNot(HaveOccurred())
-			Eventually(func() (string, error) {
-				return f.HasController.GetHasComponentConditionStatusMessage(componentName, appStudioE2EApplicationsNamespace)
-			}, timeout).Should(ContainSubstring("successfully created"), "timed out waiting for the component creation to succeed")
+			Expect(webhookRoute.Spec.Host).ShouldNot(BeEmpty())
+
+			if webhookRoute.Spec.TLS != nil {
+				webhookURL = fmt.Sprintf("https://%s", webhookRoute.Spec.Host)
+			} else {
+				webhookURL = fmt.Sprintf("http://%s", webhookRoute.Spec.Host)
+			}
 		})
+
+		It("should be eventually ready to receive events from Github", func() {
+			Eventually(func() bool {
+				c := http.Client{}
+				req, err := http.NewRequestWithContext(context.Background(), "GET", webhookURL, bytes.NewReader([]byte("{}")))
+				if err != nil {
+					return false
+				}
+				resp, err := c.Do(req)
+				if err != nil || resp.StatusCode > 299 {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the event listener to be ready")
+		})
+	})
+
+	When("the component webhook is configured on Github repository for 'push' events and a change is pushed", Label("webhook", "slow"), func() {
+		var initialContainerImageURL, newContainerImageURL string
+		var webhookID int64
+
+		BeforeAll(func() {
+			if utils.IsPrivateHostname(webhookRoute.Spec.Host) {
+				// Workaround for cleanup is needed because of the issue in ginkgo: https://github.com/onsi/ginkgo/issues/980
+				DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+				Skip("Using private cluster (not reachable from Github), skipping...")
+			}
+
+			timeout = time.Minute * 2
+			interval = time.Second * 5
+
+			// Get Component CR to check the current value of Container Image
+			component, err := f.HasController.GetHasComponent(componentName, testNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+			initialContainerImageURL = component.Spec.ContainerImage
+
+			webhookID, err = f.CommonController.Github.CreateWebhook(defaultGitSourceRepoName, webhookURL)
+			Expect(err).ShouldNot(HaveOccurred())
+			DeferCleanup(f.CommonController.Github.DeleteWebhook, defaultGitSourceRepoName, webhookID)
+
+			// Wait until EventListener's pod is ready to receive events
+			err = f.CommonController.WaitForPodSelector(f.CommonController.IsPodRunning, testNamespace, "eventlistener", componentName, 60, 100)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Update a file in Component source Github repo to trigger a push event
+			updatedFile, err := f.CommonController.Github.UpdateFile(defaultGitSourceRepoName, "README.md", "test")
+			Expect(err).NotTo(HaveOccurred())
+
+			// A new output container image URL should contain the suffix with the latest commit SHA
+			newContainerImageURL = fmt.Sprintf("%s-%s", initialContainerImageURL, updatedFile.GetSHA())
+		})
+
+		It("eventually leads to triggering another PipelineRun", func() {
+			Eventually(func() bool {
+				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true)
+				if err != nil {
+					klog.Infoln("PipelineRun has not been created yet")
+					return false
+				}
+				return pipelineRun.HasStarted()
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
+		})
+		It("PipelineRun should eventually finish", func() {
+			timeout = time.Minute * 5
+			Eventually(func() bool {
+				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				for _, condition := range pipelineRun.Status.Conditions {
+					klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+
+					if condition.Reason == "Failed" {
+						Fail(fmt.Sprintf("Pipelinerun %s has failed", pipelineRun.Name))
+					}
+				}
+				return pipelineRun.IsDone()
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to finish")
+		})
+		It("ContainerImage field should be updated with the SHA of the commit that was pushed to the Component source repo", func() {
+			Eventually(func() bool {
+				component, err := f.HasController.GetHasComponent(componentName, testNamespace)
+				if err != nil {
+					klog.Infoln("component was not updated yet")
+					return false
+				}
+				return component.Spec.ContainerImage == newContainerImageURL
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the Component CR to get updated with a new container image URL")
+		})
+	})
+})
+
+var _ = framework.BuildSuiteDescribe("Test AppStudio pipelines", func() {
+	var f *framework.Framework
+
+	var err error
+
+	var applicationName, componentName, testNamespace, outputContainerImage string
+
+	var customBundleConfigMap, defaultBundleConfigMap *v1.ConfigMap
+	var defaultBundleRef, customBundleRef string
+
+	BeforeAll(func() {
+		f, err = framework.NewFramework()
+		Expect(err).NotTo(HaveOccurred())
+
+		applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
+		testNamespace = utils.GetEnv(constants.E2E_APPLICATIONS_NAMESPACE_ENV, fmt.Sprintf("e2e-test-pipelines-%s", util.GenerateRandomString(4)))
+
+		_, err = f.CommonController.CreateTestNamespace(testNamespace)
+		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+
+		_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		// In case user want's to run the test in specific namespace, don't delete it - instead delete only resources created by a test
+		if os.Getenv(constants.E2E_APPLICATIONS_NAMESPACE_ENV) == "" {
+			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+		} else {
+			DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace)
+		}
+
+		for _, gitUrl := range componentUrls {
+			gitUrl := gitUrl
+			componentName = fmt.Sprintf("%s-%s", "test-component", util.GenerateRandomString(4))
+			componentNames = append(componentNames, componentName)
+			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+			// Create a component with Git Source URL being defined
+			_, err := f.HasController.CreateComponent(applicationName, componentName, testNamespace, gitUrl, "", outputContainerImage, "")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// In case user want's to run the test in specific namespace, delete only resources created by a test
+			if os.Getenv(constants.E2E_APPLICATIONS_NAMESPACE_ENV) != "" {
+				DeferCleanup(f.HasController.DeleteHasComponent, componentName, testNamespace)
+			}
+
+		}
+	})
+
+	for i, gitUrl := range componentUrls {
+		gitUrl := gitUrl
+		It(fmt.Sprintf("triggers PipelineRun for component with source URL %s", gitUrl), Label("build-templates-e2e"), func() {
+			timeout := time.Second * 120
+			interval := time.Second * 1
+
+			Eventually(func() bool {
+				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false)
+				if err != nil {
+					klog.Infoln("PipelineRun has not been created yet")
+					return false
+				}
+				return pipelineRun.HasStarted()
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the %s PipelineRun to start", componentNames[i])
+		})
+	}
+
+	It("should reference the custom pipeline bundle in a PipelineRun", func() {
+		customBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, testNamespace)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				klog.Infof("configmap with custom pipeline bundle not found in %s namespace\n", testNamespace)
+			} else {
+				Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, testNamespace, err))
+			}
+		} else {
+			customBundleRef = customBundleConfigMap.Data["default_build_bundle"]
+		}
+
+		if customBundleRef == "" {
+			Skip("skipping the specs - custom pipeline bundle is not defined")
+		}
+		pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(customBundleRef))
+	})
+
+	It("should reference the default pipeline bundle in a PipelineRun", func() {
+		defaultBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
+		if err != nil {
+			if errors.IsForbidden(err) {
+				klog.Infof("don't have enough permissions to get a configmap with default pipeline in %s namespace\n", constants.BuildPipelinesConfigMapDefaultNamespace)
+			} else {
+				Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace, err))
+			}
+		} else {
+			defaultBundleRef = defaultBundleConfigMap.Data["default_build_bundle"]
+		}
+
+		if customBundleRef != "" {
+			Skip("skipping - custom pipeline bundle bundle (that overrides the default one) is defined")
+		}
+		if defaultBundleRef == "" {
+			Skip("skipping - default pipeline bundle cannot be fetched")
+		}
+		pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(defaultBundleRef))
+	})
+
+	for i, gitUrl := range componentUrls {
+		gitUrl := gitUrl
+
+		It(fmt.Sprintf("should eventually finish successfully for component with source URL %s", gitUrl), Label("build-templates-e2e"), func() {
+			timeout := time.Second * 600
+			interval := time.Second * 10
+			Eventually(func() bool {
+				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				for _, condition := range pipelineRun.Status.Conditions {
+					klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+
+					if condition.Reason == "Failed" {
+						Fail(fmt.Sprintf("Pipelinerun %s has failed", pipelineRun.Name))
+					}
+				}
+				return pipelineRun.IsDone()
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to finish")
+		})
+	}
+})
+
+var _ = framework.BuildSuiteDescribe("Creating component with container image source", func() {
+	var f *framework.Framework
+	var err error
+
+	var applicationName, componentName, testNamespace string
+	var timeout, interval time.Duration
+
+	BeforeAll(func() {
+		f, err = framework.NewFramework()
+		Expect(err).NotTo(HaveOccurred())
+
+		applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
+		testNamespace = fmt.Sprintf("e2e-test-%s", util.GenerateRandomString(4))
+
+		_, err = f.CommonController.CreateTestNamespace(testNamespace)
+		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+
+		_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace)
+
+		componentName = fmt.Sprintf("build-suite-test-component-image-source-%s", util.GenerateRandomString(4))
+		outputContainerImage := ""
+		timeout = time.Second * 10
+		interval = time.Second * 1
+		// Create a component with containerImageSource being defined
+		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, "", containerImageSource, outputContainerImage, "")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+	})
+
+	It("should not trigger a PipelineRun", Label("build-templates-e2e"), func() {
+		Consistently(func() bool {
+			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
+			Expect(pipelineRun.Name).To(BeEmpty())
+
+			return strings.Contains(err.Error(), "no pipelinerun found")
+		}, timeout, interval).Should(BeTrue(), "expected the PipelineRun not to be triggered")
+	})
+})
+
+var _ = framework.BuildSuiteDescribe("Creating a configmap with 'dummy' custom pipeline bundle in the testing namespace", func() {
+	var f *framework.Framework
+	var err error
+
+	var timeout, interval time.Duration
+
+	var componentName, applicationName, testNamespace string
+
+	BeforeAll(func() {
+		f, err = framework.NewFramework()
+		Expect(err).NotTo(HaveOccurred())
+
+		testNamespace := fmt.Sprintf("e2e-test-%s", util.GenerateRandomString(4))
+		applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
+
+		_, err = f.CommonController.CreateTestNamespace(testNamespace)
+		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+
+		_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		cm := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
+			Data:       map[string]string{"default_build_bundle": dummyPipelineBundleRef},
+		}
+		_, err = f.CommonController.CreateConfigMap(cm, testNamespace)
+		Expect(err).ToNot(HaveOccurred())
+
+		componentName = "build-suite-test-bundle-overriding"
+		outputContainerImage := fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		timeout = time.Second * 120
+		interval = time.Second * 1
+
+		DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+	})
+	It("should be referenced in a PipelineRun", Label("build-bundle-overriding"), func() {
+		Eventually(func() bool {
+			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
+			if err != nil {
+				klog.Infoln("PipelineRun has not been created yet")
+				return false
+			}
+			return pipelineRun.HasStarted()
+		}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
+
+		pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(dummyPipelineBundleRef))
+	})
+})
+
+var _ = framework.BuildSuiteDescribe("A secret with dummy quay.io credentials is created in the testing namespace", func() {
+	var f *framework.Framework
+	var err error
+
+	var applicationName, componentName, testNamespace, outputContainerImage string
+	var timeout, interval time.Duration
+
+	BeforeAll(func() {
+		f, err = framework.NewFramework()
+		Expect(err).NotTo(HaveOccurred())
+
+		testNamespace = fmt.Sprintf("e2e-test-%s", util.GenerateRandomString(4))
+
+		_, err = f.CommonController.CreateTestNamespace(testNamespace)
+		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+
+		_, err := f.CommonController.GetSecret(testNamespace, constants.RegistryAuthSecretName)
+		if err != nil {
+			// If we have an error when getting RegistryAuthSecretName, it should be IsNotFound err
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+		} else {
+			Skip("a registry auth secret is already created in testing namespace - skipping....")
+		}
+
+		applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
+
+		_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace)
+
+		timeout = time.Minute * 1
+		interval = time.Second * 5
+
+		dummySecret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: constants.RegistryAuthSecretName},
+			Type:       v1.SecretTypeDockerConfigJson,
+			Data:       map[string][]byte{".dockerconfigjson": []byte("{\"auths\":{\"quay.io\":{\"username\":\"test\",\"password\":\"test\",\"auth\":\"dGVzdDp0ZXN0\",\"email\":\"\"}}}")},
+		}
+
+		_, err = f.CommonController.CreateSecret(testNamespace, dummySecret)
+		Expect(err).ToNot(HaveOccurred())
+
+		componentName = "build-suite-test-secret-overriding"
+		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
+		Expect(err).ShouldNot(HaveOccurred())
+
+		DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+	})
+
+	It("should override the shared secret", func() {
+		Eventually(func() bool {
+			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
+			if err != nil {
+				klog.Infoln("PipelineRun has not been created yet")
+				return false
+			}
+			return pipelineRun.HasStarted()
+		}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
+
+		pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(pipelineRun.Spec.Workspaces).To(HaveLen(2))
+		registryAuthWorkspace := &v1beta1.WorkspaceBinding{
+			Name: "registry-auth",
+			Secret: &v1.SecretVolumeSource{
+				SecretName: "redhat-appstudio-registry-pull-secret",
+			},
+		}
+		Expect(pipelineRun.Spec.Workspaces).To(ContainElement(*registryAuthWorkspace))
+	})
+
+	It("should not be possible to push to quay.io repo (PipelineRun should fail)", func() {
+		timeout = time.Minute * 5
+		interval = time.Second * 5
+		Eventually(func() bool {
+			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			for _, condition := range pipelineRun.Status.Conditions {
+				klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+				return condition.Reason == "Failed"
+			}
+			return false
+		}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to fail")
+	})
+})
+
+var _ = framework.BuildSuiteDescribe("Creating a component with a specific container image URL", func() {
+	var f *framework.Framework
+	var err error
+
+	var applicationName, componentName, testNamespace, outputContainerImage string
+	var timeout time.Duration
+
+	BeforeAll(func() {
+		f, err = framework.NewFramework()
+		Expect(err).NotTo(HaveOccurred())
+
+		applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
+		testNamespace = fmt.Sprintf("e2e-test-%s", util.GenerateRandomString(4))
+
+		_, err = f.CommonController.CreateTestNamespace(testNamespace)
+		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+
+		_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+	})
+
+	JustBeforeEach(func() {
+
+		componentName = fmt.Sprintf("build-suite-test-component-image-url-%s", util.GenerateRandomString(4))
+		timeout = time.Second * 10
+
+		DeferCleanup(f.HasController.DeleteHasComponent, componentName, testNamespace)
+	})
+	It("should fail for ContainerImage field set to a protected repository (without an image tag)", func() {
+		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected", utils.GetQuayIOOrganization())
+		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		Eventually(func() (string, error) {
+			return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
+		}, timeout).Should(ContainSubstring("create failed"), "timed out waiting for the component creation to fail")
+
+	})
+	It("should fail for ContainerImage field set to a protected repository followed by a random tag", func() {
+		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		Eventually(func() (string, error) {
+			return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
+		}, timeout).Should(ContainSubstring("create failed"), "timed out waiting for the component creation to fail")
+	})
+	It("should succeed for ContainerImage field set to a protected repository followed by a namespace prefix + dash + string", func() {
+		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected:%s-%s", utils.GetQuayIOOrganization(), testNamespace, strings.Replace(uuid.New().String(), "-", "", -1))
+		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		Eventually(func() (string, error) {
+			return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
+		}, timeout).Should(ContainSubstring("successfully created"), "timed out waiting for the component creation to succeed")
+	})
+	It("should succeed for ContainerImage field set to a custom (unprotected) repository without a tag being specified", func() {
+		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images", utils.GetQuayIOOrganization())
+		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
+		Expect(err).ShouldNot(HaveOccurred())
+		Eventually(func() (string, error) {
+			return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
+		}, timeout).Should(ContainSubstring("successfully created"), "timed out waiting for the component creation to succeed")
 	})
 
 })

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -39,176 +39,43 @@ var (
 	componentNames []string
 )
 
-var _ = framework.BuildSuiteDescribe("Component with git source is created", func() {
-	var f *framework.Framework
-	var err error
+var _ = framework.BuildSuiteDescribe("Build service E2E tests", func() {
 
-	var applicationName, componentName, testNamespace, outputContainerImage string
+	f, err := framework.NewFramework()
+	Expect(err).NotTo(HaveOccurred())
 
-	var timeout, interval time.Duration
+	Describe("Component with git source is created", Ordered, func() {
+		var applicationName, componentName, testNamespace, outputContainerImage string
 
-	var webhookRoute *routev1.Route
-	var webhookURL string
+		var timeout, interval time.Duration
 
-	BeforeAll(func() {
-		f, err = framework.NewFramework()
-		Expect(err).NotTo(HaveOccurred())
+		var webhookRoute *routev1.Route
+		var webhookURL string
 
-		applicationName = fmt.Sprintf("build-suite-test-application-%s", util.GenerateRandomString(4))
-		testNamespace = fmt.Sprintf("e2e-test-%s", util.GenerateRandomString(4))
-
-		_, err = f.CommonController.CreateTestNamespace(testNamespace)
-		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
-
-		_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
-		Expect(err).NotTo(HaveOccurred())
-
-		componentName = fmt.Sprintf("build-suite-test-component-git-source-%s", util.GenerateRandomString(4))
-		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-		timeout = time.Second * 120
-		interval = time.Second * 1
-		// Create a component with Git Source URL being defined
-		_, err := f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
-		Expect(err).ShouldNot(HaveOccurred())
-		DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
-	})
-
-	It("triggers a PipelineRun", func() {
-		Eventually(func() bool {
-			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
-			if err != nil {
-				klog.Infoln("PipelineRun has not been created yet")
-				return false
-			}
-			return pipelineRun.HasStarted()
-		}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
-	})
-
-	When("the PipelineRun has started", func() {
 		BeforeAll(func() {
-			timeout = time.Second * 600
-			interval = time.Second * 10
+
+			applicationName = fmt.Sprintf("build-suite-test-application-%s", util.GenerateRandomString(4))
+			testNamespace = fmt.Sprintf("e2e-test-%s", util.GenerateRandomString(4))
+
+			_, err = f.CommonController.CreateTestNamespace(testNamespace)
+			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+
+			_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			componentName = fmt.Sprintf("build-suite-test-component-git-source-%s", util.GenerateRandomString(4))
+			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+			timeout = time.Second * 120
+			interval = time.Second * 1
+			// Create a component with Git Source URL being defined
+			_, err := f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
+			Expect(err).ShouldNot(HaveOccurred())
+			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
 		})
-		It("should eventually finish successfully", func() {
+
+		It("triggers a PipelineRun", func() {
 			Eventually(func() bool {
 				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				for _, condition := range pipelineRun.Status.Conditions {
-					klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
-
-					if condition.Reason == "Failed" {
-						Fail(fmt.Sprintf("Pipelinerun %s has failed", pipelineRun.Name))
-					}
-				}
-				return pipelineRun.IsDone()
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to finish")
-		})
-	})
-
-	When("the PipelineRun is finished", func() {
-		var webhookName string
-
-		BeforeAll(func() {
-			timeout = time.Minute * 5
-			interval = time.Second * 10
-			webhookName = "el" + componentName
-
-		})
-
-		It("eventually leads to a creation of a component webhook (event listener)", Label("webhook", "slow"), func() {
-			Eventually(func() bool {
-				_, err := f.HasController.GetEventListenerRoute(componentName, testNamespace)
-				if err != nil {
-					klog.Infof("component webhook %s has not been created yet in %s namespace\n", webhookName, testNamespace)
-					return false
-				}
-				return true
-
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the component webhook to be created")
-		})
-	})
-
-	When("the container image is created and pushed to container registry", func() {
-		It("contains non-empty sbom files", Label("build-templates-e2e", "sbom", "slow"), func() {
-			component, err := f.HasController.GetHasComponent(componentName, testNamespace)
-			Expect(err).ShouldNot(HaveOccurred())
-			purl, cyclonedx, err := build.GetParsedSbomFilesContentFromImage(component.Spec.ContainerImage)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(purl.ImageContents.Dependencies).ToNot(BeEmpty())
-			Expect(cyclonedx.Components).ToNot(BeEmpty())
-		})
-	})
-	When("the component event listener is created", Label("webhook", "slow"), func() {
-		BeforeAll(func() {
-			timeout = time.Minute * 1
-			interval = time.Second * 1
-
-			webhookRoute, err = f.HasController.GetEventListenerRoute(componentName, testNamespace)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(webhookRoute.Spec.Host).ShouldNot(BeEmpty())
-
-			if webhookRoute.Spec.TLS != nil {
-				webhookURL = fmt.Sprintf("https://%s", webhookRoute.Spec.Host)
-			} else {
-				webhookURL = fmt.Sprintf("http://%s", webhookRoute.Spec.Host)
-			}
-		})
-
-		It("should be eventually ready to receive events from Github", func() {
-			Eventually(func() bool {
-				c := http.Client{}
-				req, err := http.NewRequestWithContext(context.Background(), "GET", webhookURL, bytes.NewReader([]byte("{}")))
-				if err != nil {
-					return false
-				}
-				resp, err := c.Do(req)
-				if err != nil || resp.StatusCode > 299 {
-					return false
-				}
-				return true
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the event listener to be ready")
-		})
-	})
-
-	When("the component webhook is configured on Github repository for 'push' events and a change is pushed", Label("webhook", "slow"), func() {
-		var initialContainerImageURL, newContainerImageURL string
-		var webhookID int64
-
-		BeforeAll(func() {
-			if utils.IsPrivateHostname(webhookRoute.Spec.Host) {
-				// Workaround for cleanup is needed because of the issue in ginkgo: https://github.com/onsi/ginkgo/issues/980
-				DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
-				Skip("Using private cluster (not reachable from Github), skipping...")
-			}
-
-			timeout = time.Minute * 2
-			interval = time.Second * 5
-
-			// Get Component CR to check the current value of Container Image
-			component, err := f.HasController.GetHasComponent(componentName, testNamespace)
-			Expect(err).ShouldNot(HaveOccurred())
-			initialContainerImageURL = component.Spec.ContainerImage
-
-			webhookID, err = f.CommonController.Github.CreateWebhook(defaultGitSourceRepoName, webhookURL)
-			Expect(err).ShouldNot(HaveOccurred())
-			DeferCleanup(f.CommonController.Github.DeleteWebhook, defaultGitSourceRepoName, webhookID)
-
-			// Wait until EventListener's pod is ready to receive events
-			err = f.CommonController.WaitForPodSelector(f.CommonController.IsPodRunning, testNamespace, "eventlistener", componentName, 60, 100)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Update a file in Component source Github repo to trigger a push event
-			updatedFile, err := f.CommonController.Github.UpdateFile(defaultGitSourceRepoName, "README.md", "test")
-			Expect(err).NotTo(HaveOccurred())
-
-			// A new output container image URL should contain the suffix with the latest commit SHA
-			newContainerImageURL = fmt.Sprintf("%s-%s", initialContainerImageURL, updatedFile.GetSHA())
-		})
-
-		It("eventually leads to triggering another PipelineRun", func() {
-			Eventually(func() bool {
-				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true)
 				if err != nil {
 					klog.Infoln("PipelineRun has not been created yet")
 					return false
@@ -216,412 +83,524 @@ var _ = framework.BuildSuiteDescribe("Component with git source is created", fun
 				return pipelineRun.HasStarted()
 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
 		})
-		It("PipelineRun should eventually finish", func() {
-			timeout = time.Minute * 5
-			Eventually(func() bool {
-				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true)
-				Expect(err).ShouldNot(HaveOccurred())
 
-				for _, condition := range pipelineRun.Status.Conditions {
-					klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+		When("the PipelineRun has started", func() {
+			BeforeAll(func() {
+				timeout = time.Second * 600
+				interval = time.Second * 10
+			})
+			It("should eventually finish successfully", func() {
+				Eventually(func() bool {
+					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
+					Expect(err).ShouldNot(HaveOccurred())
 
-					if condition.Reason == "Failed" {
-						Fail(fmt.Sprintf("Pipelinerun %s has failed", pipelineRun.Name))
+					for _, condition := range pipelineRun.Status.Conditions {
+						klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+
+						if condition.Reason == "Failed" {
+							Fail(fmt.Sprintf("Pipelinerun %s has failed", pipelineRun.Name))
+						}
 					}
-				}
-				return pipelineRun.IsDone()
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to finish")
+					return pipelineRun.IsDone()
+				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to finish")
+			})
 		})
-		It("ContainerImage field should be updated with the SHA of the commit that was pushed to the Component source repo", func() {
-			Eventually(func() bool {
+
+		When("the PipelineRun is finished", func() {
+			var webhookName string
+
+			BeforeAll(func() {
+				timeout = time.Minute * 5
+				interval = time.Second * 10
+				webhookName = "el" + componentName
+
+			})
+
+			It("eventually leads to a creation of a component webhook (event listener)", Label("webhook", "slow"), func() {
+				Eventually(func() bool {
+					_, err := f.HasController.GetEventListenerRoute(componentName, testNamespace)
+					if err != nil {
+						klog.Infof("component webhook %s has not been created yet in %s namespace\n", webhookName, testNamespace)
+						return false
+					}
+					return true
+
+				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the component webhook to be created")
+			})
+		})
+
+		When("the container image is created and pushed to container registry", func() {
+			It("contains non-empty sbom files", Label("build-templates-e2e", "sbom", "slow"), func() {
 				component, err := f.HasController.GetHasComponent(componentName, testNamespace)
-				if err != nil {
-					klog.Infoln("component was not updated yet")
-					return false
+				Expect(err).ShouldNot(HaveOccurred())
+				purl, cyclonedx, err := build.GetParsedSbomFilesContentFromImage(component.Spec.ContainerImage)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(purl.ImageContents.Dependencies).ToNot(BeEmpty())
+				Expect(cyclonedx.Components).ToNot(BeEmpty())
+			})
+		})
+		When("the component event listener is created", Label("webhook", "slow"), func() {
+			BeforeAll(func() {
+				timeout = time.Minute * 1
+				interval = time.Second * 1
+
+				webhookRoute, err = f.HasController.GetEventListenerRoute(componentName, testNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(webhookRoute.Spec.Host).ShouldNot(BeEmpty())
+
+				if webhookRoute.Spec.TLS != nil {
+					webhookURL = fmt.Sprintf("https://%s", webhookRoute.Spec.Host)
+				} else {
+					webhookURL = fmt.Sprintf("http://%s", webhookRoute.Spec.Host)
 				}
-				return component.Spec.ContainerImage == newContainerImageURL
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the Component CR to get updated with a new container image URL")
+			})
+
+			It("should be eventually ready to receive events from Github", func() {
+				Eventually(func() bool {
+					c := http.Client{}
+					req, err := http.NewRequestWithContext(context.Background(), "GET", webhookURL, bytes.NewReader([]byte("{}")))
+					if err != nil {
+						return false
+					}
+					resp, err := c.Do(req)
+					if err != nil || resp.StatusCode > 299 {
+						return false
+					}
+					return true
+				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the event listener to be ready")
+			})
+		})
+
+		When("the component webhook is configured on Github repository for 'push' events and a change is pushed", Label("webhook", "slow"), func() {
+			var initialContainerImageURL, newContainerImageURL string
+			var webhookID int64
+
+			BeforeAll(func() {
+				if utils.IsPrivateHostname(webhookRoute.Spec.Host) {
+					// Workaround for cleanup is needed because of the issue in ginkgo: https://github.com/onsi/ginkgo/issues/980
+					DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+					Skip("Using private cluster (not reachable from Github), skipping...")
+				}
+
+				timeout = time.Minute * 2
+				interval = time.Second * 5
+
+				// Get Component CR to check the current value of Container Image
+				component, err := f.HasController.GetHasComponent(componentName, testNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+				initialContainerImageURL = component.Spec.ContainerImage
+
+				webhookID, err = f.CommonController.Github.CreateWebhook(defaultGitSourceRepoName, webhookURL)
+				Expect(err).ShouldNot(HaveOccurred())
+				DeferCleanup(f.CommonController.Github.DeleteWebhook, defaultGitSourceRepoName, webhookID)
+
+				// Wait until EventListener's pod is ready to receive events
+				err = f.CommonController.WaitForPodSelector(f.CommonController.IsPodRunning, testNamespace, "eventlistener", componentName, 60, 100)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Update a file in Component source Github repo to trigger a push event
+				updatedFile, err := f.CommonController.Github.UpdateFile(defaultGitSourceRepoName, "README.md", "test")
+				Expect(err).NotTo(HaveOccurred())
+
+				// A new output container image URL should contain the suffix with the latest commit SHA
+				newContainerImageURL = fmt.Sprintf("%s-%s", initialContainerImageURL, updatedFile.GetSHA())
+			})
+
+			It("eventually leads to triggering another PipelineRun", func() {
+				Eventually(func() bool {
+					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true)
+					if err != nil {
+						klog.Infoln("PipelineRun has not been created yet")
+						return false
+					}
+					return pipelineRun.HasStarted()
+				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
+			})
+			It("PipelineRun should eventually finish", func() {
+				timeout = time.Minute * 5
+				Eventually(func() bool {
+					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					for _, condition := range pipelineRun.Status.Conditions {
+						klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+
+						if condition.Reason == "Failed" {
+							Fail(fmt.Sprintf("Pipelinerun %s has failed", pipelineRun.Name))
+						}
+					}
+					return pipelineRun.IsDone()
+				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to finish")
+			})
+			It("ContainerImage field should be updated with the SHA of the commit that was pushed to the Component source repo", func() {
+				Eventually(func() bool {
+					component, err := f.HasController.GetHasComponent(componentName, testNamespace)
+					if err != nil {
+						klog.Infoln("component was not updated yet")
+						return false
+					}
+					return component.Spec.ContainerImage == newContainerImageURL
+				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the Component CR to get updated with a new container image URL")
+			})
 		})
 	})
-})
 
-var _ = framework.BuildSuiteDescribe("Test AppStudio pipelines", func() {
-	var f *framework.Framework
+	Describe("Test AppStudio pipelines", Ordered, func() {
 
-	var err error
+		var applicationName, componentName, testNamespace, outputContainerImage string
 
-	var applicationName, componentName, testNamespace, outputContainerImage string
+		var customBundleConfigMap, defaultBundleConfigMap *v1.ConfigMap
+		var defaultBundleRef, customBundleRef string
 
-	var customBundleConfigMap, defaultBundleConfigMap *v1.ConfigMap
-	var defaultBundleRef, customBundleRef string
+		BeforeAll(func() {
 
-	BeforeAll(func() {
-		f, err = framework.NewFramework()
-		Expect(err).NotTo(HaveOccurred())
+			applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
+			testNamespace = utils.GetEnv(constants.E2E_APPLICATIONS_NAMESPACE_ENV, fmt.Sprintf("e2e-test-pipelines-%s", util.GenerateRandomString(4)))
 
-		applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
-		testNamespace = utils.GetEnv(constants.E2E_APPLICATIONS_NAMESPACE_ENV, fmt.Sprintf("e2e-test-pipelines-%s", util.GenerateRandomString(4)))
+			_, err = f.CommonController.CreateTestNamespace(testNamespace)
+			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
 
-		_, err = f.CommonController.CreateTestNamespace(testNamespace)
-		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+			_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
+			Expect(err).NotTo(HaveOccurred())
 
-		_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
-		Expect(err).NotTo(HaveOccurred())
-
-		// In case user want's to run the test in specific namespace, don't delete it - instead delete only resources created by a test
-		if os.Getenv(constants.E2E_APPLICATIONS_NAMESPACE_ENV) == "" {
-			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
-		} else {
-			DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace)
-		}
-
-		for _, gitUrl := range componentUrls {
-			gitUrl := gitUrl
-			componentName = fmt.Sprintf("%s-%s", "test-component", util.GenerateRandomString(4))
-			componentNames = append(componentNames, componentName)
-			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-			// Create a component with Git Source URL being defined
-			_, err := f.HasController.CreateComponent(applicationName, componentName, testNamespace, gitUrl, "", outputContainerImage, "")
-			Expect(err).ShouldNot(HaveOccurred())
-
-			// In case user want's to run the test in specific namespace, delete only resources created by a test
-			if os.Getenv(constants.E2E_APPLICATIONS_NAMESPACE_ENV) != "" {
-				DeferCleanup(f.HasController.DeleteHasComponent, componentName, testNamespace)
+			// In case user want's to run the test in specific namespace, don't delete it - instead delete only resources created by a test
+			if os.Getenv(constants.E2E_APPLICATIONS_NAMESPACE_ENV) == "" {
+				DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+			} else {
+				DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace)
 			}
 
+			for _, gitUrl := range componentUrls {
+				gitUrl := gitUrl
+				componentName = fmt.Sprintf("%s-%s", "test-component", util.GenerateRandomString(4))
+				componentNames = append(componentNames, componentName)
+				outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+				// Create a component with Git Source URL being defined
+				_, err := f.HasController.CreateComponent(applicationName, componentName, testNamespace, gitUrl, "", outputContainerImage, "")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// In case user want's to run the test in specific namespace, delete only resources created by a test
+				if os.Getenv(constants.E2E_APPLICATIONS_NAMESPACE_ENV) != "" {
+					DeferCleanup(f.HasController.DeleteHasComponent, componentName, testNamespace)
+				}
+
+			}
+		})
+
+		for i, gitUrl := range componentUrls {
+			gitUrl := gitUrl
+			It(fmt.Sprintf("triggers PipelineRun for component with source URL %s", gitUrl), Label("build-templates-e2e"), func() {
+				timeout := time.Second * 120
+				interval := time.Second * 1
+
+				Eventually(func() bool {
+					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false)
+					if err != nil {
+						klog.Infoln("PipelineRun has not been created yet")
+						return false
+					}
+					return pipelineRun.HasStarted()
+				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the %s PipelineRun to start", componentNames[i])
+			})
+		}
+
+		It("should reference the custom pipeline bundle in a PipelineRun", func() {
+			customBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, testNamespace)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					klog.Infof("configmap with custom pipeline bundle not found in %s namespace\n", testNamespace)
+				} else {
+					Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, testNamespace, err))
+				}
+			} else {
+				customBundleRef = customBundleConfigMap.Data["default_build_bundle"]
+			}
+
+			if customBundleRef == "" {
+				Skip("skipping the specs - custom pipeline bundle is not defined")
+			}
+			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(customBundleRef))
+		})
+
+		It("should reference the default pipeline bundle in a PipelineRun", func() {
+			defaultBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
+			if err != nil {
+				if errors.IsForbidden(err) {
+					klog.Infof("don't have enough permissions to get a configmap with default pipeline in %s namespace\n", constants.BuildPipelinesConfigMapDefaultNamespace)
+				} else {
+					Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace, err))
+				}
+			} else {
+				defaultBundleRef = defaultBundleConfigMap.Data["default_build_bundle"]
+			}
+
+			if customBundleRef != "" {
+				Skip("skipping - custom pipeline bundle bundle (that overrides the default one) is defined")
+			}
+			if defaultBundleRef == "" {
+				Skip("skipping - default pipeline bundle cannot be fetched")
+			}
+			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(defaultBundleRef))
+		})
+
+		for i, gitUrl := range componentUrls {
+			gitUrl := gitUrl
+
+			It(fmt.Sprintf("should eventually finish successfully for component with source URL %s", gitUrl), Label("build-templates-e2e"), func() {
+				timeout := time.Second * 600
+				interval := time.Second * 10
+				Eventually(func() bool {
+					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					for _, condition := range pipelineRun.Status.Conditions {
+						klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+
+						if condition.Reason == "Failed" {
+							Fail(fmt.Sprintf("Pipelinerun %s has failed", pipelineRun.Name))
+						}
+					}
+					return pipelineRun.IsDone()
+				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to finish")
+			})
 		}
 	})
 
-	for i, gitUrl := range componentUrls {
-		gitUrl := gitUrl
-		It(fmt.Sprintf("triggers PipelineRun for component with source URL %s", gitUrl), Label("build-templates-e2e"), func() {
-			timeout := time.Second * 120
-			interval := time.Second * 1
+	Describe("Creating component with container image source", Ordered, func() {
 
+		var applicationName, componentName, testNamespace string
+		var timeout, interval time.Duration
+
+		BeforeAll(func() {
+
+			applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
+			testNamespace = fmt.Sprintf("e2e-test-%s", util.GenerateRandomString(4))
+
+			_, err = f.CommonController.CreateTestNamespace(testNamespace)
+			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+
+			_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace)
+
+			componentName = fmt.Sprintf("build-suite-test-component-image-source-%s", util.GenerateRandomString(4))
+			outputContainerImage := ""
+			timeout = time.Second * 10
+			interval = time.Second * 1
+			// Create a component with containerImageSource being defined
+			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, "", containerImageSource, outputContainerImage, "")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+		})
+
+		It("should not trigger a PipelineRun", Label("build-templates-e2e"), func() {
+			Consistently(func() bool {
+				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
+				Expect(pipelineRun.Name).To(BeEmpty())
+
+				return strings.Contains(err.Error(), "no pipelinerun found")
+			}, timeout, interval).Should(BeTrue(), "expected the PipelineRun not to be triggered")
+		})
+	})
+
+	Describe("Creating a configmap with 'dummy' custom pipeline bundle in the testing namespace", Ordered, func() {
+		var timeout, interval time.Duration
+
+		var componentName, applicationName, testNamespace string
+
+		BeforeAll(func() {
+
+			testNamespace := fmt.Sprintf("e2e-test-%s", util.GenerateRandomString(4))
+			applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
+
+			_, err = f.CommonController.CreateTestNamespace(testNamespace)
+			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+
+			_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			cm := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
+				Data:       map[string]string{"default_build_bundle": dummyPipelineBundleRef},
+			}
+			_, err = f.CommonController.CreateConfigMap(cm, testNamespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			componentName = "build-suite-test-bundle-overriding"
+			outputContainerImage := fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			timeout = time.Second * 120
+			interval = time.Second * 1
+
+			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+		})
+		It("should be referenced in a PipelineRun", Label("build-bundle-overriding"), func() {
 			Eventually(func() bool {
-				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false)
+				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
 				if err != nil {
 					klog.Infoln("PipelineRun has not been created yet")
 					return false
 				}
 				return pipelineRun.HasStarted()
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the %s PipelineRun to start", componentNames[i])
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
+
+			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(dummyPipelineBundleRef))
 		})
-	}
-
-	It("should reference the custom pipeline bundle in a PipelineRun", func() {
-		customBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, testNamespace)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				klog.Infof("configmap with custom pipeline bundle not found in %s namespace\n", testNamespace)
-			} else {
-				Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, testNamespace, err))
-			}
-		} else {
-			customBundleRef = customBundleConfigMap.Data["default_build_bundle"]
-		}
-
-		if customBundleRef == "" {
-			Skip("skipping the specs - custom pipeline bundle is not defined")
-		}
-		pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false)
-		Expect(err).ShouldNot(HaveOccurred())
-
-		Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(customBundleRef))
 	})
 
-	It("should reference the default pipeline bundle in a PipelineRun", func() {
-		defaultBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
-		if err != nil {
-			if errors.IsForbidden(err) {
-				klog.Infof("don't have enough permissions to get a configmap with default pipeline in %s namespace\n", constants.BuildPipelinesConfigMapDefaultNamespace)
+	Describe("A secret with dummy quay.io credentials is created in the testing namespace", Ordered, func() {
+
+		var applicationName, componentName, testNamespace, outputContainerImage string
+		var timeout, interval time.Duration
+
+		BeforeAll(func() {
+
+			testNamespace = fmt.Sprintf("e2e-test-%s", util.GenerateRandomString(4))
+
+			_, err = f.CommonController.CreateTestNamespace(testNamespace)
+			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+
+			_, err := f.CommonController.GetSecret(testNamespace, constants.RegistryAuthSecretName)
+			if err != nil {
+				// If we have an error when getting RegistryAuthSecretName, it should be IsNotFound err
+				Expect(errors.IsNotFound(err)).To(BeTrue())
 			} else {
-				Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace, err))
+				Skip("a registry auth secret is already created in testing namespace - skipping....")
 			}
-		} else {
-			defaultBundleRef = defaultBundleConfigMap.Data["default_build_bundle"]
-		}
 
-		if customBundleRef != "" {
-			Skip("skipping - custom pipeline bundle bundle (that overrides the default one) is defined")
-		}
-		if defaultBundleRef == "" {
-			Skip("skipping - default pipeline bundle cannot be fetched")
-		}
-		pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(defaultBundleRef))
-	})
+			applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
 
-	for i, gitUrl := range componentUrls {
-		gitUrl := gitUrl
+			_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace)
 
-		It(fmt.Sprintf("should eventually finish successfully for component with source URL %s", gitUrl), Label("build-templates-e2e"), func() {
-			timeout := time.Second * 600
-			interval := time.Second * 10
+			timeout = time.Minute * 2
+			interval = time.Second * 1
+
+			dummySecret := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: constants.RegistryAuthSecretName},
+				Type:       v1.SecretTypeDockerConfigJson,
+				Data:       map[string][]byte{".dockerconfigjson": []byte("{\"auths\":{\"quay.io\":{\"username\":\"test\",\"password\":\"test\",\"auth\":\"dGVzdDp0ZXN0\",\"email\":\"\"}}}")},
+			}
+
+			_, err = f.CommonController.CreateSecret(testNamespace, dummySecret)
+			Expect(err).ToNot(HaveOccurred())
+
+			componentName = "build-suite-test-secret-overriding"
+			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+		})
+
+		It("should override the shared secret", func() {
 			Eventually(func() bool {
-				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false)
+				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
+				if err != nil {
+					klog.Infoln("PipelineRun has not been created yet")
+					return false
+				}
+				return pipelineRun.HasStarted()
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
+
+			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pipelineRun.Spec.Workspaces).To(HaveLen(2))
+			registryAuthWorkspace := &v1beta1.WorkspaceBinding{
+				Name: "registry-auth",
+				Secret: &v1.SecretVolumeSource{
+					SecretName: "redhat-appstudio-registry-pull-secret",
+				},
+			}
+			Expect(pipelineRun.Spec.Workspaces).To(ContainElement(*registryAuthWorkspace))
+		})
+
+		It("should not be possible to push to quay.io repo (PipelineRun should fail)", func() {
+			timeout = time.Minute * 5
+			interval = time.Second * 5
+			Eventually(func() bool {
+				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				for _, condition := range pipelineRun.Status.Conditions {
 					klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
-
-					if condition.Reason == "Failed" {
-						Fail(fmt.Sprintf("Pipelinerun %s has failed", pipelineRun.Name))
-					}
+					return condition.Reason == "Failed"
 				}
-				return pipelineRun.IsDone()
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to finish")
+				return false
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to fail")
 		})
-	}
-})
-
-var _ = framework.BuildSuiteDescribe("Creating component with container image source", func() {
-	var f *framework.Framework
-	var err error
-
-	var applicationName, componentName, testNamespace string
-	var timeout, interval time.Duration
-
-	BeforeAll(func() {
-		f, err = framework.NewFramework()
-		Expect(err).NotTo(HaveOccurred())
-
-		applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
-		testNamespace = fmt.Sprintf("e2e-test-%s", util.GenerateRandomString(4))
-
-		_, err = f.CommonController.CreateTestNamespace(testNamespace)
-		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
-
-		_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
-		Expect(err).NotTo(HaveOccurred())
-		DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace)
-
-		componentName = fmt.Sprintf("build-suite-test-component-image-source-%s", util.GenerateRandomString(4))
-		outputContainerImage := ""
-		timeout = time.Second * 10
-		interval = time.Second * 1
-		// Create a component with containerImageSource being defined
-		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, "", containerImageSource, outputContainerImage, "")
-		Expect(err).ShouldNot(HaveOccurred())
-
-		DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
 	})
 
-	It("should not trigger a PipelineRun", Label("build-templates-e2e"), func() {
-		Consistently(func() bool {
-			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
-			Expect(pipelineRun.Name).To(BeEmpty())
+	Describe("Creating a component with a specific container image URL", Ordered, func() {
 
-			return strings.Contains(err.Error(), "no pipelinerun found")
-		}, timeout, interval).Should(BeTrue(), "expected the PipelineRun not to be triggered")
-	})
-})
+		var applicationName, componentName, testNamespace, outputContainerImage string
+		var timeout time.Duration
 
-var _ = framework.BuildSuiteDescribe("Creating a configmap with 'dummy' custom pipeline bundle in the testing namespace", func() {
-	var f *framework.Framework
-	var err error
+		BeforeAll(func() {
 
-	var timeout, interval time.Duration
+			applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
+			testNamespace = fmt.Sprintf("e2e-test-%s", util.GenerateRandomString(4))
 
-	var componentName, applicationName, testNamespace string
+			_, err = f.CommonController.CreateTestNamespace(testNamespace)
+			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
 
-	BeforeAll(func() {
-		f, err = framework.NewFramework()
-		Expect(err).NotTo(HaveOccurred())
+			_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
+			Expect(err).NotTo(HaveOccurred())
 
-		testNamespace := fmt.Sprintf("e2e-test-%s", util.GenerateRandomString(4))
-		applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
+			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+		})
 
-		_, err = f.CommonController.CreateTestNamespace(testNamespace)
-		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+		JustBeforeEach(func() {
 
-		_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
-		Expect(err).NotTo(HaveOccurred())
+			componentName = fmt.Sprintf("build-suite-test-component-image-url-%s", util.GenerateRandomString(4))
+			timeout = time.Second * 10
 
-		cm := &v1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
-			Data:       map[string]string{"default_build_bundle": dummyPipelineBundleRef},
-		}
-		_, err = f.CommonController.CreateConfigMap(cm, testNamespace)
-		Expect(err).ToNot(HaveOccurred())
-
-		componentName = "build-suite-test-bundle-overriding"
-		outputContainerImage := fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
-		Expect(err).ShouldNot(HaveOccurred())
-
-		timeout = time.Second * 120
-		interval = time.Second * 1
-
-		DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
-	})
-	It("should be referenced in a PipelineRun", Label("build-bundle-overriding"), func() {
-		Eventually(func() bool {
-			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
-			if err != nil {
-				klog.Infoln("PipelineRun has not been created yet")
-				return false
-			}
-			return pipelineRun.HasStarted()
-		}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
-
-		pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(dummyPipelineBundleRef))
-	})
-})
-
-var _ = framework.BuildSuiteDescribe("A secret with dummy quay.io credentials is created in the testing namespace", func() {
-	var f *framework.Framework
-	var err error
-
-	var applicationName, componentName, testNamespace, outputContainerImage string
-	var timeout, interval time.Duration
-
-	BeforeAll(func() {
-		f, err = framework.NewFramework()
-		Expect(err).NotTo(HaveOccurred())
-
-		testNamespace = fmt.Sprintf("e2e-test-%s", util.GenerateRandomString(4))
-
-		_, err = f.CommonController.CreateTestNamespace(testNamespace)
-		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
-
-		_, err := f.CommonController.GetSecret(testNamespace, constants.RegistryAuthSecretName)
-		if err != nil {
-			// If we have an error when getting RegistryAuthSecretName, it should be IsNotFound err
-			Expect(errors.IsNotFound(err)).To(BeTrue())
-		} else {
-			Skip("a registry auth secret is already created in testing namespace - skipping....")
-		}
-
-		applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
-
-		_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
-		Expect(err).NotTo(HaveOccurred())
-		DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace)
-
-		timeout = time.Minute * 2
-		interval = time.Second * 1
-
-		dummySecret := &v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: constants.RegistryAuthSecretName},
-			Type:       v1.SecretTypeDockerConfigJson,
-			Data:       map[string][]byte{".dockerconfigjson": []byte("{\"auths\":{\"quay.io\":{\"username\":\"test\",\"password\":\"test\",\"auth\":\"dGVzdDp0ZXN0\",\"email\":\"\"}}}")},
-		}
-
-		_, err = f.CommonController.CreateSecret(testNamespace, dummySecret)
-		Expect(err).ToNot(HaveOccurred())
-
-		componentName = "build-suite-test-secret-overriding"
-		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
-		Expect(err).ShouldNot(HaveOccurred())
-
-		DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
-	})
-
-	It("should override the shared secret", func() {
-		Eventually(func() bool {
-			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
-			if err != nil {
-				klog.Infoln("PipelineRun has not been created yet")
-				return false
-			}
-			return pipelineRun.HasStarted()
-		}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
-
-		pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(pipelineRun.Spec.Workspaces).To(HaveLen(2))
-		registryAuthWorkspace := &v1beta1.WorkspaceBinding{
-			Name: "registry-auth",
-			Secret: &v1.SecretVolumeSource{
-				SecretName: "redhat-appstudio-registry-pull-secret",
-			},
-		}
-		Expect(pipelineRun.Spec.Workspaces).To(ContainElement(*registryAuthWorkspace))
-	})
-
-	It("should not be possible to push to quay.io repo (PipelineRun should fail)", func() {
-		timeout = time.Minute * 5
-		interval = time.Second * 5
-		Eventually(func() bool {
-			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
+			DeferCleanup(f.HasController.DeleteHasComponent, componentName, testNamespace)
+		})
+		It("should fail for ContainerImage field set to a protected repository (without an image tag)", func() {
+			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected", utils.GetQuayIOOrganization())
+			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(func() (string, error) {
+				return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
+			}, timeout).Should(ContainSubstring("create failed"), "timed out waiting for the component creation to fail")
 
-			for _, condition := range pipelineRun.Status.Conditions {
-				klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
-				return condition.Reason == "Failed"
-			}
-			return false
-		}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to fail")
-	})
-})
-
-var _ = framework.BuildSuiteDescribe("Creating a component with a specific container image URL", func() {
-	var f *framework.Framework
-	var err error
-
-	var applicationName, componentName, testNamespace, outputContainerImage string
-	var timeout time.Duration
-
-	BeforeAll(func() {
-		f, err = framework.NewFramework()
-		Expect(err).NotTo(HaveOccurred())
-
-		applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
-		testNamespace = fmt.Sprintf("e2e-test-%s", util.GenerateRandomString(4))
-
-		_, err = f.CommonController.CreateTestNamespace(testNamespace)
-		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
-
-		_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
-		Expect(err).NotTo(HaveOccurred())
-
-		DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
-	})
-
-	JustBeforeEach(func() {
-
-		componentName = fmt.Sprintf("build-suite-test-component-image-url-%s", util.GenerateRandomString(4))
-		timeout = time.Second * 10
-
-		DeferCleanup(f.HasController.DeleteHasComponent, componentName, testNamespace)
-	})
-	It("should fail for ContainerImage field set to a protected repository (without an image tag)", func() {
-		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected", utils.GetQuayIOOrganization())
-		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
-		Expect(err).ShouldNot(HaveOccurred())
-		Eventually(func() (string, error) {
-			return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
-		}, timeout).Should(ContainSubstring("create failed"), "timed out waiting for the component creation to fail")
+		})
+		It("should fail for ContainerImage field set to a protected repository followed by a random tag", func() {
+			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(func() (string, error) {
+				return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
+			}, timeout).Should(ContainSubstring("create failed"), "timed out waiting for the component creation to fail")
+		})
+		It("should succeed for ContainerImage field set to a protected repository followed by a namespace prefix + dash + string", func() {
+			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected:%s-%s", utils.GetQuayIOOrganization(), testNamespace, strings.Replace(uuid.New().String(), "-", "", -1))
+			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(func() (string, error) {
+				return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
+			}, timeout).Should(ContainSubstring("successfully created"), "timed out waiting for the component creation to succeed")
+		})
+		It("should succeed for ContainerImage field set to a custom (unprotected) repository without a tag being specified", func() {
+			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images", utils.GetQuayIOOrganization())
+			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(func() (string, error) {
+				return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
+			}, timeout).Should(ContainSubstring("successfully created"), "timed out waiting for the component creation to succeed")
+		})
 
 	})
-	It("should fail for ContainerImage field set to a protected repository followed by a random tag", func() {
-		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
-		Expect(err).ShouldNot(HaveOccurred())
-		Eventually(func() (string, error) {
-			return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
-		}, timeout).Should(ContainSubstring("create failed"), "timed out waiting for the component creation to fail")
-	})
-	It("should succeed for ContainerImage field set to a protected repository followed by a namespace prefix + dash + string", func() {
-		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected:%s-%s", utils.GetQuayIOOrganization(), testNamespace, strings.Replace(uuid.New().String(), "-", "", -1))
-		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
-		Expect(err).ShouldNot(HaveOccurred())
-		Eventually(func() (string, error) {
-			return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
-		}, timeout).Should(ContainSubstring("successfully created"), "timed out waiting for the component creation to succeed")
-	})
-	It("should succeed for ContainerImage field set to a custom (unprotected) repository without a tag being specified", func() {
-		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images", utils.GetQuayIOOrganization())
-		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, defaultGitSourceURL, "", outputContainerImage, "")
-		Expect(err).ShouldNot(HaveOccurred())
-		Eventually(func() (string, error) {
-			return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
-		}, timeout).Should(ContainSubstring("successfully created"), "timed out waiting for the component creation to succeed")
-	})
-
 })

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -95,7 +95,7 @@ var _ = framework.BuildSuiteDescribe("Build Service E2E tests", func() {
 			timeout = time.Second * 60
 			interval = time.Second * 1
 			// Create a component with Git Source URL being defined
-			component, err = f.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, gitSourceURL, "", outputContainerImage, "")
+			component, err = f.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, defaultGitSourceURL, "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			DeferCleanup(f.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace)
 

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -129,8 +129,8 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", func() {
 			})
 		})
 
-		When("the container image is created and pushed to container registry", func() {
-			It("contains non-empty sbom files", Label("build-templates-e2e", "sbom", "slow"), func() {
+		When("the container image is created and pushed to container registry", Label("sbom", "slow"), func() {
+			It("contains non-empty sbom files", func() {
 				component, err := f.HasController.GetHasComponent(componentName, testNamespace)
 				Expect(err).ShouldNot(HaveOccurred())
 				purl, cyclonedx, err := build.GetParsedSbomFilesContentFromImage(component.Spec.ContainerImage)
@@ -399,7 +399,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", func() {
 			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
 		})
 
-		It("should not trigger a PipelineRun", Label("build-templates-e2e"), func() {
+		It("should not trigger a PipelineRun", func() {
 			Consistently(func() bool {
 				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
 				Expect(pipelineRun.Name).To(BeEmpty())

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -502,8 +502,8 @@ var _ = framework.BuildSuiteDescribe("A secret with dummy quay.io credentials is
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace)
 
-		timeout = time.Minute * 1
-		interval = time.Second * 5
+		timeout = time.Minute * 2
+		interval = time.Second * 1
 
 		dummySecret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: constants.RegistryAuthSecretName},

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -276,7 +276,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", func() {
 					bundlePullSpec := defaultBundleConfigMap.Data["default_build_bundle"]
 					hacbsBundleConfigMap := &v1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
-						Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "/build-", "/hacbs-", 1)},
+						Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
 					}
 					_, err = f.CommonController.CreateConfigMap(hacbsBundleConfigMap, testNamespace)
 					Expect(err).ToNot(HaveOccurred())
@@ -288,7 +288,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", func() {
 				bundlePullSpec := customBundleConfigMap.Data["default_build_bundle"]
 				hacbsBundleConfigMap := &v1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
-					Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "/build-", "/hacbs-", 1)},
+					Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
 				}
 
 				_, err = f.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -15,13 +15,13 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/build"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	klog "k8s.io/klog/v2"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -99,27 +99,41 @@ var _ = framework.BuildSuiteDescribe("Build Service E2E tests", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			DeferCleanup(f.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace)
 
-			customBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, appStudioE2EApplicationsNamespace)
-			if err != nil {
-				if errors.IsNotFound(err) {
-					klog.Infof("configmap with custom pipeline bundle not found in %s namespace\n", appStudioE2EApplicationsNamespace)
+			for _, comp := range createdComponents { //multiple urls
+				componentName = fmt.Sprintf("%s-%s", comp.Name, util.GenerateRandomString(10))
+				outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+				timeout = time.Second * 60
+				interval = time.Second * 1
+				// Create a component with Git Source URL being defined
+				component, err = f.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, defaultGitSourceURL, "", outputContainerImage, "")
+				Expect(err).ShouldNot(HaveOccurred())
+				DeferCleanup(f.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace)
+
+				customBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, appStudioE2EApplicationsNamespace)
+				if err != nil {
+					if errors.IsNotFound(err) {
+						klog.Infof("configmap with custom pipeline bundle not found in %s namespace\n", appStudioE2EApplicationsNamespace)
+					} else {
+						Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, appStudioE2EApplicationsNamespace, err))
+					}
 				} else {
-					Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, appStudioE2EApplicationsNamespace, err))
+					customBundleRef = customBundleConfigMap.Data["default_build_bundle"]
 				}
-			} else {
-				customBundleRef = customBundleConfigMap.Data["default_build_bundle"]
+
+				defaultBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
+				if err != nil {
+					if errors.IsForbidden(err) {
+						klog.Infof("don't have enough permissions to get a configmap with default pipeline in %s namespace\n", constants.BuildPipelinesConfigMapDefaultNamespace)
+					} else {
+						Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace, err))
+					}
+				} else {
+					defaultBundleRef = defaultBundleConfigMap.Data["default_build_bundle"]
+				}
+				createdComponents = append(createdComponents, component) //collected created components
 			}
 
-			defaultBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
-			if err != nil {
-				if errors.IsForbidden(err) {
-					klog.Infof("don't have enough permissions to get a configmap with default pipeline in %s namespace\n", constants.BuildPipelinesConfigMapDefaultNamespace)
-				} else {
-					Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace, err))
-				}
-			} else {
-				defaultBundleRef = defaultBundleConfigMap.Data["default_build_bundle"]
-			}
+			Expect(createdComponents).ShouldNot(BeEmpty())
 
 		})
 		It("triggers a PipelineRun", Label("build-templates-e2e"), func() {
@@ -140,15 +154,14 @@ var _ = framework.BuildSuiteDescribe("Build Service E2E tests", func() {
 			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(customBundleRef))
-		})
+					pipelineRun, err := f.HasController.GetComponentPipeline(comp.Name, applicationName, appStudioE2EApplicationsNamespace)
+					if err != nil {
+						klog.Infoln("PipelineRun has not been created yet")
+						return false
+					}
+					return pipelineRun.HasStarted()
+				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the %s PipelineRun to start", comp.Name)
 
-		It("should reference the default pipeline bundle in a PipelineRun", func() {
-			if customBundleRef != "" {
-				Skip("skipping - custom pipeline bundle bundle (that overrides the default one) is defined")
-			}
-			if defaultBundleRef == "" {
-				Skip("skipping - default pipeline bundle cannot be fetched")
 			}
 			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -165,15 +178,39 @@ var _ = framework.BuildSuiteDescribe("Build Service E2E tests", func() {
 					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false)
 					Expect(err).ShouldNot(HaveOccurred())
 
-					for _, condition := range pipelineRun.Status.Conditions {
-						klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+			It("should reference the default pipeline bundle in a PipelineRun", func() {
+				if customBundleRef != "" {
+					Skip("skipping - custom pipeline bundle bundle (that overrides the default one) is defined")
+				}
+				if defaultBundleRef == "" {
+					Skip("skipping - default pipeline bundle cannot be fetched")
+				}
+				pipelineRun, err := f.HasController.GetComponentPipeline(comp.Name, applicationName, appStudioE2EApplicationsNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(defaultBundleRef))
+			})
 
-						if condition.Reason == "Failed" {
-							Fail(fmt.Sprintf("Pipelinerun %s has failed", pipelineRun.Name))
+			When("the PipelineRun has started", func() {
+				BeforeAll(func() {
+					timeout = time.Second * 600
+					interval = time.Second * 10
+				})
+				It("should eventually finish successfully", func() {
+					Eventually(func() bool {
+						pipelineRun, err := f.HasController.GetComponentPipeline(comp.Name, applicationName, appStudioE2EApplicationsNamespace)
+						Expect(err).ShouldNot(HaveOccurred())
+
+						for _, condition := range pipelineRun.Status.Conditions {
+							klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+
+							if condition.Reason == "Failed" {
+								Fail(fmt.Sprintf("Pipelinerun %s has failed", pipelineRun.Name))
+							}
 						}
-					}
-					return pipelineRun.IsDone()
-				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to finish")
+						return pipelineRun.IsDone()
+					}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to finish")
+				})
+
 			})
 		})
 

--- a/tests/build/const.go
+++ b/tests/build/const.go
@@ -1,5 +1,5 @@
 package build
 
 const (
-	ENV_URL_KEY string = "COMPONENT_REPO_URLS"
+	COMPONENT_REPO_URLS_ENV string = "COMPONENT_REPO_URLS"
 )

--- a/tests/build/const.go
+++ b/tests/build/const.go
@@ -1,0 +1,5 @@
+package build
+
+const (
+	ENV_URL_KEY string = "COMPONENT_REPO_URLS"
+)


### PR DESCRIPTION
# Description

Allow specifying multiple component URLs to build

This PR also contains changes that allow build-service tests to run in parallel. There is a plan to run other tests in parallel too in a future - see [this doc](https://docs.google.com/document/d/1Nxy08I9AikLRADfFM4Slmmf_paSZjuocg0ECiOBOEz8/edit#heading=h.w4snan7yrscx) for more details

This PR also introduces testing of build using the HACBS pipeline (instead of base-appstudio one) in one test case.
This test case (labeled as build-templates-e2e) is then used in PR test in [build-definitions repo](https://github.com/redhat-appstudio/build-definitions/pull/156)

## Issue ticket number and link

https://issues.redhat.com/browse/PLNSRVCE-180

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```bash
export COMPONENT_REPO_URLS=https://github.com/redhat-appstudio-qe/devfile-sample-hello-world,https://github.com/devfile-samples/devfile-sample-python-basic
# "-p" flag allows running build-service tests in parallel
ginkgo -p --progress --focus="build-service" ./cmd -- --config-suites=/Users/psturc/work/redhat-appstudio/e2e-tests/tests/e2e-demos/config/default.yaml
```
# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
