### PR TITLE
test: add has application delete test

### DIFF
--- a/pkg/utils/has/controller.go
+++ b/pkg/utils/has/controller.go
@@ -140,7 +140,7 @@ func (h *SuiteController) CreateComponent(applicationName, componentName, namesp
 }
 
 // CreateComponentFromCDQ create a HAS Component resource from a Completed CDQ resource, which includes a stub Component CR
-func (h *SuiteController) CreateComponentFromStub(compDetected appservice.ComponentDetectionDescription, componentName, namespace, secret string) (*appservice.Component, error) {
+func (h *SuiteController) CreateComponentFromStub(compDetected appservice.ComponentDetectionDescription, componentName, namespace, secret, applicationName string) (*appservice.Component, error) {
 	// The Component from the CDQ is only a template, and needs things like name filled in
 	component := &appservice.Component{
 		ObjectMeta: metav1.ObjectMeta{
@@ -150,6 +150,7 @@ func (h *SuiteController) CreateComponentFromStub(compDetected appservice.Compon
 		Spec: compDetected.ComponentStub,
 	}
 	component.Spec.Secret = secret
+	component.Spec.Application = applicationName
 	err := h.KubeRest().Create(context.TODO(), component)
 	if err != nil {
 		return nil, err

--- a/tests/has/devfile_private_source.go
+++ b/tests/has/devfile_private_source.go
@@ -143,7 +143,7 @@ var _ = framework.HASSuiteDescribe("private devfile source", func() {
 	})
 
 	It("Create Red Hat AppStudio Quarkus component", func() {
-		component, err := framework.HasController.CreateComponentFromStub(compDetected, componentName, AppStudioE2EApplicationsNamespace, SPIAccessTokenSecretName)
+		component, err := framework.HasController.CreateComponentFromStub(compDetected, componentName, AppStudioE2EApplicationsNamespace, SPIAccessTokenSecretName, applicationName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(component.Name).To(Equal(componentName))
 	})

--- a/tests/has/devfile_source.go
+++ b/tests/has/devfile_source.go
@@ -134,7 +134,7 @@ var _ = framework.HASSuiteDescribe("devfile source", func() {
 		Expect(component.Name).To(Equal(componentName))
 	})
 
-	It("Check a Component gets deleted when its Application is deleted", func() {
+	It("Check a Component gets deleted when its application is deleted", func() {
 		err = framework.HasController.DeleteHasApplication(applicationName, AppStudioE2EApplicationsNamespace)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(func() bool {

--- a/tests/has/devfile_source.go
+++ b/tests/has/devfile_source.go
@@ -134,8 +134,7 @@ var _ = framework.HASSuiteDescribe("devfile source", func() {
 		Expect(component.Name).To(Equal(componentName))
 	})
 
-	It("Check a Component gets deleted when its application is deleted", func() {
-
+	It("Check a Component gets deleted when its Application is deleted", func() {
 		err = framework.HasController.DeleteHasApplication(applicationName, AppStudioE2EApplicationsNamespace)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(func() bool {
@@ -145,7 +144,7 @@ var _ = framework.HASSuiteDescribe("devfile source", func() {
 			}
 
 			return false
-		}, 2*time.Minute, 10*time.Second).Should(BeTrue(), "Component didn't get get deleted with its Application")
+		}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "Component didn't get get deleted with its Application")
 		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
# Description

This PR adds a test to verify that when the Application CR is deleted before the Component CR, the associated Component CRs should all be deleted. 
It also fixes a bug: when creating a component using CreateComponentFromStub the Application name was not set, failing to set the owner references properly.

## Issue ticket number and link

https://issues.redhat.com/browse/DEVHAS-58

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
