### PR TITLE
fix: Linter go version issues

### DIFF
--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -9,6 +9,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup Golang
         uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:


### PR DESCRIPTION
# Description

fixing issues caused by golangci-lint and goversion mismatch
