### PR TITLE
fix: test-container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,5 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 WORKDIR /root/
 COPY --from=builder /github.com/redhat-appstudio/e2e-tests/bin/e2e-appstudio ./
+COPY --from=builder /github.com/redhat-appstudio/e2e-tests/tests ./tests
 ENTRYPOINT ["/root/e2e-appstudio"]


### PR DESCRIPTION
# Description

fix the error that's encountered when running e2e tests as a pod in openshift:

```
[SynchronizedBeforeSuite] [FAILED] [0.000 seconds]
[SynchronizedBeforeSuite]
/github.com/redhat-appstudio/e2e-tests/cmd/e2e_test.go:27

  Begin Captured GinkgoWriter Output >>
    [SynchronizedBeforeSuite] TOP-LEVEL
      /github.com/redhat-appstudio/e2e-tests/cmd/e2e_test.go:27
  << End Captured GinkgoWriter Output

  Unexpected error:
      <*fs.PathError | 0xc0009f6b10>: {
          Op: "open",
          Path: "/root/tests/e2e-demos/config/default.yaml",
          Err: <syscall.Errno>0x2,
      }
      open /root/tests/e2e-demos/config/default.yaml: no such file or directory
  occurred
  In [SynchronizedBeforeSuite] at: /github.com/redhat-appstudio/e2e-tests/tests/e2e-demos/e2e-demo.go:43
```

tests are failing in [this PR](https://github.com/redhat-appstudio/build-definitions/pull/148)

## Issue ticket number and link
N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```bash
make build-container
docker run -v ~/.kube/config:/config -e KUBECONFIG=/config quay.io/redhat-appstudio/e2e-tests:next --ginkgo.focus=cluster-registration-suite --ginkgo.progress --ginkgo.v
```

# Checklist:

- [x] I have performed a self-review of my code
