### PR TITLE
[DRAFT] fix: Adjust the test so it can handle 202 or 204 responses from SPI token upload service

### DIFF
--- a/tests/has/devfile_private_source.go
+++ b/tests/has/devfile_private_source.go
@@ -199,7 +199,7 @@ func createAndInjectTokenToSPI(framework *framework.Framework, token, repoURL, s
 		client := &http.Client{}
 		resp, err := client.Do(req)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resp.StatusCode).Should(Equal(204))
+		Expect(resp.StatusCode).Should(Or(Equal(http.StatusAccepted), Equal(http.StatusNoContent)))
 		defer resp.Body.Close()
 
 		// Check to see if the token was successfully injected


### PR DESCRIPTION

# Description
Adjust the test so it can handle 202 or 204 responses from SPI token upload service

## Issue ticket number and link

https://github.com/redhat-appstudio/service-provider-integration-oauth/pull/103
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Run agains https://github.com/redhat-appstudio/infra-deployments/pull/475
# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
