### PR TITLE
fix: release: runtime error

### DIFF
--- a/pkg/utils/common/controller.go
+++ b/pkg/utils/common/controller.go
@@ -240,7 +240,7 @@ func (s *SuiteController) CreateRegistryAuthSecret(secretName, namespace, secret
 			Name:      secretName,
 			Namespace: namespace,
 		},
-		Type: "kubernetes.io/dockerconfigjson",
+		Type:       "kubernetes.io/dockerconfigjson",
 		StringData: map[string]string{".dockerconfigjson": string(rawDecodedText)},
 	}
 	er := s.KubeRest().Create(context.TODO(), secret)
@@ -262,10 +262,10 @@ func (s *SuiteController) DeleteNamespace(namespace string) error {
 }
 
 // CreateTestNamespace creates a namespace where Application and Component CR will be created
-func (h *SuiteController) CreateTestNamespace(name string) (*corev1.Namespace, error) {
+func (s *SuiteController) CreateTestNamespace(name string) (*corev1.Namespace, error) {
 
 	// Check if the E2E test namespace already exists
-	ns, err := h.KubeInterface().CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
+	ns, err := s.KubeInterface().CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
 
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
@@ -275,7 +275,7 @@ func (h *SuiteController) CreateTestNamespace(name string) (*corev1.Namespace, e
 					Name:   name,
 					Labels: map[string]string{constants.ArgoCDLabelKey: constants.ArgoCDLabelValue},
 				}}
-			ns, err = h.KubeInterface().CoreV1().Namespaces().Create(context.TODO(), &nsTemplate, metav1.CreateOptions{})
+			ns, err = s.KubeInterface().CoreV1().Namespaces().Create(context.TODO(), &nsTemplate, metav1.CreateOptions{})
 			if err != nil {
 				return nil, fmt.Errorf("error when creating %s namespace: %v", name, err)
 			}
@@ -289,11 +289,26 @@ func (h *SuiteController) CreateTestNamespace(name string) (*corev1.Namespace, e
 		}
 		// Update test namespace labels in case they are missing argoCD label
 		ns.Labels[constants.ArgoCDLabelKey] = constants.ArgoCDLabelValue
-		ns, err = h.KubeInterface().CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
+		ns, err = s.KubeInterface().CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("error when updating labels in '%s' namespace: %v", name, err)
 		}
 	}
 
+	// "pipeline" service account needs to be present in the namespace before we start with creating tekton resources
+	if err := s.WaitUntil(s.ServiceaccountPresent("pipeline", name), time.Second*30); err != nil {
+		return nil, err
+	}
+
 	return ns, nil
+}
+
+func (s *SuiteController) ServiceaccountPresent(saName, namespace string) wait.ConditionFunc {
+	return func() (bool, error) {
+		_, err := s.GetServiceAccount(saName, namespace)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	}
 }

--- a/tests/release/release-failures.go
+++ b/tests/release/release-failures.go
@@ -64,7 +64,7 @@ var _ = framework.ReleaseSuiteDescribe("test-release-service-failures", func() {
 				Eventually(func() bool {
 					release, err := framework.ReleaseController.GetRelease(releaseName, devNamespace)
 
-					if err != nil || release == nil {
+					if err != nil || release == nil || len(release.Status.Conditions) == 0 {
 						return false
 					}
 
@@ -77,7 +77,7 @@ var _ = framework.ReleaseSuiteDescribe("test-release-service-failures", func() {
 				Eventually(func() bool {
 					release, err := framework.ReleaseController.GetRelease(releaseName, devNamespace)
 
-					if err != nil || release == nil {
+					if err != nil || release == nil || len(release.Status.Conditions) == 0 {
 						return false
 					}
 


### PR DESCRIPTION
# Description

* Fix runtime error occurring when the `release.Status.Condition` field is not populated with any items yet, e.g. [in this test run](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/redhat-appstudio_infra-deployments/466/pull-ci-redhat-appstudio-infra-deployments-main-appstudio-e2e-deployment/1542492678392909824)
* add a check for validating that "pipeline" service account is present in the test namespace before proceeding with test
## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested against quicklab cluster

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
