### PR TITLE
feat: PLNSRVCE-452: add initial e2e test for jvm-build-service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/openshift/oc v0.0.0-alpha.0.0.20220614012638-35c7eeb5274e
 	github.com/redhat-appstudio/application-service v0.0.0-20220509201208-86571e38f52e
 	github.com/redhat-appstudio/integration-service v0.0.0-20220622135319-863425d2cad2
+	github.com/redhat-appstudio/jvm-build-service v0.0.0-20220714212008-d1b637f56c4d
 	github.com/redhat-appstudio/managed-gitops/backend v0.0.0-20220506042230-3a79f373a001
 	github.com/redhat-appstudio/release-service v0.0.0-20220620143459-53c2f4bcc510
 	github.com/redhat-appstudio/service-provider-integration-operator v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -2019,7 +2019,8 @@ github.com/redhat-appstudio/application-service v0.0.0-20220509201208-86571e38f5
 github.com/redhat-appstudio/application-service v0.0.0-20220509201208-86571e38f52e/go.mod h1:QzlBejIgkmnzM/tiKzJKK86IXil/6j8KxmxaDInqtmU=
 github.com/redhat-appstudio/integration-service v0.0.0-20220622135319-863425d2cad2 h1:wVpENUra8XAN2UgR09KLjyejoiHcd20P79gVx2wdIuE=
 github.com/redhat-appstudio/integration-service v0.0.0-20220622135319-863425d2cad2/go.mod h1:FNCuALWZDRMbMKm3Vb/5E2R8ei6eFwcEhgYcFKRVZJU=
-
+github.com/redhat-appstudio/jvm-build-service v0.0.0-20220714212008-d1b637f56c4d h1:uDKH0bbGjQaoiTxVv2ThIfNH84IOXxwDsoWDLxlOr34=
+github.com/redhat-appstudio/jvm-build-service v0.0.0-20220714212008-d1b637f56c4d/go.mod h1:wmAb5bQZcUO0v0eUvJGRhggTytV1ktTHCrsx8Vqwk/E=
 github.com/redhat-appstudio/managed-gitops/appstudio-shared v0.0.0-20220623041404-010a781bb3fb h1:w0yj4jUZotnRVa3TFmaNBQj2pgZmgUOvSjinQrC2wxk=
 github.com/redhat-appstudio/managed-gitops/appstudio-shared v0.0.0-20220623041404-010a781bb3fb/go.mod h1:zI6l6177ZbAu4MNovCWinVq3Ii3qpD9svV7t9a58b/s=
 github.com/redhat-appstudio/managed-gitops/backend v0.0.0-20220506042230-3a79f373a001 h1:dHYSaZ8slDW27YrbAYj59Zd82Oml3oTj9ieICLtzk8Y=

--- a/pkg/apis/kubernetes/client.go
+++ b/pkg/apis/kubernetes/client.go
@@ -6,8 +6,11 @@ import (
 	gitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend/apis/managed-gitops/v1alpha1"
 
-	release "github.com/redhat-appstudio/release-service/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	integrationservice "github.com/redhat-appstudio/integration-service/api/v1alpha1"
+	jvmbuildservice "github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
+	jvmbuildserviceclientset "github.com/redhat-appstudio/jvm-build-service/pkg/client/clientset/versioned"
+	release "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	spi "github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipelineclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -16,7 +19,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
@@ -24,6 +26,7 @@ type K8sClient struct {
 	kubeClient     *kubernetes.Clientset
 	crClient       crclient.Client
 	pipelineClient pipelineclientset.Interface
+	jvmbuildserviceClient jvmbuildserviceclientset.Interface
 }
 
 var (
@@ -41,6 +44,7 @@ func init() {
 	utilruntime.Must(release.AddToScheme(scheme))
 	utilruntime.Must(gitopsv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(integrationservice.AddToScheme(scheme))
+	utilruntime.Must(jvmbuildservice.AddToScheme(scheme))
 }
 
 // Kube returns the clientset for Kubernetes upstream.
@@ -55,6 +59,10 @@ func (c *K8sClient) KubeRest() crclient.Client {
 
 func (c *K8sClient) PipelineClient() pipelineclientset.Interface {
 	return c.pipelineClient
+}
+
+func (c *K8sClient) JvmbuildserviceClient() jvmbuildserviceclientset.Interface {
+	return c.jvmbuildserviceClient
 }
 
 // NewHASClient creates kubernetes client wrapper
@@ -81,9 +89,15 @@ func NewK8SClient() (*K8sClient, error) {
 		return nil, err
 	}
 
+	jvmbildserviceClient, err := jvmbuildserviceclientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	return &K8sClient{
 		kubeClient:     client,
 		crClient:       crClient,
 		pipelineClient: pipelineClient,
+		jvmbuildserviceClient: jvmbildserviceClient,
 	}, nil
 }

--- a/pkg/framework/describe.go
+++ b/pkg/framework/describe.go
@@ -27,6 +27,10 @@ func BuildSuiteDescribe(text string, body func()) bool {
 	return Describe("[build-service-suite "+text+"]", body)
 }
 
+func JVMBuildSuiteDescribe(text string, body func()) bool {
+	return Describe("[jvm-build-service-suite "+text+"]", Ordered, body)
+}
+
 func ClusterRegistrationSuiteDescribe(text string, body func()) bool {
 	return Describe("[cluster-registration-suite "+text+"]", Ordered, body)
 }
@@ -38,4 +42,3 @@ func ReleaseSuiteDescribe(text string, body func()) bool {
 func IntegrationServiceSuiteDescribe(text string, body func()) bool {
 	return Describe("[integration-service-suite "+text+"]", Ordered, body)
 }
-

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -7,8 +7,9 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/common"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/gitops"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/has"
-	"github.com/redhat-appstudio/e2e-tests/pkg/utils/release"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/integration"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils/jvmbuildservice"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils/release"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/spi"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
 )
@@ -22,6 +23,7 @@ type Framework struct {
 	SPIController     *spi.SuiteController
 	ReleaseController *release.SuiteController
 	IntegrationController *integration.SuiteController
+	JvmbuildserviceController *jvmbuildservice.SuiteController
 }
 
 // Initialize all test controllers and return them in a Framework
@@ -75,6 +77,11 @@ func NewFramework() (*Framework, error) {
 		return nil, err
 	}
 
+	jvmbuildserviceController, err := jvmbuildservice.NewSuiteControler(kubeClient)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Framework{
 		CommonController:  commonCtrl,
 		HasController:     hasController,
@@ -83,5 +90,6 @@ func NewFramework() (*Framework, error) {
 		SPIController:     spiController,
 		ReleaseController: releaseController,
 		IntegrationController: integrationController,
+		JvmbuildserviceController: jvmbuildserviceController,
 	}, nil
 }

--- a/pkg/utils/jvmbuildservice/controller.go
+++ b/pkg/utils/jvmbuildservice/controller.go
@@ -1,0 +1,36 @@
+package jvmbuildservice
+
+import (
+	"context"
+
+	kubeCl "github.com/redhat-appstudio/e2e-tests/pkg/apis/kubernetes"
+	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type SuiteController struct {
+	*kubeCl.K8sClient
+}
+
+func NewSuiteControler(kube *kubeCl.K8sClient) (*SuiteController, error) {
+	return &SuiteController{
+		kube,
+	}, nil
+}
+
+func (s *SuiteController) ListArtifactBuilds(namespace string) (*v1alpha1.ArtifactBuildList, error) {
+	return s.JvmbuildserviceClient().JvmbuildserviceV1alpha1().ArtifactBuilds(namespace).List(context.TODO(), metav1.ListOptions{})
+}
+
+func (s *SuiteController) DeleteArtifactBuild(name, namespace string) error {
+	return s.JvmbuildserviceClient().JvmbuildserviceV1alpha1().ArtifactBuilds(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+}
+
+func (s *SuiteController) ListDependencyBuilds(namespace string) (*v1alpha1.DependencyBuildList, error) {
+	return s.JvmbuildserviceClient().JvmbuildserviceV1alpha1().DependencyBuilds(namespace).List(context.TODO(), metav1.ListOptions{})
+}
+
+func (s *SuiteController) DeleteDependencyBuild(name, namespace string) error {
+	return s.JvmbuildserviceClient().JvmbuildserviceV1alpha1().DependencyBuilds(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+}

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -1,0 +1,349 @@
+package build
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
+	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
+	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	klog "k8s.io/klog/v2"
+	"knative.dev/pkg/apis"
+)
+
+var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", func() {
+	defer GinkgoRecover()
+
+	var appStudioE2EApplicationsNamespace, prGeneratedName string
+	var timeout, interval time.Duration
+
+	var streamTektonYaml = func(url string) []byte {
+		resp, err := http.Get(url)
+		Expect(err).NotTo(HaveOccurred(), "error getting %s", url)
+		defer resp.Body.Close()
+		bytes, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred(), "error getting bytes")
+		return bytes
+	}
+
+	f, err := framework.NewFramework()
+	Expect(err).NotTo(HaveOccurred())
+
+	// got panics in DeferCleanup when I tried to do multi param invocations, so following the pattern we used in openshift/origin
+	AfterAll(func() {
+		if CurrentSpecReport().Failed() {
+			logs, err := f.TektonController.GetPipelineRunLogs(prGeneratedName, appStudioE2EApplicationsNamespace)
+			if err != nil {
+				klog.Infof("got error fetching PR logs: %s", err.Error())
+			}
+			klog.Infof("failed PR logs: %s", logs)
+			trList, err := f.TektonController.ListAllTaskRuns(appStudioE2EApplicationsNamespace)
+			if err != nil {
+				klog.Infof("got error fetching TR list: %s", err.Error())
+			}
+			for _, tr := range trList.Items {
+				trLog, err := f.TektonController.GetTaskRunLogs(tr.Name, tr.Namespace)
+				if err != nil {
+					klog.Infof("got error fetcing TR logs for %s: %s", tr.Name, err.Error())
+				}
+				klog.Infof("task run log for %s: %s", tr.Name, trLog)
+			}
+		}
+		abList, err := f.JvmbuildserviceController.ListArtifactBuilds(appStudioE2EApplicationsNamespace)
+		if err != nil {
+			klog.Infof("got error fetching artifactbuilds: %s", err.Error())
+		}
+		for _, ab := range abList.Items {
+			err := f.JvmbuildserviceController.DeleteArtifactBuild(ab.Name, ab.Namespace)
+			if err != nil {
+				klog.Infof("got error deleting AB %s: %s", ab.Name, err.Error())
+			}
+		}
+		dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(appStudioE2EApplicationsNamespace)
+		if err != nil {
+			klog.Infof("got error fetching dependencybuilds: %s", err.Error())
+		}
+		for _, db := range dbList.Items {
+			err := f.JvmbuildserviceController.DeleteDependencyBuild(db.Name, db.Namespace)
+			if err != nil {
+				klog.Infof("got error deleting DB %s: %s", db.Name, err.Error())
+			}
+		}
+		err = f.TektonController.DeletePipelineRun(prGeneratedName, appStudioE2EApplicationsNamespace)
+		if err != nil {
+			klog.Infof("error deleting pr %s: %s", prGeneratedName, err.Error())
+		}
+		err = f.TektonController.DeletePipeline("sample-component-build", appStudioE2EApplicationsNamespace)
+		if err != nil {
+			klog.Infof("error deleting pipeline sample-component-build: %s", err.Error())
+		}
+		err = f.TektonController.DeleteTask("maven", appStudioE2EApplicationsNamespace)
+		if err != nil {
+			klog.Infof("error deleting task maven: %s", err.Error())
+		}
+		err = f.TektonController.DeleteTask("git-clone", appStudioE2EApplicationsNamespace)
+		if err != nil {
+			klog.Infof("error deleting task git-clone", err.Error())
+		}
+		trList, err := f.TektonController.ListAllTaskRuns(appStudioE2EApplicationsNamespace)
+		if err != nil {
+			klog.Infof("got error fetching TR list: %s", err.Error())
+		}
+		for _, tr := range trList.Items {
+			err := f.TektonController.DeleteTaskRun(tr.Name, tr.Namespace)
+			if err != nil {
+				klog.Infof("got error deleting TR %s: %s", tr.Name, err.Error())
+			}
+		}
+	})
+
+	BeforeAll(func() {
+		appStudioE2EApplicationsNamespace = utils.GetEnv(constants.E2E_APPLICATIONS_NAMESPACE_ENV, "appstudio-e2e-test")
+
+		klog.Infof("Test namespace: %s", appStudioE2EApplicationsNamespace)
+
+		_, err := f.CommonController.CreateTestNamespace(appStudioE2EApplicationsNamespace)
+		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", appStudioE2EApplicationsNamespace, err)
+
+		timeout = time.Minute * 10
+		interval = time.Minute * 1
+
+		decodingScheme := runtime.NewScheme()
+		utilruntime.Must(v1beta1.AddToScheme(decodingScheme))
+		decoderCodecFactory := serializer.NewCodecFactory(decodingScheme)
+		decoder := decoderCodecFactory.UniversalDecoder(v1beta1.SchemeGroupVersion)
+
+		gitCloneTaskBytes := streamTektonYaml("https://raw.githubusercontent.com/redhat-appstudio/build-definitions/main/tasks/git-clone.yaml")
+		gitClone := &v1beta1.Task{}
+		err = runtime.DecodeInto(decoder, gitCloneTaskBytes, gitClone)
+		Expect(err).NotTo(HaveOccurred(), "error converting git clone yaml to task obj")
+		err = f.TektonController.DeleteTask(gitClone.Name, appStudioE2EApplicationsNamespace)
+		if err != nil && !errors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred(), "error deleting git-clone task")
+		}
+		_, err = f.TektonController.CreateTask(gitClone, appStudioE2EApplicationsNamespace)
+		Expect(err).NotTo(HaveOccurred(), "error creating git clone task")
+
+		mavenLocation := "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/deploy/base/maven-v0.2.yaml"
+		prOwner := os.Getenv("JVM_BUILD_SERVICE_PR_OWNER")
+		prCommit := os.Getenv("JVM_BUILD_SERVICE_PR_SHA")
+		if len(prOwner) > 0 && len(prCommit) > 0 {
+			mavenLocation = fmt.Sprintf("https://raw.githubusercontent.com/%s/jvm-build-service/%s/deploy/base/maven-v0.2.yaml", prOwner, prCommit)
+		}
+		klog.Infof("fetching maven def from %s", mavenLocation)
+		mavenData := streamTektonYaml(mavenLocation)
+		maven := &v1beta1.Task{}
+		err = runtime.DecodeInto(decoder, mavenData, maven)
+		Expect(err).NotTo(HaveOccurred(), "error creating maven task")
+		// override images if needed
+		analyserImage := os.Getenv("JVM_BUILD_SERVICE_ANALYZER_IMAGE")
+		if len(analyserImage) > 0 {
+			klog.Infof("PR analyzer image: %s", analyserImage)
+			for _, step := range maven.Spec.Steps {
+				if step.Name != "analyse-dependencies" {
+					continue
+				}
+				klog.Infof("Updating analyse-dependencies step with image %s", analyserImage)
+				step.Image = analyserImage
+			}
+		}
+		sidecarImage := os.Getenv("JVM_BUILD_SERVICE_SIDECAR_IMAGE")
+		if len(sidecarImage) > 0 {
+			klog.Infof("PR sidecar image: %s", sidecarImage)
+			for _, sidecar := range maven.Spec.Sidecars {
+				if sidecar.Name != "proxy" {
+					continue
+				}
+				klog.Infof("Updating proxy sidecar with image %s", sidecarImage)
+				sidecar.Image = sidecarImage
+			}
+		}
+
+		err = f.TektonController.DeleteTask("maven", appStudioE2EApplicationsNamespace)
+		if err != nil && !errors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred(), "error cleaning up maven task before create")
+		}
+		_, err = f.TektonController.CreateTask(maven, appStudioE2EApplicationsNamespace)
+		Expect(err).NotTo(HaveOccurred(), "error creating maven task")
+
+		pipelineLocation := "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/hack/examples/pipeline.yaml"
+		if len(prOwner) > 0 && len(prCommit) > 0 {
+			pipelineLocation = fmt.Sprintf("https://raw.githubusercontent.com/%s/jvm-build-service/%s/hack/examples/pipeline.yaml", prOwner, prCommit)
+		}
+		klog.Infof("fetching pipeline def from %s", pipelineLocation)
+		pipelineData := streamTektonYaml(pipelineLocation)
+		pipeline := &v1beta1.Pipeline{}
+		err = runtime.DecodeInto(decoder, pipelineData, pipeline)
+		Expect(err).NotTo(HaveOccurred(), "error decoding pipeline")
+
+		err = f.TektonController.DeletePipeline(pipeline.Name, appStudioE2EApplicationsNamespace)
+		if err != nil && !errors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred(), "error cleaning up build pipeline before create")
+		}
+		_, err = f.TektonController.CreatePipeline(pipeline, appStudioE2EApplicationsNamespace)
+		Expect(err).NotTo(HaveOccurred(), "error creating build pipeline")
+
+		runLocation := "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/hack/examples/run.yaml"
+		if len(prOwner) > 0 && len(prCommit) > 0 {
+			runLocation = fmt.Sprintf("https://raw.githubusercontent.com/%s/jvm-build-service/%s/hack/examples/run.yaml", prOwner, prCommit)
+		}
+		klog.Infof("fetching pipelinerun def from %s", runLocation)
+		runData := streamTektonYaml(runLocation)
+		run := &v1beta1.PipelineRun{}
+		err = runtime.DecodeInto(decoder, runData, run)
+		Expect(err).NotTo(HaveOccurred(), "error decoding build pipelinerun")
+
+		// since we use generated name no need to cleanup before create
+		run, err = f.TektonController.CreatePipelineRun(run, appStudioE2EApplicationsNamespace)
+		Expect(err).NotTo(HaveOccurred(), "error creating build pipelinerun")
+		prGeneratedName = run.Name
+
+		klog.Infof("Generated pipeline run %s", prGeneratedName)
+	})
+
+	When("pipelinerun with the appropriate jvm-build-service repository analysis are launched", func() {
+
+		It("those pipeline runs complete successfully", func() {
+			Eventually(func() bool {
+				pr, err := f.TektonController.GetPipelineRun(prGeneratedName, appStudioE2EApplicationsNamespace)
+				if err != nil {
+					klog.Infof("get of pr %s returned error: %s", prGeneratedName, err.Error())
+					return false
+				}
+				if !pr.IsDone() {
+					klog.Infof("pipeline run %s not done", pr.Name)
+					return false
+				}
+				prLogs, err := f.TektonController.GetPipelineRunLogs(pr.Name, pr.Namespace)
+				if err != nil {
+					klog.Infof("only partial logs at best for pipeline run %s: err: %s logs: %s", pr.Name, err.Error(), prLogs)
+				} else {
+					klog.Infof("pipeline run logs for %s: %s", pr.Name, prLogs)
+				}
+				if !pr.GetStatusCondition().GetCondition(apis.ConditionSucceeded).IsTrue() {
+					// just because the condition succeeded is not set does not mean it won't be soon
+					prBytes, err := json.MarshalIndent(pr, "", "  ")
+					if err != nil {
+						klog.Infof("problem marshalling failed pipelinerun to bytes: %s", err.Error())
+						return false
+					}
+					klog.Infof("not yet successful pipeline run: %s", string(prBytes))
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the pipeline run to complete")
+		})
+
+		It("that artifactbuilds and dependencybuilds are generated", func() {
+			Eventually(func() bool {
+				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(appStudioE2EApplicationsNamespace)
+				if err != nil {
+					klog.Infof("error listing artifactbuilds: %s", err.Error())
+					return false
+				}
+				gotABs := false
+				if len(abList.Items) > 0 {
+					gotABs = true
+				}
+				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(appStudioE2EApplicationsNamespace)
+				if err != nil {
+					klog.Infof("error listing dependencybuilds: %s", err.Error())
+					return false
+				}
+				gotDBs := false
+				if len(dbList.Items) > 0 {
+					gotDBs = true
+				}
+				if gotABs && gotDBs {
+					return true
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the generation of artifactbuilds and dependencybuilds")
+		})
+
+		It("that pipelinerun generates task runs related to artifactbuilds and dependencybuilds", func() {
+			Eventually(func() bool {
+				// as the values of the jvm build service labels are volatile, we'll just fetch all of them
+				// and validate label keys
+				taskRuns, err := f.TektonController.ListAllTaskRuns(appStudioE2EApplicationsNamespace)
+				if err != nil {
+					klog.Infof("list on label taskruns returned error: %s", err.Error())
+					return false
+				}
+				if len(taskRuns.Items) == 0 {
+					klog.Infof("list 0 length")
+					return false
+				}
+				foundGenericLabel := false
+				foundABRLabel := false
+				foundDBLabel := false
+				for _, taskRun := range taskRuns.Items {
+					klog.Infof("taskrun %s has label map of len %d", taskRun.Name, len(taskRun.Labels))
+					for k := range taskRun.Labels {
+						klog.Infof("taskrun %s has label %s", taskRun.Name, k)
+						if k == "jvmbuildservice.io/taskrun" {
+							foundGenericLabel = true
+						}
+						if k == "jvmbuildservice.io/abr-id" {
+							foundABRLabel = true
+						}
+						if k == "jvmbuildservice.io/dependencybuild-id" {
+							foundDBLabel = true
+						}
+						if foundGenericLabel && foundABRLabel && foundDBLabel {
+							return true
+						}
+					}
+				}
+
+				return false
+			}, timeout, interval).Should(BeTrue(), "timed out waiting for artifactbuild/dependencybuild tekton objexts")
+		})
+		It("that some artifactbuilds and dependencybuilds complete", func() {
+			Eventually(func() bool {
+				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(appStudioE2EApplicationsNamespace)
+				if err != nil {
+					klog.Infof("error listing artifactbuilds: %s", err.Error())
+					return false
+				}
+				abComplete := false
+				for _, ab := range abList.Items {
+					if ab.Status.State == v1alpha1.ArtifactBuildStateComplete {
+						abComplete = true
+						break
+					}
+				}
+				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(appStudioE2EApplicationsNamespace)
+				if err != nil {
+					klog.Infof("error listing dependencybuilds: %s", err.Error())
+					return false
+				}
+				dbComplete := false
+				for _, db := range dbList.Items {
+					if db.Status.State == v1alpha1.DependencyBuildStateComplete {
+						dbComplete = true
+						break
+					}
+				}
+				if abComplete && dbComplete {
+					return true
+				}
+				return false
+			}, 2*timeout, interval).Should(BeTrue(), "timed out waiting for some artifactbuilds/dependencybuilds to complete")
+		})
+	})
+})


### PR DESCRIPTION
# Description

Adding a new suite for testing https://github.com/redhat-appstudio/jvm-build-service PR's via the openshift/release induced e2e test flow.

Certainly we'll augment this as jvm-build-service matures (including a component induced flow, gradle based builds, multi-versions, etc etc etc).  I did not initially add a run with the service registry, but that is certainly a desired target.  And lastly, once we have some meets min verification up, I envision further introspection of the artifactbuild and dependencybuild taskruns.

An added step I chose not to take on with this initial introduction PR is add a `SuiteController` that can examine the jvm-build-service `ArtifactBuild` and `DependencyBuild` CRD instances and their various states.  A subsequent story/goal I suspect.

@psturc @stuartwdouglas @brunoapimentel @dwalluck @phillip-kruger FYI / PTAL

## Issue ticket number and link

https://issues.redhat.com/browse/PLNSRVCE-452

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [/ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Local test run:

```
gmontero ~/go/src/github.com/redhat-appstudio/e2e-tests  (add-initial-jvm-bld-srvc-test)$ ./bin/e2e-appstudio --ginkgo.progress --ginkgo.focus="JVM Build Service"
I0715 11:17:29.619371  382529 e2e_test.go:43] Starting Red Hat App Studio e2e tests...
I0715 11:17:31.435612  382529 request.go:601] Waited for 1.048973233s due to client-side throttling, not priority and fairness, request: GET:https://api.gmontero410.devcluster.openshift.com:6443/apis/policy/v1beta1?timeout=32s
I0715 11:17:41.482106  382529 request.go:601] Waited for 1.049420156s due to client-side throttling, not priority and fairness, request: GET:https://api.gmontero410.devcluster.openshift.com:6443/apis/apiextensions.k8s.io/v1?timeout=32s
I0715 11:17:43.615563  382529 e2e-demo.go:37] Starting e2e-demo test suites from config: /home/gmontero/go/src/github.com/redhat-appstudio/e2e-tests/tests/e2e-demos/config/default.yaml
I0715 11:17:51.514630  382529 request.go:601] Waited for 1.049946379s due to client-side throttling, not priority and fairness, request: GET:https://api.gmontero410.devcluster.openshift.com:6443/apis/quota.openshift.io/v1?timeout=32s
I0715 11:18:01.554595  382529 request.go:601] Waited for 1.049651853s due to client-side throttling, not priority and fairness, request: GET:https://api.gmontero410.devcluster.openshift.com:6443/apis/console.openshift.io/v1?timeout=32s
Running Suite: Red Hat App Studio E2E tests - /home/gmontero/go/src/github.com/redhat-appstudio/e2e-tests
=========================================================================================================
Random Seed: 1657898249

Will run 2 of 107 specs

....


Ran 2 of 107 Specs in 191.151 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 105 Skipped
PASS
gmontero ~/go/src/github.com/redhat-appstudio/e2e-tests  (add-initial-jvm-bld-srvc-test)$ 
```

# Checklist:

- [ /] I have performed a self-review of my code
- [ /] I have commented my code, particularly in hard-to-understand areas
- [ n/a ] I have made corresponding changes to the documentation
