### PR TITLE
fix: compare all conditions not just first

### DIFF
--- a/pkg/utils/has/controller.go
+++ b/pkg/utils/has/controller.go
@@ -338,13 +338,13 @@ func (h *SuiteController) DeleteAllApplicationsInASpecificNamespace(namespace st
 	return h.KubeRest().DeleteAllOf(context.TODO(), &appservice.Application{}, client.InNamespace(namespace))
 }
 
-func (h *SuiteController) GetHasComponentConditionStatusMessage(name, namespace string) (string, error) {
+func (h *SuiteController) GetHasComponentConditionStatusMessages(name, namespace string) (messages []string, err error) {
 	c, err := h.GetHasComponent(name, namespace)
 	if err != nil {
-		return "", fmt.Errorf("error getting HAS component: %v", err)
+		return messages, fmt.Errorf("error getting HAS component: %v", err)
 	}
-	if len(c.Status.Conditions) > 0 {
-		return c.Status.Conditions[0].Message, nil
+	for _, condition := range c.Status.Conditions {
+		messages = append(messages, condition.Message)
 	}
-	return "", nil
+	return
 }

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -600,34 +600,34 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", func() {
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected", utils.GetQuayIOOrganization())
 			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			Eventually(func() (string, error) {
-				return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
-			}, timeout).Should(ContainSubstring("create failed"), "timed out waiting for the component creation to fail")
+			Eventually(func() ([]string, error) {
+				return f.HasController.GetHasComponentConditionStatusMessages(componentName, testNamespace)
+			}, timeout).Should(ContainElement(ContainSubstring("create failed")))
 
 		})
 		It("should fail for ContainerImage field set to a protected repository followed by a random tag", func() {
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
 			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			Eventually(func() (string, error) {
-				return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
-			}, timeout).Should(ContainSubstring("create failed"), "timed out waiting for the component creation to fail")
+			Eventually(func() ([]string, error) {
+				return f.HasController.GetHasComponentConditionStatusMessages(componentName, testNamespace)
+			}, timeout).Should(ContainElement(ContainSubstring("create failed")))
 		})
 		It("should succeed for ContainerImage field set to a protected repository followed by a namespace prefix + dash + string", func() {
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected:%s-%s", utils.GetQuayIOOrganization(), testNamespace, strings.Replace(uuid.New().String(), "-", "", -1))
 			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			Eventually(func() (string, error) {
-				return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
-			}, timeout).Should(ContainSubstring("successfully created"), "timed out waiting for the component creation to succeed")
+			Eventually(func() ([]string, error) {
+				return f.HasController.GetHasComponentConditionStatusMessages(componentName, testNamespace)
+			}, timeout).Should(ContainElement(ContainSubstring("successfully created")))
 		})
 		It("should succeed for ContainerImage field set to a custom (unprotected) repository without a tag being specified", func() {
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images", utils.GetQuayIOOrganization())
 			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			Eventually(func() (string, error) {
-				return f.HasController.GetHasComponentConditionStatusMessage(componentName, testNamespace)
-			}, timeout).Should(ContainSubstring("successfully created"), "timed out waiting for the component creation to succeed")
+			Eventually(func() ([]string, error) {
+				return f.HasController.GetHasComponentConditionStatusMessages(componentName, testNamespace)
+			}, timeout).Should(ContainElement(ContainSubstring("successfully created")))
 		})
 
 	})


### PR DESCRIPTION
Look for expected message in all component conditions.

# Description

Current comparing mechanism is taking only first condition but conditions are created randomly, instead look for expected message in all conditions.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Not tested

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
