### PR TITLE
refactor: bundle image reference for pull requests

### DIFF
--- a/pkg/utils/tekton/controller.go
+++ b/pkg/utils/tekton/controller.go
@@ -3,6 +3,7 @@ package tekton
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -31,16 +32,8 @@ type KubeController struct {
 }
 
 type Bundles struct {
-	BuildTemplatesBundle            string
-	HACBSTemplatesBundle            string
-	HACBSCoreServiceTemplatesBundle string
-}
-
-// quay.io/redhat-appstudio/hacbs-core-service-templates-bundle is available only with the `latest` tag
-func coreServiceBundleName(defaultBuildBundle string) string {
-	parts := strings.SplitN(strings.Replace(defaultBuildBundle, "/build-", "/hacbs-core-service-", 1), ":", 2)
-
-	return parts[0] + ":latest"
+	BuildTemplatesBundle string
+	HACBSTemplatesBundle string
 }
 
 func newBundles(client kubernetes.Interface) (*Bundles, error) {
@@ -51,10 +44,11 @@ func newBundles(client kubernetes.Interface) (*Bundles, error) {
 
 	bundle := buildPipelineDefaults.Data["default_build_bundle"]
 
+	r := regexp.MustCompile(`([/:])(?:build|base)-`)
+
 	return &Bundles{
-		BuildTemplatesBundle:            bundle,
-		HACBSTemplatesBundle:            strings.Replace(bundle, "/build-", "/hacbs-", 1),
-		HACBSCoreServiceTemplatesBundle: coreServiceBundleName(bundle),
+		BuildTemplatesBundle: bundle,
+		HACBSTemplatesBundle: r.ReplaceAllString(bundle, "${1}hacbs-"),
 	}, nil
 }
 


### PR DESCRIPTION
# Description

Pull request bundle images are from `quay.io/repository/redhat-appstudio/pull-request-builds` repository and they have tags reflecting their flavor (base or HACBS). The replacement that was looking for `/<flavor>` was not appropriate for this as the flavor was in the tag (e.g. `:<flavor>`). This adjusts for both pull request builds that change the bundles and those that do not.

It also seems that `HACBSCoreServiceTemplatesBundle` is unused, so instead of adjusting that the logic to deduce the value and the field has been removed.

## Issue ticket number and link

https://issues.redhat.com/browse/HACBS-890

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Adjusted the unit tests

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
