### PR TITLE
refactor: tests for `cosign-verify-*` tasks

### DIFF
--- a/pkg/utils/tekton/pipelines.go
+++ b/pkg/utils/tekton/pipelines.go
@@ -61,55 +61,6 @@ func (g BuildahDemo) Generate() *v1beta1.PipelineRun {
 	}
 }
 
-type CosignVerify struct {
-	PipelineRunName string
-	Image           string
-	Bundle          string
-}
-
-// image is full url to the image, e.g.:
-// image-registry.openshift-image-registry.svc:5000/tekton-chains/buildah-demo@sha256:abc...
-func (t CosignVerify) Generate() *v1beta1.PipelineRun {
-	imageInfo := strings.Split(t.Image, "/")
-	namespace := imageInfo[1]
-
-	return &v1beta1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", t.PipelineRunName),
-			Namespace:    namespace,
-		},
-		Spec: v1beta1.PipelineRunSpec{
-			Params: []v1beta1.Param{
-				{
-					Name: "IMAGE_REF",
-					Value: v1beta1.ArrayOrString{
-						Type:      v1beta1.ParamTypeString,
-						StringVal: t.Image,
-					},
-				},
-				{
-					Name: "PUBLIC_KEY",
-					Value: v1beta1.ArrayOrString{
-						Type:      v1beta1.ParamTypeString,
-						StringVal: "k8s://tekton-chains/signing-secrets",
-					},
-				},
-				{
-					Name: "PIPELINERUN_NAME",
-					Value: v1beta1.ArrayOrString{
-						Type:      v1beta1.ParamTypeString,
-						StringVal: "",
-					},
-				},
-			},
-			PipelineRef: &v1beta1.PipelineRef{
-				Name:   "e2e-ec",
-				Bundle: t.Bundle,
-			},
-		},
-	}
-}
-
 type VerifyEnterpriseContract struct {
 	PipelineRunName string
 	ImageRef        string

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -105,28 +105,6 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 			)
 			g.GinkgoWriter.Println("Cosign verify pass with .att and .sig ImageStreamTags found")
 		})
-		g.It("verify image attestation", func() {
-			generator := tekton.CosignVerify{
-				PipelineRunName: "cosign-verify-attestation",
-				Image:           imageWithDigest,
-				Bundle:          framework.TektonController.Bundles.HACBSTemplatesBundle,
-			}
-			pr, waitTrErr := kubeController.RunPipeline(generator, pipelineRunTimeout)
-			Expect(waitTrErr).NotTo(HaveOccurred())
-			waitErr := kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)
-			Expect(waitErr).NotTo(HaveOccurred())
-		})
-		g.It("cosign verify", func() {
-			generator := tekton.CosignVerify{
-				PipelineRunName: "cosign-verify",
-				Image:           imageWithDigest,
-				Bundle:          framework.TektonController.Bundles.HACBSTemplatesBundle,
-			}
-			pr, waitTrErr := kubeController.RunPipeline(generator, pipelineRunTimeout)
-			Expect(waitTrErr).NotTo(HaveOccurred())
-			waitErr := kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)
-			Expect(waitErr).NotTo(HaveOccurred())
-		})
 
 		g.Context("verify-enterprise-contract task", func() {
 			var generator tekton.VerifyEnterpriseContract


### PR DESCRIPTION
# Description

Follow up on redhat-appstudio/build-definitions#173 to remove testing of `cosign-verify-*` tasks that are removed there.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Not at all, but removing stuff doesn't break the tests, right?

![yeah-sure-ross-geller](https://user-images.githubusercontent.com/1306050/179953464-0675867b-6213-4fbf-8393-dcb6508c3b27.gif)

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
