### PR TITLE
fix: everything in Enterprise contract tests suite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gosuri/uiprogress v0.0.1
 	github.com/gosuri/uitable v0.0.4
+	github.com/hacbs-contract/enterprise-contract-controller v0.0.0-20220608144538-7d47a3f5da49
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
 	github.com/openshift/api v0.0.0-20220525145417-ee5b62754c68
@@ -19,6 +20,7 @@ require (
 	github.com/redhat-appstudio/application-service v0.0.0-20220509201208-86571e38f52e
 	github.com/redhat-appstudio/integration-service v0.0.0-20220622135319-863425d2cad2
 	github.com/redhat-appstudio/jvm-build-service v0.0.0-20220714212008-d1b637f56c4d
+	github.com/redhat-appstudio/managed-gitops/appstudio-shared v0.0.0-20220623041404-010a781bb3fb
 	github.com/redhat-appstudio/managed-gitops/backend v0.0.0-20220506042230-3a79f373a001
 	github.com/redhat-appstudio/release-service v0.0.0-20220620143459-53c2f4bcc510
 	github.com/redhat-appstudio/service-provider-integration-operator v0.5.0
@@ -36,9 +38,8 @@ require (
 	k8s.io/klog/v2 v2.60.1
 	knative.dev/pkg v0.0.0-20220329144915-0a1ec2e0d46c
 	sigs.k8s.io/controller-runtime v0.12.1
+	sigs.k8s.io/yaml v1.3.0
 )
-
-require github.com/redhat-appstudio/managed-gitops/appstudio-shared v0.0.0-20220623041404-010a781bb3fb
 
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d // indirect
@@ -222,7 +223,6 @@ require (
 	sigs.k8s.io/kustomize/api v0.11.4 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 replace github.com/redhat-appstudio/managed-gitops/backend-shared => github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0-20220506042230-3a79f373a001

--- a/go.sum
+++ b/go.sum
@@ -1233,6 +1233,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
+github.com/hacbs-contract/enterprise-contract-controller v0.0.0-20220608144538-7d47a3f5da49 h1:FnV0az+++1gCXHm8jA8WLRJmzntYkGKazj3PkpaAU0U=
+github.com/hacbs-contract/enterprise-contract-controller v0.0.0-20220608144538-7d47a3f5da49/go.mod h1:HvkKDp1N58ymh+WAmsSDfZCc13dUhH8jigwKAlZXb+M=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/cap v0.1.1/go.mod h1:VfBvK2ULRyqsuqAnjgZl7HJ7/CGMC7ro4H5eXiZuun8=
 github.com/hashicorp/consul-template v0.27.2-0.20211014231529-4ff55381f1c4/go.mod h1:cAi5bOqno7Ao5sFHu7O80wMOPnqcF5ADrTApWU4Lqx4=

--- a/pkg/apis/kubernetes/client.go
+++ b/pkg/apis/kubernetes/client.go
@@ -7,6 +7,7 @@ import (
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend/apis/managed-gitops/v1alpha1"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	ecp "github.com/hacbs-contract/enterprise-contract-controller/api/v1alpha1"
 	integrationservice "github.com/redhat-appstudio/integration-service/api/v1alpha1"
 	jvmbuildservice "github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
 	jvmbuildserviceclientset "github.com/redhat-appstudio/jvm-build-service/pkg/client/clientset/versioned"
@@ -45,6 +46,7 @@ func init() {
 	utilruntime.Must(gitopsv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(integrationservice.AddToScheme(scheme))
 	utilruntime.Must(jvmbuildservice.AddToScheme(scheme))
+	utilruntime.Must(ecp.AddToScheme(scheme))
 }
 
 // Kube returns the clientset for Kubernetes upstream.

--- a/pkg/framework/describe.go
+++ b/pkg/framework/describe.go
@@ -6,25 +6,25 @@ import (
 
 // HASSuiteDescribe annotates the application service tests with the application label.
 func HASSuiteDescribe(text string, body func()) bool {
-	return Describe("[has-suite "+text+"]", Ordered, body)
+	return Describe("[has-suite "+text+"]", Ordered, Label("has"), body)
 }
 
 // E2ESuiteDescribe annotates the e2e scenarios tests with the e2e-scenarios label.
 func E2ESuiteDescribe(body func()) bool {
-	return Describe("[e2e-demos-suite]", Ordered, body)
+	return Describe("[e2e-demos-suite]", Ordered, Label("demos"), body)
 }
 
 // CommonSuiteDescribe annotates the common tests with the application label.
 func CommonSuiteDescribe(text string, body func()) bool {
-	return Describe("[common-suite "+text+"]", Ordered, body)
+	return Describe("[common-suite "+text+"]", Ordered, Label("common"), body)
 }
 
 func ChainsSuiteDescribe(text string, body func()) bool {
-	return Describe("[chains-suite "+text+"]", Ordered, body)
+	return Describe("[chains-suite "+text+"]", Ordered, Label("ec"), body)
 }
 
 func BuildSuiteDescribe(text string, body func()) bool {
-	return Describe("[build-service-suite "+text+"]", body)
+	return Describe("[build-service-suite "+text+"]", Label("build"), body)
 }
 
 func JVMBuildSuiteDescribe(text string, body func()) bool {
@@ -32,13 +32,13 @@ func JVMBuildSuiteDescribe(text string, body func()) bool {
 }
 
 func ClusterRegistrationSuiteDescribe(text string, body func()) bool {
-	return Describe("[cluster-registration-suite "+text+"]", Ordered, body)
+	return Describe("[cluster-registration-suite "+text+"]", Ordered, Label("cluster-registration"), body)
 }
 
 func ReleaseSuiteDescribe(text string, body func()) bool {
-	return Describe("[release-suite "+text+"]", Ordered, body)
+	return Describe("[release-suite "+text+"]", Ordered, Label("release"), body)
 }
 
 func IntegrationServiceSuiteDescribe(text string, body func()) bool {
-	return Describe("[integration-service-suite "+text+"]", Ordered, body)
+	return Describe("[integration-service-suite "+text+"]", Ordered, Label("integration-service"), body)
 }

--- a/pkg/utils/tekton/matchers.go
+++ b/pkg/utils/tekton/matchers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"knative.dev/pkg/apis"
 )
 
 type TaskRunResultMatcher struct {
@@ -61,4 +62,14 @@ func MatchTaskRunResult(name, value string) types.GomegaMatcher {
 
 func MatchTaskRunResultWithJSONValue(name string, json interface{}) types.GomegaMatcher {
 	return &TaskRunResultMatcher{name: name, jsonValue: &json}
+}
+
+func DidTaskSucceed(tr interface{}) bool {
+	switch tr := tr.(type) {
+	case *v1beta1.PipelineRunTaskRunStatus:
+		return tr.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
+	case *v1beta1.TaskRunStatus:
+		return tr.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
+	}
+	return false
 }

--- a/pkg/utils/tekton/pipelines.go
+++ b/pkg/utils/tekton/pipelines.go
@@ -61,55 +61,6 @@ func (g BuildahDemo) Generate() *v1beta1.PipelineRun {
 	}
 }
 
-type CosignVerify struct {
-	PipelineRunName string
-	Image           string
-	Bundle          string
-}
-
-// image is full url to the image, e.g.:
-// image-registry.openshift-image-registry.svc:5000/tekton-chains/buildah-demo@sha256:abc...
-func (t CosignVerify) Generate() *v1beta1.PipelineRun {
-	imageInfo := strings.Split(t.Image, "/")
-	namespace := imageInfo[1]
-
-	return &v1beta1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", t.PipelineRunName),
-			Namespace:    namespace,
-		},
-		Spec: v1beta1.PipelineRunSpec{
-			Params: []v1beta1.Param{
-				{
-					Name: "IMAGE_REF",
-					Value: v1beta1.ArrayOrString{
-						Type:      v1beta1.ParamTypeString,
-						StringVal: t.Image,
-					},
-				},
-				{
-					Name: "PUBLIC_KEY",
-					Value: v1beta1.ArrayOrString{
-						Type:      v1beta1.ParamTypeString,
-						StringVal: "k8s://tekton-chains/signing-secrets",
-					},
-				},
-				{
-					Name: "PIPELINERUN_NAME",
-					Value: v1beta1.ArrayOrString{
-						Type:      v1beta1.ParamTypeString,
-						StringVal: "",
-					},
-				},
-			},
-			PipelineRef: &v1beta1.PipelineRef{
-				Name:   "e2e-ec",
-				Bundle: t.Bundle,
-			},
-		},
-	}
-}
-
 type VerifyEnterpriseContract struct {
 	PipelineRunName string
 	ImageRef        string

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -16,10 +16,6 @@ import (
 var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 	defer g.GinkgoRecover()
 
-	// Set this to true to skip contract tests
-	var skipContract bool = false
-	var skipContractMsg string = "Temporarily disabling until the EC task definition is updated"
-
 	// Initialize the tests controllers
 	framework, err := framework.NewFramework()
 	Expect(err).NotTo(HaveOccurred())
@@ -146,9 +142,6 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 			})
 
 			g.It("succeeds when policy is met", func() {
-				if skipContract {
-					g.Skip(skipContractMsg)
-				}
 				// Setup a policy config to ignore the policy check for tests
 				policies := `{"non_blocking_checks":["not_useful", "test"]}`
 				g.GinkgoWriter.Printf("Set the non-blocking checks to policies: %s\n", policies)
@@ -177,9 +170,6 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 			})
 
 			g.It("does not pass when tests are not satisfied on non-strict mode", func() {
-				if skipContract {
-					g.Skip(skipContractMsg)
-				}
 				generator.StrictPolicy = "0"
 				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
 				Expect(err).NotTo(HaveOccurred())
@@ -213,9 +203,6 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 			})
 
 			g.It("fails when tests are not satisfied on strict mode", func() {
-				if skipContract {
-					g.Skip(skipContractMsg)
-				}
 				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
 				Expect(err).NotTo(HaveOccurred())
 				err = kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)
@@ -232,9 +219,6 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 			})
 
 			g.It("fails when unexpected signature is used", func() {
-				if skipContract {
-					g.Skip(skipContractMsg)
-				}
 				secretName := fmt.Sprintf("dummy-public-key-%s", util.GenerateRandomString(10))
 				publicKey := []byte("-----BEGIN PUBLIC KEY-----\n" +
 					"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENZxkE/d0fKvJ51dXHQmxXaRMTtVz\n" +

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -17,7 +17,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 	defer g.GinkgoRecover()
 
 	// Set this to true to skip contract tests
-	var skipContract bool = true
+	var skipContract bool = false
 	var skipContractMsg string = "Temporarily disabling until the EC task definition is updated"
 
 	// Initialize the tests controllers
@@ -104,34 +104,6 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 				attestationTimeout.String(),
 			)
 			g.GinkgoWriter.Println("Cosign verify pass with .att and .sig ImageStreamTags found")
-		})
-		g.It("verify image attestation", func() {
-			if skipContract {
-				g.Skip(skipContractMsg)
-			}
-			generator := tekton.CosignVerify{
-				PipelineRunName: "cosign-verify-attestation",
-				Image:           imageWithDigest,
-				Bundle:          framework.TektonController.Bundles.HACBSTemplatesBundle,
-			}
-			pr, waitTrErr := kubeController.RunPipeline(generator, pipelineRunTimeout)
-			Expect(waitTrErr).NotTo(HaveOccurred())
-			waitErr := kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)
-			Expect(waitErr).NotTo(HaveOccurred())
-		})
-		g.It("cosign verify", func() {
-			if skipContract {
-				g.Skip(skipContractMsg)
-			}
-			generator := tekton.CosignVerify{
-				PipelineRunName: "cosign-verify",
-				Image:           imageWithDigest,
-				Bundle:          framework.TektonController.Bundles.HACBSTemplatesBundle,
-			}
-			pr, waitTrErr := kubeController.RunPipeline(generator, pipelineRunTimeout)
-			Expect(waitTrErr).NotTo(HaveOccurred())
-			waitErr := kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)
-			Expect(waitErr).NotTo(HaveOccurred())
 		})
 
 		g.Context("verify-enterprise-contract task", func() {

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -8,45 +8,45 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
 
-	g "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 )
 
 var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
-	defer g.GinkgoRecover()
+	defer GinkgoRecover()
 
 	// Initialize the tests controllers
 	framework, err := framework.NewFramework()
 	Expect(err).NotTo(HaveOccurred())
 
-	g.Context("infrastructure is running", func() {
-		g.It("verify the chains controller is running", func() {
+	Context("infrastructure is running", func() {
+		It("verify the chains controller is running", func() {
 			err := framework.CommonController.WaitForPodSelector(framework.CommonController.IsPodRunning, constants.TEKTON_CHAINS_NS, "app", "tekton-chains-controller", 60, 100)
 			Expect(err).NotTo(HaveOccurred())
 		})
-		g.It("verify the correct secrets have been created", func() {
+		It("verify the correct secrets have been created", func() {
 			_, err := framework.CommonController.GetSecret(constants.TEKTON_CHAINS_NS, "chains-ca-cert")
 			Expect(err).NotTo(HaveOccurred())
 		})
-		g.It("verify the correct roles are created", func() {
+		It("verify the correct roles are created", func() {
 			_, csaErr := framework.CommonController.GetRole("chains-secret-admin", constants.TEKTON_CHAINS_NS)
 			Expect(csaErr).NotTo(HaveOccurred())
 			_, srErr := framework.CommonController.GetRole("secret-reader", "openshift-ingress-operator")
 			Expect(srErr).NotTo(HaveOccurred())
 		})
-		g.It("verify the correct rolebindings are created", func() {
+		It("verify the correct rolebindings are created", func() {
 			_, csaErr := framework.CommonController.GetRoleBinding("chains-secret-admin", constants.TEKTON_CHAINS_NS)
 			Expect(csaErr).NotTo(HaveOccurred())
 			_, csrErr := framework.CommonController.GetRoleBinding("chains-secret-reader", "openshift-ingress-operator")
 			Expect(csrErr).NotTo(HaveOccurred())
 		})
-		g.It("verify the correct service account is created", func() {
+		It("verify the correct service account is created", func() {
 			_, err := framework.CommonController.GetServiceAccount("chains-secrets-admin", constants.TEKTON_CHAINS_NS)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
-	g.Context("test creating and signing an image and task", func() {
+	Context("test creating and signing an image and task", func() {
 		// Make the TaskRun name and namespace predictable. For convenience, the name of the
 		// TaskRun that builds an image, is the same as the repository where the image is
 		// pushed to.
@@ -64,7 +64,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 
 		var imageWithDigest string
 
-		g.BeforeAll(func() {
+		BeforeAll(func() {
 			// At a bare minimum, each spec within this context relies on the existence of
 			// an image that has been signed by Tekton Chains. Trigger a demo task to fulfill
 			// this purpose.
@@ -74,7 +74,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 			Expect(buildPipelineRunName).To(Equal(pr.ObjectMeta.Name))
 			Expect(namespace).To(Equal(pr.ObjectMeta.Namespace))
 			Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
-			g.GinkgoWriter.Printf("The pipeline run is %q under namespace %q\n", pr.ObjectMeta.Name, pr.ObjectMeta.Namespace)
+			GinkgoWriter.Printf("The pipeline run is %q under namespace %q\n", pr.ObjectMeta.Name, pr.ObjectMeta.Namespace)
 
 			// The TaskRun resource has been updated, refresh our reference.
 			pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.ObjectMeta.Name, pr.ObjectMeta.Namespace)
@@ -84,13 +84,13 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 			digest, err := kubeController.GetTaskRunResult(pr, "build-container", "IMAGE_DIGEST")
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("%s", err))
 			Expect(kubeController.GetTaskRunResult(pr, "build-container", "IMAGE_URL")).To(Equal(image))
-			g.GinkgoWriter.Printf("The image signed by Tekton Chains is %s@%s\n", image, digest)
+			GinkgoWriter.Printf("The image signed by Tekton Chains is %s@%s\n", image, digest)
 
 			// Specs now have a deterministic image reference for validation \o/
 			imageWithDigest = fmt.Sprintf("%s@%s", image, digest)
 		})
 
-		g.It("creates signature and attestation", func() {
+		It("creates signature and attestation", func() {
 			err = kubeController.AwaitAttestationAndSignature(imageWithDigest, attestationTimeout)
 			Expect(err).NotTo(
 				HaveOccurred(),
@@ -99,21 +99,21 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 					"Look at the chains-controller logs.",
 				attestationTimeout.String(),
 			)
-			g.GinkgoWriter.Println("Cosign verify pass with .att and .sig ImageStreamTags found")
+			GinkgoWriter.Println("Cosign verify pass with .att and .sig ImageStreamTags found")
 		})
 
-		g.Context("verify-enterprise-contract task", func() {
+		Context("verify-enterprise-contract task", func() {
 			var generator tekton.VerifyEnterpriseContract
 			var rekorHost string
 			publicSecretName := "cosign-public-key"
 
-			g.BeforeAll(func() {
+			BeforeAll(func() {
 				// Copy the public key from tekton-chains/signing-secrets to a new
 				// secret that contains just the public key to ensure that access
 				// to password and private key are not needed.
 				publicKey, err := kubeController.GetPublicKey("signing-secrets", "tekton-chains")
 				Expect(err).ToNot(HaveOccurred())
-				g.GinkgoWriter.Println("Copy public key from tekton-chains/signing-secrets to a new secret")
+				GinkgoWriter.Println("Copy public key from tekton-chains/signing-secrets to a new secret")
 				Expect(kubeController.CreateOrUpdateSigningSecret(
 					publicKey, publicSecretName, namespace)).To(Succeed())
 
@@ -121,7 +121,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			g.BeforeEach(func() {
+			BeforeEach(func() {
 				generator = tekton.VerifyEnterpriseContract{
 					PipelineRunName: "verify-enterprise-contract",
 					ImageRef:        imageWithDigest,
@@ -136,15 +136,15 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 				// Since specs could update the config policy, make sure it has a consistent
 				// baseline at the start of each spec.
 				baselinePolicies := `{"non_blocking_checks":["not_useful"]}`
-				g.GinkgoWriter.Printf("Set the non-blocking checks to baseline policies: %s\n", baselinePolicies)
+				GinkgoWriter.Printf("Set the non-blocking checks to baseline policies: %s\n", baselinePolicies)
 				Expect(kubeController.CreateOrUpdateConfigPolicy(
 					namespace, baselinePolicies)).To(Succeed())
 			})
 
-			g.It("succeeds when policy is met", func() {
+			It("succeeds when policy is met", func() {
 				// Setup a policy config to ignore the policy check for tests
 				policies := `{"non_blocking_checks":["not_useful", "test"]}`
-				g.GinkgoWriter.Printf("Set the non-blocking checks to policies: %s\n", policies)
+				GinkgoWriter.Printf("Set the non-blocking checks to policies: %s\n", policies)
 				Expect(kubeController.CreateOrUpdateConfigPolicy(
 					namespace, policies)).To(Succeed())
 				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
@@ -156,7 +156,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 				Expect(err).NotTo(HaveOccurred())
 				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract")
 				Expect(err).NotTo(HaveOccurred())
-				g.GinkgoWriter.Printf("Make sure task %q has passed\n", pr.Name)
+				GinkgoWriter.Printf("Make sure task %q has passed\n", pr.Name)
 				Expect(tr.Status.TaskRunResults).Should(ContainElements(
 					tekton.MatchTaskRunResultWithJSONValue("OUTPUT", `[
 						{
@@ -169,7 +169,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 				))
 			})
 
-			g.It("does not pass when tests are not satisfied on non-strict mode", func() {
+			It("does not pass when tests are not satisfied on non-strict mode", func() {
 				generator.StrictPolicy = "0"
 				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
 				Expect(err).NotTo(HaveOccurred())
@@ -178,7 +178,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 				// Refresh our copy of the PipelineRun for latest results
 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
 				Expect(err).NotTo(HaveOccurred())
-				g.GinkgoWriter.Printf("Make sure pipeline %q has failed\n", pr.Name)
+				GinkgoWriter.Printf("Make sure pipeline %q has failed\n", pr.Name)
 				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(tr.Status.TaskRunResults).Should(ContainElements(
@@ -202,7 +202,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 				))
 			})
 
-			g.It("fails when tests are not satisfied on strict mode", func() {
+			It("fails when tests are not satisfied on strict mode", func() {
 				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
 				Expect(err).NotTo(HaveOccurred())
 				err = kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)
@@ -211,20 +211,20 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 				// Refresh our copy of the PipelineRun for latest results
 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
 				Expect(err).NotTo(HaveOccurred())
-				g.GinkgoWriter.Printf("Make sure pipeline %q has failed\n", pr.Name)
+				GinkgoWriter.Printf("Make sure pipeline %q has failed\n", pr.Name)
 				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(tr.Status.GetCondition("Succeeded").IsTrue()).To(BeFalse())
 				// Because the task fails, no results are created
 			})
 
-			g.It("fails when unexpected signature is used", func() {
+			It("fails when unexpected signature is used", func() {
 				secretName := fmt.Sprintf("dummy-public-key-%s", util.GenerateRandomString(10))
 				publicKey := []byte("-----BEGIN PUBLIC KEY-----\n" +
 					"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENZxkE/d0fKvJ51dXHQmxXaRMTtVz\n" +
 					"BQWcmJD/7pcMDEmBcmk8O1yUPIiFj5TMZqabjS9CQQN+jKHG+Bfi0BYlHg==\n" +
 					"-----END PUBLIC KEY-----")
-				g.GinkgoWriter.Println("Create an unexpected public signing key")
+				GinkgoWriter.Println("Create an unexpected public signing key")
 				Expect(kubeController.CreateOrUpdateSigningSecret(publicKey, secretName, namespace)).To(Succeed())
 				generator.PublicSecret = fmt.Sprintf("k8s://%s/%s", namespace, secretName)
 
@@ -236,7 +236,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", func() {
 				// Refresh our copy of the PipelineRun for latest results
 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
 				Expect(err).NotTo(HaveOccurred())
-				g.GinkgoWriter.Printf("Make sure pipeline %q has failed\n", pr.Name)
+				GinkgoWriter.Printf("Make sure pipeline %q has failed\n", pr.Name)
 				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(tr.Status.GetCondition("Succeeded").IsTrue()).To(BeFalse())


### PR DESCRIPTION
This should fix all outstanding issues with Enterprise contract end to end tests. I've unified all the changes made in #146 and #145 because to get the end to end test to pass all of these changes need to be lumped together.

Here is the text from the commit messages and links to individual commits to make the review somewhat easier:

[refactor: tests for cosign-verify-* tasks](https://github.com/redhat-appstudio/e2e-tests/commit/f6ae31a24418477200b35cade28cfa9a218a70f4)

Follow up on https://github.com/redhat-appstudio/build-definitions/pull/173 to remove testing of `cosign-verify-*` tasks that are removed there.

This was previously present in #146

[refactor: bundle image reference for pull requests](https://github.com/redhat-appstudio/e2e-tests/commit/d326642f8a5bcb1f3cde05601e06377dfeef988c)

Pull request bundle images are from `quay.io/repository/redhat-appstudio/pull-request-builds` repository and they have tags reflecting their flavor (base or HACBS). The replacement that was looking for `/<flavor>` was not appropriate for this as the flavor was in the tag (e.g. `:<flavor>`). This adjusts for both pull request builds that change the bundles and those that do not.

It also seems that `HACBSCoreServiceTemplatesBundle` is unused, so instead of adjusting that the logic to deduce the value and the field has been removed.

This was previously present in #145 

[feat: labels for test suites](https://github.com/redhat-appstudio/e2e-tests/commit/861cd8a0f483b7ce8d7c4ee63c17749f492933a8)

This sets the default labels on suites and all tests within those. This allows us to selectively run or disable whole test suites.

For example to disable running Enterprise contract test suite, labeled with `ec`, run with:

    --ginkgo.label-filter='!ec'

[refactor: remove skip functionality in ec tests](https://github.com/redhat-appstudio/e2e-tests/commit/5b3181fee8c6dc3a2e38263fd0b8e1876a3fccaa)

With the default labels being set at the Enterprise contract test suite level, we no longer need the skip functionality within the test suite, as we can skip the test by excluding the label in the `label-filter` parameter, i.e. run with `--ginkgo.label-filter='!ec'`.

[refactor: use . import for ginkgo](https://github.com/redhat-appstudio/e2e-tests/commit/6de7ea56d0d953983dd54702aae79adca59da50e)

For nicer readability of tests.

[refactor: cleanup debug messages and assertions](https://github.com/redhat-appstudio/e2e-tests/commit/fd9588c2ccd11ad8a540a76b90184bea939d1972)

Debug are now more descriptive and in correct places. The assertions have their `expected` and `received` values in correct places.

[feat: use EnterpriseContractPolicy custom resource](https://github.com/redhat-appstudio/e2e-tests/commit/0b52115dad1242d7b2d6873187ef53c8e46bdde4)

This refactors the tests to create and use EnterpriseContractPolicy custom resource instead of the ConfigMap. In verify-enterprise-contract Tekton Task both ConfigMap and EnterpriseContractPolicy are supported, whereas in v2 only EnterpriseContractPolicy is supported.

The tests now assert the state as expected today, i.e. the failing Tasks are asserted to fail as we expect today. We no longer assert the `OUTPUT` TaskRun result as that is brittle with corresponding changes to the changes in hacbs-contract/ec-policy repository.

By default the policy sources are fetched from hacbs-contract/ec-policy repository main branch. This can be overridden by creating a ConfigMap e2e-tests/ec-config with keys `revision` and `repository`, each of those can replace this default settings. This will come in useful if we want to pin a certain revision we know the tests are good to run against, e.g. if we enable pull request updates via redhat-appstudio/infra-deployments from hacbs-contract/ec-policies; or
if we setup a separate repository with policies suited for the end to end tests. This brings the groundwork for that, either of those options could be a good solution to reduce the brittleness, but this is left for the future.

Also refactors the tests to add more debug output when the tests fail.

## Issue ticket number and link

https://issues.redhat.com/browse/HACBS-890
https://issues.redhat.com/browse/HACBS-894

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've run the end to end tests against a cluster with infra-deployments at 63fcce12c02453943137eb3914ca42483e5ca413 and with bundle images from https://github.com/redhat-appstudio/build-definitions/pull/173 set by changing ConfigMap build-templates/build-pipelines-defaults to have:

```
default_build_bundle: quay.io/redhat-appstudio/pull-request-builds:base-12936a403e7f46b49bb680c1294a94286ea74461
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
