### PR TITLE
fix: vault-init script env var

### DIFF
--- a/scripts/install-appstudio-e2e-mode.sh
+++ b/scripts/install-appstudio-e2e-mode.sh
@@ -53,7 +53,8 @@ function addQERemoteForkAndInstallAppstudio() {
 
 # Add a custom remote for infra-deployments repository.
 function initializeSPIVault() {
-   curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/main/scripts/spi-e2e-setup.sh | bash -s
+   # The env var NAMESPACE is exported by openshift-ci and breaks the vault-init script. It has to be set to an empty string.
+   curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/main/scripts/spi-e2e-setup.sh | NAMESPACE="" bash -s
 }
 
 # Secrets used by pipelines to push component containers to quay.io

--- a/scripts/spi-e2e-setup.sh
+++ b/scripts/spi-e2e-setup.sh
@@ -39,7 +39,8 @@ oc apply -f -
 
 rm "$tmpfile"
 
-curl https://raw.githubusercontent.com/redhat-appstudio/service-provider-integration-operator/main/hack/vault-init.sh | bash -s
+# The env var NAMESPACE is exported by openshift-ci and breaks the vault-init script. It has to be set to an empty string.
+curl https://raw.githubusercontent.com/redhat-appstudio/service-provider-integration-operator/main/hack/vault-init.sh | NAMESPACE="" bash -s
 
 oc rollout restart  deployment/spi-controller-manager -n spi-system
 oc rollout restart  deployment/spi-oauth-service -n spi-system


### PR DESCRIPTION
# Description

Hopefully should fix this issue in openshift-ci
```bash
[INFO] Deploying SPI OAuth2 config
Please go to https://github.com/settings/developers.
And register new Github OAuth application for callback https://spi-oauth-route-spi-system.apps.ci-ocp-4-9-amd64-aws-us-west-1-fvxng.hive.aws.ci.openshift.org/github/callback
namespace/spi-system configured
secret/oauth-config created
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0  6151    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  6151  100  6151    0     0  30133      0 --:--:-- --:--:-- --:--:-- 30004
Error from server (NotFound): namespaces "ci-op-pklbf6pm" not found
Waiting for Vault pod to be ready.
Error from server (NotFound): namespaces "ci-op-pklbf6pm" not found
Waiting for Vault pod to be ready.
Error from server (NotFound): namespaces "ci-op-pklbf6pm" not found
Waiting for Vault pod to be ready.
```

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
