### PR TITLE
fix: Avoid double deployment of components in e2e-demo

### DIFF
--- a/pkg/utils/gitops/controller.go
+++ b/pkg/utils/gitops/controller.go
@@ -11,6 +11,7 @@ import (
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend/apis/managed-gitops/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type SuiteController struct {
@@ -55,6 +56,12 @@ func (h *SuiteController) DeleteGitOpsCR(name string, namespace string) error {
 		},
 	}
 	return h.KubeRest().Delete(context.TODO(), gitOpsDeployment)
+}
+
+// Remove all components from a given repository. Usefull when create a lot of resources and want to remove all of them
+func (h *SuiteController) DeleteAllGitOpDeploymentsCRsInASpecificNamespace(namespace string) error {
+
+	return h.KubeRest().DeleteAllOf(context.TODO(), &managedgitopsv1alpha1.GitOpsDeployment{}, client.InNamespace(namespace))
 }
 
 // GetGitOpsDeployedImage return the image used by the given component deployment

--- a/tests/e2e-demos/e2e-demo.go
+++ b/tests/e2e-demos/e2e-demo.go
@@ -59,6 +59,7 @@ var _ = framework.E2ESuiteDescribe(func() {
 	AfterAll(func() {
 		Expect(fw.HasController.DeleteAllComponentsInASpecificNamespace(AppStudioE2EApplicationsNamespace)).To(Succeed())
 		Expect(fw.HasController.DeleteAllApplicationsInASpecificNamespace(AppStudioE2EApplicationsNamespace)).To(Succeed())
+		Expect(fw.GitOpsController.DeleteAllGitOpDeploymentsCRsInASpecificNamespace(AppStudioE2EApplicationsNamespace)).To(Succeed())
 	})
 
 	for _, appTest := range configTest.Tests {
@@ -135,11 +136,6 @@ var _ = framework.E2ESuiteDescribe(func() {
 
 				// Deploy the component using gitops and check for the health
 				It(fmt.Sprintf("deploy component %s using gitops", componentTest.Name), func() {
-					gitOpsRepository := utils.ObtainGitOpsRepositoryUrl(application.Status.Devfile)
-					gitOpsRepositoryPath := fmt.Sprintf("components/%s/base", componentTest.Name)
-
-					_, err := fw.GitOpsController.CreateGitOpsCR(GitOpsDeploymentName, AppStudioE2EApplicationsNamespace, gitOpsRepository, gitOpsRepositoryPath, GitOpsRepositoryRevision)
-					Expect(err).NotTo(HaveOccurred())
 
 					Eventually(func() bool {
 						deployment, err := fw.CommonController.GetAppDeploymentByName(componentTest.Name, AppStudioE2EApplicationsNamespace)


### PR DESCRIPTION
# Description

What is currently being done to deploy Applications/Components in `e2e-demo.go` appears to be incorrect: the test should not be [creating a `Component`](https://github.com/redhat-appstudio/e2e-tests/blob/171fae559916f163da847fba3a65d00124ad0f18/tests/e2e-demos/e2e-demo.go#L102), then [*also* manually creating a `GitOpsDeployment` targeting that component](https://github.com/redhat-appstudio/e2e-tests/blob/171fae559916f163da847fba3a65d00124ad0f18/tests/e2e-demos/e2e-demo.go#L141).

It should only be necessary to create the Component, then wait for HAS to update the GitOps repository with the new component contents.

The problem with the way the test currently works is it ends up creating 2 `GitOpsDeployment` resources, _both targetting the same namespace with the same resources_ (but with slightly different metadata). This means that Argo CD is constantly fighting with itself to deploy 2 separate Argo CD `Application`s into the same namespace.

See [this video](https://drive.google.com/file/d/1x3T7Cf5aJpCmsz-ZNUAKCTAumeevjclf/view?usp=sharing) to see what happens in this case. Notice that:
- Argo CD is constantly deploying and redeploying the same resources on top of each other (see the flashing resources and status in the Argo CD UI)
- Argo CD is warning about the resources clashing with each other, and the warning disappears and reappears (as the two 2 Argo CD Applications conflict)
- (I recommend *downloading* the video to get the full 1080p resolution: google drive preview compresses the preview to be almost unreadable)

This is also likely causing the tests to intermittently fail, and is also likely causing them to take MUCH longer than they should. 

My proposed solution is just to let HAS update the GitOps repository, after the component is created/updated, and let GitOps Service deploy the resulting update.

See below for how to reproduce the issue.

## Issue ticket number and link

N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

The most obvious way to observe this is open the Argo CD web UI (see below), and then run the e2e tests:
- You will see Argo CD Applications being created and constantly refreshing, as they are updating K8s resources on top of each other
- You will see Argo CD Applications with warnings about resources being in the same namespce.


# How to reproduce

You can see this behaviour if you open the Argo CD instance under `gitops-service-argocd` while the e2e-demo test is running.

Here is how you open the `gitops-service-argocd` instance:

1) Run this command to get the Argo CD URL, then  open Argo CD URL for the Argo CD installed `gitops-service-argocd` namespace (different URL from the `openshift-gitops` one):
```
ARGO_CD_ROUTE=$(kubectl get \
                 -n gitops-service-argocd \
                 -o template \
                 --template={{.spec.host}} \
                 route/gitops-service-argocd-server \
               )
echo "https://$ARGO_CD_ROUTE"
```

2) Run this command to get the password:
```
echo `kubectl -n gitops-service-argocd get secret gitops-service-argocd-cluster -o jsonpath="{.data.admin\.password}" | base64 --decode`
```

Enter `admin` and the password above, to log in. 

Now, if you run the e2e tests, you can see the behaviour above.

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
