### PR TITLE
feat: e2e tests for verify-enterprise-contract-v2

### DIFF
--- a/.ci/oci-launch-e2e.sh
+++ b/.ci/oci-launch-e2e.sh
@@ -14,7 +14,7 @@ export ARTIFACTS_DIR=${ARTIFACT_DIR:-"/tmp/appstudio"}
 
 function executeE2ETests() {
     make build
-    "${WORKSPACE}"/bin/e2e-appstudio --ginkgo.junit-report="${ARTIFACTS_DIR}"/e2e-report.xml --ginkgo.progress --ginkgo.v --ginkgo.label-filter='!ec'
+    "${WORKSPACE}"/bin/e2e-appstudio --ginkgo.junit-report="${ARTIFACTS_DIR}"/e2e-report.xml --ginkgo.progress --ginkgo.v
 }
 
 # Initiate openshift ci users

--- a/pkg/utils/tekton/controller_test.go
+++ b/pkg/utils/tekton/controller_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kfake "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -47,7 +48,7 @@ func TestCosignResultMissingFormat(t *testing.T) {
 	}.Missing("prefix"))
 }
 
-func newTag(name string, hash string) unstructured.Unstructured {
+func newTag(name string, hash string, noLayers int) client.Object {
 	tag := unstructured.Unstructured{}
 	tag.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "image.openshift.io",
@@ -56,6 +57,10 @@ func newTag(name string, hash string) unstructured.Unstructured {
 	})
 	tag.SetNamespace("test-namespace")
 	tag.SetName(name)
+	layers := make([]interface{}, noLayers)
+	tag.Object["image"] = map[string]interface{}{
+		"dockerImageLayers": layers,
+	}
 
 	if hash != "" {
 		if err := unstructured.SetNestedField(tag.Object, hash, "image", "metadata", "name"); err != nil {
@@ -63,45 +68,46 @@ func newTag(name string, hash string) unstructured.Unstructured {
 		}
 	}
 
-	return tag
+	return &tag
 }
 
 func TestFindingCosignResults(t *testing.T) {
 	cases := []struct {
 		Name          string
-		Tags          []unstructured.Unstructured
+		Tags          []client.Object
 		ExpectedError string
 		Result        *CosignResult
 	}{
-		{"happy day", []unstructured.Unstructured{
-			newTag("test-image:latest", "sha256:hash"),
-			newTag("test-image:sha256-hash.sig", ""),
-			newTag("test-image:sha256-hash.att", ""),
+		{"happy day", []client.Object{
+			newTag("test-image:latest", "sha256:hash", 1),
+			newTag("test-image:sha256-hash.sig", "", 1),
+			newTag("test-image:sha256-hash.att", "", 2),
 		}, "", &CosignResult{
 			signatureImageRef:   "test-image:sha256-hash.sig",
 			attestationImageRef: "test-image:sha256-hash.att",
 		}},
-		{"missing signature", []unstructured.Unstructured{
-			newTag("test-image:latest", "sha256:hash"),
-			newTag("test-image:sha256-hash.att", ""),
+		{"missing signature", []client.Object{
+			newTag("test-image:latest", "sha256:hash", 1),
+			newTag("test-image:sha256-hash.att", "", 2),
 		}, "ImageStreamTag.image.openshift.io \"test-image:sha256-hash.sig\" not found", nil},
-		{"missing attestation", []unstructured.Unstructured{
-			newTag("test-image:latest", "sha256:hash"),
-			newTag("test-image:sha256-hash.sig", ""),
+		{"missing attestation", []client.Object{
+			newTag("test-image:latest", "sha256:hash", 1),
+			newTag("test-image:sha256-hash.sig", "", 1),
 		}, "ImageStreamTag.image.openshift.io \"test-image:sha256-hash.att\" not found", nil},
-		{"missing signature and attestation", []unstructured.Unstructured{
-			newTag("test-image:latest", "sha256:hash"),
+		{"missing signature and attestation", []client.Object{
+			newTag("test-image:latest", "sha256:hash", 1),
 		}, "ImageStreamTag.image.openshift.io \"test-image:sha256-hash.sig and test-image:sha256-hash.att\" not found", nil},
-		{"everything missing", []unstructured.Unstructured{}, "ImageStreamTag.image.openshift.io \"test-image:sha256-hash.sig and test-image:sha256-hash.att\" not found", nil},
+		{"everything missing", []client.Object{}, "ImageStreamTag.image.openshift.io \"test-image:sha256-hash.sig and test-image:sha256-hash.att\" not found", nil},
+		{"missing layer in attestation", []client.Object{
+			newTag("test-image:latest", "sha256:hash", 1),
+			newTag("test-image:sha256-hash.sig", "", 1),
+			newTag("test-image:sha256-hash.att", "", 1),
+		}, "ImageStreamTag.image.openshift.io \"test-image:sha256-hash.att\" not found", nil},
 	}
 
 	for _, cse := range cases {
 		t.Run(cse.Name, func(t *testing.T) {
-			tags := unstructured.UnstructuredList{
-				Items: cse.Tags,
-			}
-
-			client := fake.NewClientBuilder().WithLists(&tags).Build()
+			client := fake.NewClientBuilder().WithObjects(cse.Tags...).Build()
 
 			result, err := findCosignResultsForImage("image-registry.openshift-image-registry.svc:5000/test-namespace/test-image@sha256-hash", client)
 

--- a/pkg/utils/tekton/matchers.go
+++ b/pkg/utils/tekton/matchers.go
@@ -1,17 +1,21 @@
 package tekton
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/client-go/util/jsonpath"
 	"knative.dev/pkg/apis"
 )
 
 type TaskRunResultMatcher struct {
 	name        string
+	jsonPath    *string
 	value       *string
 	jsonValue   *interface{}
 	jsonMatcher types.GomegaMatcher
@@ -36,16 +40,62 @@ func (matcher *TaskRunResultMatcher) Match(actual interface{}) (success bool, er
 			return false, nil
 		}
 
+		given := tr.Value
+		if matcher.jsonPath != nil {
+			p := jsonpath.New("test")
+			p.EnableJSONOutput(true)
+			if err := p.Parse(*matcher.jsonPath); err != nil {
+				return false, err
+			}
+
+			var v interface{}
+			if err := json.Unmarshal([]byte(given), &v); err != nil {
+				return false, err
+			}
+
+			results, err := p.FindResults(v)
+			if err != nil {
+				return false, err
+			}
+			var values []interface{}
+			for _, result := range results {
+				var buffy bytes.Buffer
+				if err := p.PrintResults(&buffy, result); err != nil {
+					return false, err
+				}
+
+				var value interface{}
+				if err := json.Unmarshal(buffy.Bytes(), &value); err != nil {
+					return false, err
+				}
+				values = append(values, value)
+			}
+			if len(values) == 1 {
+				if b, err := json.Marshal(values[0]); err != nil {
+					return false, err
+				} else {
+					given = string(b)
+				}
+			} else if b, err := json.Marshal(values); err != nil {
+				return false, err
+			} else {
+				given = string(b)
+			}
+		}
+
 		if matcher.value != nil {
-			return strings.TrimSpace(tr.Value) == *matcher.value, nil
+			return strings.TrimSpace(given) == *matcher.value, nil
 		} else {
 			matcher.jsonMatcher = gomega.MatchJSON(*matcher.jsonValue)
-			return matcher.jsonMatcher.Match(tr.Value)
+			return matcher.jsonMatcher.Match(given)
 		}
 	}
 }
 
 func (matcher *TaskRunResultMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	if matcher.jsonPath != nil && matcher.jsonValue != nil {
+		return fmt.Sprintf("value `%s` for JSONPath `%s` not to equal `%s`", actual, *matcher.jsonPath, *matcher.jsonValue)
+	}
 	if matcher.value != nil {
 		return fmt.Sprintf("%v not to equal %v", actual, v1beta1.TaskRunResult{
 			Name:  matcher.name,
@@ -62,6 +112,10 @@ func MatchTaskRunResult(name, value string) types.GomegaMatcher {
 
 func MatchTaskRunResultWithJSONValue(name string, json interface{}) types.GomegaMatcher {
 	return &TaskRunResultMatcher{name: name, jsonValue: &json}
+}
+
+func MatchTaskRunResultWithJSONPathValue(name, path string, json interface{}) types.GomegaMatcher {
+	return &TaskRunResultMatcher{name: name, jsonPath: &path, jsonValue: &json}
 }
 
 func DidTaskSucceed(tr interface{}) bool {

--- a/pkg/utils/tekton/matchers_test.go
+++ b/pkg/utils/tekton/matchers_test.go
@@ -26,3 +26,23 @@ func TestTaskRunResultMatcherJSONValue(t *testing.T) {
 	assert.True(t, match)
 	assert.Nil(t, err)
 }
+
+func TestMatchTaskRunResultWithJSONPathValue(t *testing.T) {
+	match, err := MatchTaskRunResultWithJSONPathValue("a", "{$.c[0].d}", "[2]").Match(v1beta1.TaskRunResult{
+		Name:  "a",
+		Value: `{"b":1, "c": [{"d": 2}]}`,
+	})
+
+	assert.True(t, match)
+	assert.Nil(t, err)
+}
+
+func TestMatchTaskRunResultWithJSONPathValueMultiple(t *testing.T) {
+	match, err := MatchTaskRunResultWithJSONPathValue("a", "{$.c[*].d}", "[2, 1]").Match(v1beta1.TaskRunResult{
+		Name:  "a",
+		Value: `{"b":1, "c": [{"d": 2}, {"d": 1}]}`,
+	})
+
+	assert.True(t, match)
+	assert.Nil(t, err)
+}

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -169,7 +169,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec"), fu
 					PipelineName:    "pipeline-run-that-does-not-exist",
 					RekorHost:       rekorHost,
 					SslCertDir:      "/var/run/secrets/kubernetes.io/serviceaccount",
-					StrictPolicy:    "1",
+					StrictPolicy:    true,
 					Bundle:          fwk.TektonController.Bundles.HACBSTemplatesBundle,
 				}
 
@@ -222,7 +222,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec"), fu
 			})
 
 			It("does not pass when tests are not satisfied on non-strict mode", func() {
-				generator.StrictPolicy = "0"
+				generator.StrictPolicy = false
 				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -62,7 +62,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec"), fu
 		// Make the TaskRun name and namespace predictable. For convenience, the name of the
 		// TaskRun that builds an image, is the same as the repository where the image is
 		// pushed to.
-		namespace := "tekton-chains"
+		namespace := constants.TEKTON_CHAINS_NS
 		buildPipelineRunName := fmt.Sprintf("buildah-demo-%s", util.GenerateRandomString(10))
 		image := fmt.Sprintf("image-registry.openshift-image-registry.svc:5000/%s/%s", namespace, buildPipelineRunName)
 		var imageWithDigest string


### PR DESCRIPTION
This includes some refactoring and fixes in order to test the verify-enterprise-contract-v2 task. Namely:

[fix: two layers needed in attestation image](https://github.com/redhat-appstudio/e2e-tests/pull/158/commits/720a04f052552c7bcfadc66ba0c7c78adb00d546)

The Tekton Chains controller will push two layers to the attestation
image. One containing the TaskRun attestation and one containing the
PipelineRun attestation. We require PipelineRun attestation to be
present. Without downloading and examining the image we can make sure
that the PipelineRun attestation is present if the `ImageStreamTag` has
two `dockerImageLayers`.

We're now fetching the `ImageStreamTag` directly rather than listing all
and filtering the items list for `ImageStreamTag` with a specific name.

[feat: JSONPath matching for TaskRunResults](https://github.com/redhat-appstudio/e2e-tests/pull/158/commits/56bbee06ecdc2cf72dd7ba2f27c9c17c1d5a1c32)

This enables asserting parts of the TaskRunResult values with JSONPath,
assuming that those contain a JSON value.

The JSONPath is in the syntax `{...}` and the asserted value needs to
conform to an array of values. The array of values is needed because the
evaluation of the of the JSONPath might yield more than one value.

[feat: introduce parameters for the V2 task](https://github.com/redhat-appstudio/e2e-tests/pull/158/commits/8b608b8ef75064d5f38ba0356d23d7777e88a121)

For the `verify-enterprise-contract-v2` task we need to provide
`STRICT` and `IMAGES` parameters.

[feat: assert verify-enterprise-contract-v2 task](https://github.com/redhat-appstudio/e2e-tests/pull/158/commits/23c4a0750f7ad350bbf5ea036cef6887dc9115d1)

This adds assertions for the `verify-enterprise-contract-v2` task,
making sure it behaves much in the same way `verify-enterprise-contract`
task does.

## Issue ticket number and link

https://issues.redhat.com/browse/HACBS-762

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run the `ec` tests locally against a cluster in CRC, added unit tests.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated labels (if needed)
