### PR TITLE
fix: assertion in chains test

### DIFF
--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -234,7 +234,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec"), fu
 				Expect(err).NotTo(HaveOccurred())
 				printTaskRunStatus(tr, namespace, *fwk.CommonController)
 				GinkgoWriter.Printf("Make sure TaskRun %q has not suceeded\n", pr.Name)
-				Expect(tekton.DidTaskSucceed(tr)).To(BeFalse())
+				Expect(tekton.DidTaskSucceed(tr)).To(BeTrue())
 			})
 
 			It("fails when tests are not satisfied on strict mode", func() {


### PR DESCRIPTION
# Description

For this test we expect the TaskRun not to fail as it is running in
non-strict mode. This assertion was erroneously changed from `ToBeTrue`
to `ToBeFalse` in #151.

## Issue ticket number and link

https://issues.redhat.com/browse/HACBS-949

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run the test locally against CRC

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated labels (if needed)
