### PR TITLE
fix: Wait for Argo CD Role/RoleBindings on Namespace creation, and cleanup PipelineRuns on Namespace deletion

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -60,6 +60,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 
 			_, err = f.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
 
 			_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
@@ -71,7 +72,8 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 			// Create a component with Git Source URL being defined
 			_, err := f.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+
+			DeferCleanup(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
 		})
 
 		It("triggers a PipelineRun", func() {
@@ -270,7 +272,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 			_, err = f.HasController.GetHasApplication(applicationName, testNamespace)
 			// In case the app with the same name exist in the selected namespace, delete it first
 			if err == nil {
-				Expect(f.HasController.DeleteHasApplication(applicationName, testNamespace)).To(Succeed())
+				Expect(f.HasController.DeleteHasApplication(applicationName, testNamespace, false)).To(Succeed())
 				Eventually(func() bool {
 					_, err := f.HasController.GetHasApplication(applicationName, testNamespace)
 					return errors.IsNotFound(err)
@@ -292,7 +294,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 					}
 					_, err = f.CommonController.CreateConfigMap(hacbsBundleConfigMap, testNamespace)
 					Expect(err).ToNot(HaveOccurred())
-					DeferCleanup(f.CommonController.DeleteConfigMap, constants.BuildPipelinesConfigMapName, testNamespace)
+					DeferCleanup(f.CommonController.DeleteConfigMap, constants.BuildPipelinesConfigMapName, testNamespace, false)
 				} else {
 					Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, testNamespace, err))
 				}
@@ -332,8 +334,9 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 				// Clean up only Application CR (Component and Pipelines are included) in case we are targeting specific namespace
 				// Used e.g. in build-defintions e2e tests, where we are targeting build-templates-e2e namespace
 				if os.Getenv(constants.E2E_APPLICATIONS_NAMESPACE_ENV) != "" {
-					DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace)
+					DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace, false)
 				} else {
+					Expect(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(Succeed())
 					Expect(f.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
 				}
 			} else {
@@ -341,9 +344,10 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 				// an issue reported here: https://issues.redhat.com/browse/PLNSRVCE-484
 				// TODO: delete the whole 'else' block after the issue is resolved
 				if os.Getenv(constants.E2E_APPLICATIONS_NAMESPACE_ENV) != "" {
-					DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace)
+					DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace, false)
 				}
 			}
+
 		})
 
 		for i, gitUrl := range componentUrls {
@@ -444,10 +448,11 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 
 			_, err = f.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
 
 			_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace)
+			DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace, false)
 
 			componentName = fmt.Sprintf("build-suite-test-component-image-source-%s", util.GenerateRandomString(4))
 			outputContainerImage := ""
@@ -456,8 +461,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 			// Create a component with containerImageSource being defined
 			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, "", containerImageSource, outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
-
-			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+			DeferCleanup(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
 		})
 
 		It("should not trigger a PipelineRun", func() {
@@ -482,6 +486,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 
 			_, err = f.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
 
 			_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
@@ -497,12 +502,17 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 			outputContainerImage := fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
 			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
+			DeferCleanup(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
 
 			timeout = time.Second * 120
 			interval = time.Second * 1
 
-			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
 		})
+
+		// AfterAll(func() {
+		// 	f.CommonController.DeleteNamespace(testNamespace)
+		// })
+
 		It("should be referenced in a PipelineRun", Label("build-bundle-overriding"), func() {
 			Eventually(func() bool {
 				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
@@ -530,6 +540,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 
 			_, err = f.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
 
 			_, err := f.CommonController.GetSecret(testNamespace, constants.RegistryAuthSecretName)
 			if err != nil {
@@ -543,7 +554,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 
 			_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace)
+			DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace, false)
 
 			timeout = time.Minute * 2
 			interval = time.Second * 1
@@ -561,8 +572,8 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
 			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
+			DeferCleanup(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
 
-			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
 		})
 
 		It("should override the shared secret", func() {
@@ -615,11 +626,12 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 
 			_, err = f.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
 
 			_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
 
-			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
 		})
 
 		JustBeforeEach(func() {

--- a/tests/has/devfile_private_source.go
+++ b/tests/has/devfile_private_source.go
@@ -72,7 +72,7 @@ var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label(
 		err := framework.HasController.DeleteHasComponent(componentName, AppStudioE2EApplicationsNamespace)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = framework.HasController.DeleteHasApplication(applicationName, AppStudioE2EApplicationsNamespace)
+		err = framework.HasController.DeleteHasApplication(applicationName, AppStudioE2EApplicationsNamespace, false)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = framework.SPIController.DeleteSPIAccessTokenBinding(SPIAccessTokenBindingName, AppStudioE2EApplicationsNamespace)
@@ -84,6 +84,8 @@ var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label(
 
 			return framework.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
 		}, 1*time.Minute, 100*time.Millisecond).Should(BeFalse(), "Has controller didn't remove Red Hat AppStudio application gitops repository")
+
+		Expect(framework.CommonController.DeleteNamespace(AppStudioE2EApplicationsNamespace)).To(Succeed())
 	})
 
 	It("Create Red Hat AppStudio Application", func() {

--- a/tests/has/devfile_source.go
+++ b/tests/has/devfile_source.go
@@ -135,7 +135,7 @@ var _ = framework.HASSuiteDescribe("[test_id:01] devfile source", Label("has"), 
 	})
 
 	It("Check a Component gets deleted when its application is deleted", func() {
-		err = framework.HasController.DeleteHasApplication(applicationName, AppStudioE2EApplicationsNamespace)
+		err = framework.HasController.DeleteHasApplication(applicationName, AppStudioE2EApplicationsNamespace, false)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(func() bool {
 			_, err := framework.HasController.GetHasComponent(componentName, AppStudioE2EApplicationsNamespace)

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -58,7 +58,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 
 		_, err = f.HasController.CreateHasApplication(applicationName, appStudioE2EApplicationsNamespace)
 		Expect(err).NotTo(HaveOccurred())
-		DeferCleanup(f.HasController.DeleteHasApplication, applicationName, appStudioE2EApplicationsNamespace)
+		DeferCleanup(f.HasController.DeleteHasApplication, applicationName, appStudioE2EApplicationsNamespace, false)
 
 	})
 


### PR DESCRIPTION
# Description

This PR should fix intermittent issues seen with 'namespace is not managed' errors from Argo CD, as reported on [this PR](https://github.com/redhat-appstudio/infra-deployments/pull/415#issuecomment-1200940627) and elsewhere.
- This is caused by the OpenShift GitOps operator (not the GitOps Service) incorrectly handling `Namespace`s that are stuck in the 'Terminating' state. I will [follow up with the OpenShift GitOps team](https://issues.redhat.com/browse/GITOPS-2242) on the desired behaviour, here.
- Instead, this PR avoids this issue by ensuring that `PipelineRun`s (and their finalizers) are cleaned up before a `Namespace` is deleted.

See below for details of the fix.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This PR:
- When creating a test namespace (a namespace with `argocd.argoproj.io/managed-by` label), ensure that the OpenShift GitOps Operator has created the Role/RoleBinding in the Namespace. (The Role/Binding is what allows Argo CD to deploy to it.)
- Add `ListAllPipelineRuns` and `DeleteAllPipelineRunsInaSpecificNamespace` to help handle `PipelineRun` cleanup, when deleting a Namespace.
- Add additional cleanup of `PipelineRun`s and `Namespace`s in `build.go` tests
- If a namespace cannot be deleted (stuck in Terminating), report resources in the namespace that are blocking the deletion as part of the error string
- Add dynamic k8s client (used by above check)
- Update Delete functions to optionally ignore 'not found' errors, if attempting to delete a resource that doesn't exist.


# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have updated labels (if needed)
