### PR TITLE
fix: build: image repo protection test

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -632,8 +632,8 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 		})
 
 		AfterAll(func() {
-			f.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)
-			f.CommonController.DeleteNamespace(testNamespace)
+			Expect(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(Succeed())
+			Expect(f.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
 		})
 
 		JustBeforeEach(func() {

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -626,20 +626,19 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build"), 
 
 			_, err = f.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
-			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
-
 			_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			DeferCleanup(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
 
 		})
 
-		JustBeforeEach(func() {
+		AfterAll(func() {
+			f.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)
+			f.CommonController.DeleteNamespace(testNamespace)
+		})
 
+		JustBeforeEach(func() {
 			componentName = fmt.Sprintf("build-suite-test-component-image-url-%s", util.GenerateRandomString(4))
 			timeout = time.Second * 10
-
-			DeferCleanup(f.HasController.DeleteHasComponent, componentName, testNamespace)
 		})
 		It("should fail for ContainerImage field set to a protected repository (without an image tag)", func() {
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected", utils.GetQuayIOOrganization())


### PR DESCRIPTION
# Description

Follow-up PR on https://github.com/redhat-appstudio/e2e-tests/pull/161. Changes in that PR caused the "image repo protection" test flakey, because the new **pipelinerun** cleanup function conflicts with **component** cleanup function (which I removed in this PR)

## Issue ticket number and link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
```bash
# 10 clean test runs, no failure
for i in {1..10}; do echo $i && ginkgo --focus="Creating a component with a specific container image URL" --progress -v ./cmd -- --config-suites=/Users/psturc/work/redhat-appstudio/e2e-tests/tests/e2e-demos/config/default.yaml > /dev/null || echo ERROR; done
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated labels (if needed)
