### PR TITLE
fix: disable jvm-build-service tests temporarily

### DIFF
--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -1,323 +1,246 @@
 package build
 
-import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"time"
+// import (
+// 	"context"
+// 	"encoding/json"
+// 	"fmt"
+// 	"strings"
+// 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
+// 	"github.com/devfile/library/pkg/util"
+// 	"github.com/google/uuid"
+// 	. "github.com/onsi/ginkgo/v2"
+// 	. "github.com/onsi/gomega"
+// 	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
 
-	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
-	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
-	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+// 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
+// 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
+// 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	klog "k8s.io/klog/v2"
-	"knative.dev/pkg/apis"
-)
+// 	corev1 "k8s.io/api/core/v1"
+// 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+// 	klog "k8s.io/klog/v2"
+// 	"knative.dev/pkg/apis"
+// )
 
-var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jvm-build"), func() {
-	defer GinkgoRecover()
+// const (
+// 	testProjectGitUrl = "https://github.com/stuartwdouglas/hacbs-test-project"
+// 	// TODO update this
+// 	testProjectDevfileUrl = "https://raw.githubusercontent.com/psturc/shaded-java-app/main/devfile.yaml"
+// )
 
-	var appStudioE2EApplicationsNamespace, prGeneratedName string
-	var timeout, interval time.Duration
+// var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jvm-build"), func() {
+// 	defer GinkgoRecover()
 
-	var streamTektonYaml = func(url string) []byte {
-		resp, err := http.Get(url)
-		Expect(err).NotTo(HaveOccurred(), "error getting %s", url)
-		defer resp.Body.Close()
-		bytes, err := io.ReadAll(resp.Body)
-		Expect(err).NotTo(HaveOccurred(), "error getting bytes")
-		return bytes
-	}
+// 	var testNamespace, prGeneratedName, applicationName, componentName, outputContainerImage string
+// 	var timeout, interval time.Duration
 
-	f, err := framework.NewFramework()
-	Expect(err).NotTo(HaveOccurred())
+// 	f, err := framework.NewFramework()
+// 	Expect(err).NotTo(HaveOccurred())
 
-	// got panics in DeferCleanup when I tried to do multi param invocations, so following the pattern we used in openshift/origin
-	AfterAll(func() {
-		if CurrentSpecReport().Failed() {
-			// get jvm-build-service logs
-			jvmPodList, jerr := f.CommonController.K8sClient.KubeInterface().CoreV1().Pods("jvm-build-service").List(context.TODO(), metav1.ListOptions{})
-			if jerr != nil {
-				klog.Infof("error listing jvm-build-service pods: %s", jerr.Error())
-			}
-			klog.Infof("found %d pods in jvm-build-service namespace", len(jvmPodList.Items))
-			for _, pod := range jvmPodList.Items {
-				podLog := fmt.Sprintf("jvm-build-service namespace pod %s:\n", pod.Name)
-				containers := []corev1.Container{}
-				containers = append(containers, pod.Spec.InitContainers...)
-				containers = append(containers, pod.Spec.Containers...)
-				for _, c := range containers {
-					cLog, cerr := f.CommonController.GetContainerLogs(pod.Name, c.Name, pod.Namespace)
-					if cerr != nil {
-						klog.Infof("error getting logs for pod/container %s/%s: %s", pod.Name, c.Name, cerr.Error())
-						continue
-					}
-					podLog = fmt.Sprintf("%s\n%s\n", podLog, cLog)
-				}
-				klog.Info(podLog)
-			}
-			// let's make sure and print the pr that starts the analysis first
-			logs, err := f.TektonController.GetPipelineRunLogs(prGeneratedName, appStudioE2EApplicationsNamespace)
-			if err != nil {
-				klog.Infof("got error fetching PR logs: %s", err.Error())
-			}
-			klog.Infof("failed PR logs: %s", logs)
-			prList, err := f.TektonController.ListAllPipelineRuns(appStudioE2EApplicationsNamespace)
-			if err != nil {
-				klog.Infof("got error fetching PR list: %s", err.Error())
-			}
-			klog.Infof("total number of pipeline runs not pruned: %d", len(prList.Items))
-			for _, pr := range prList.Items {
-				if pr.Name == prGeneratedName {
-					continue
-				}
-				prLog, err := f.TektonController.GetPipelineRunLogs(pr.Name, pr.Namespace)
-				if err != nil {
-					klog.Infof("got error fetching PR logs for %s: %s", pr.Name, err.Error())
-				}
-				klog.Infof("pipeline run log for %s: %s", pr.Name, prLog)
-			}
-		}
-		abList, err := f.JvmbuildserviceController.ListArtifactBuilds(appStudioE2EApplicationsNamespace)
-		if err != nil {
-			klog.Infof("got error fetching artifactbuilds: %s", err.Error())
-		}
-		for _, ab := range abList.Items {
-			err := f.JvmbuildserviceController.DeleteArtifactBuild(ab.Name, ab.Namespace)
-			if err != nil {
-				klog.Infof("got error deleting AB %s: %s", ab.Name, err.Error())
-			}
-		}
-		dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(appStudioE2EApplicationsNamespace)
-		if err != nil {
-			klog.Infof("got error fetching dependencybuilds: %s", err.Error())
-		}
-		for _, db := range dbList.Items {
-			err := f.JvmbuildserviceController.DeleteDependencyBuild(db.Name, db.Namespace)
-			if err != nil {
-				klog.Infof("got error deleting DB %s: %s", db.Name, err.Error())
-			}
-		}
-		err = f.TektonController.DeletePipelineRun(prGeneratedName, appStudioE2EApplicationsNamespace)
-		if err != nil {
-			klog.Infof("error deleting pr %s: %s", prGeneratedName, err.Error())
-		}
-		err = f.TektonController.DeletePipeline("sample-component-build", appStudioE2EApplicationsNamespace)
-		if err != nil {
-			klog.Infof("error deleting pipeline sample-component-build: %s", err.Error())
-		}
-		err = f.TektonController.DeleteTask("maven", appStudioE2EApplicationsNamespace)
-		if err != nil {
-			klog.Infof("error deleting task maven: %s", err.Error())
-		}
-		err = f.TektonController.DeleteTask("git-clone", appStudioE2EApplicationsNamespace)
-		if err != nil {
-			klog.Infof("error deleting task git-clone", err.Error())
-		}
-	})
+// 	// got panics in DeferCleanup when I tried to do multi param invocations, so following the pattern we used in openshift/origin
+// 	AfterAll(func() {
+// 		if CurrentSpecReport().Failed() {
+// 			// get jvm-build-service logs
+// 			jvmPodList, jerr := f.CommonController.K8sClient.KubeInterface().CoreV1().Pods("jvm-build-service").List(context.TODO(), metav1.ListOptions{})
+// 			if jerr != nil {
+// 				klog.Infof("error listing jvm-build-service pods: %s", jerr.Error())
+// 			}
+// 			klog.Infof("found %d pods in jvm-build-service namespace", len(jvmPodList.Items))
+// 			for _, pod := range jvmPodList.Items {
+// 				podLog := fmt.Sprintf("jvm-build-service namespace pod %s:\n", pod.Name)
+// 				containers := []corev1.Container{}
+// 				containers = append(containers, pod.Spec.InitContainers...)
+// 				containers = append(containers, pod.Spec.Containers...)
+// 				for _, c := range containers {
+// 					cLog, cerr := f.CommonController.GetContainerLogs(pod.Name, c.Name, pod.Namespace)
+// 					if cerr != nil {
+// 						klog.Infof("error getting logs for pod/container %s/%s: %s", pod.Name, c.Name, cerr.Error())
+// 						continue
+// 					}
+// 					podLog = fmt.Sprintf("%s\n%s\n", podLog, cLog)
+// 				}
+// 				klog.Info(podLog)
+// 			}
+// 			// let's make sure and print the pr that starts the analysis first
+// 			logs, err := f.TektonController.GetPipelineRunLogs(prGeneratedName, testNamespace)
+// 			if err != nil {
+// 				klog.Infof("got error fetching PR logs: %s", err.Error())
+// 			}
+// 			klog.Infof("failed PR logs: %s", logs)
+// 			prList, err := f.TektonController.ListAllPipelineRuns(testNamespace)
+// 			if err != nil {
+// 				klog.Infof("got error fetching PR list: %s", err.Error())
+// 			}
+// 			klog.Infof("total number of pipeline runs not pruned: %d", len(prList.Items))
+// 			for _, pr := range prList.Items {
+// 				if pr.Name == prGeneratedName {
+// 					continue
+// 				}
+// 				prLog, err := f.TektonController.GetPipelineRunLogs(pr.Name, pr.Namespace)
+// 				if err != nil {
+// 					klog.Infof("got error fetching PR logs for %s: %s", pr.Name, err.Error())
+// 				}
+// 				klog.Infof("pipeline run log for %s: %s", pr.Name, prLog)
+// 			}
+// 		}
+// 		abList, err := f.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
+// 		if err != nil {
+// 			klog.Infof("got error fetching artifactbuilds: %s", err.Error())
+// 		}
+// 		for _, ab := range abList.Items {
+// 			err := f.JvmbuildserviceController.DeleteArtifactBuild(ab.Name, ab.Namespace)
+// 			if err != nil {
+// 				klog.Infof("got error deleting AB %s: %s", ab.Name, err.Error())
+// 			}
+// 		}
+// 		dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
+// 		if err != nil {
+// 			klog.Infof("got error fetching dependencybuilds: %s", err.Error())
+// 		}
+// 		for _, db := range dbList.Items {
+// 			err := f.JvmbuildserviceController.DeleteDependencyBuild(db.Name, db.Namespace)
+// 			if err != nil {
+// 				klog.Infof("got error deleting DB %s: %s", db.Name, err.Error())
+// 			}
+// 		}
+// 		err = f.TektonController.DeletePipelineRun(prGeneratedName, testNamespace)
+// 		if err != nil {
+// 			klog.Infof("error deleting pr %s: %s", prGeneratedName, err.Error())
+// 		}
+// 		err = f.TektonController.DeletePipeline("sample-component-build", testNamespace)
+// 		if err != nil {
+// 			klog.Infof("error deleting pipeline sample-component-build: %s", err.Error())
+// 		}
+// 		err = f.TektonController.DeleteTask("maven", testNamespace)
+// 		if err != nil {
+// 			klog.Infof("error deleting task maven: %s", err.Error())
+// 		}
+// 		err = f.TektonController.DeleteTask("git-clone", testNamespace)
+// 		if err != nil {
+// 			klog.Infof("error deleting task git-clone", err.Error())
+// 		}
+// 	})
 
-	BeforeAll(func() {
-		appStudioE2EApplicationsNamespace = utils.GetEnv(constants.E2E_APPLICATIONS_NAMESPACE_ENV, "appstudio-e2e-test")
+// 	BeforeAll(func() {
+// 		testNamespace = utils.GetEnv(constants.E2E_APPLICATIONS_NAMESPACE_ENV, "appstudio-e2e-test")
 
-		klog.Infof("Test namespace: %s", appStudioE2EApplicationsNamespace)
+// 		klog.Infof("Test namespace: %s", testNamespace)
 
-		_, err := f.CommonController.CreateTestNamespace(appStudioE2EApplicationsNamespace)
-		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", appStudioE2EApplicationsNamespace, err)
+// 		_, err := f.CommonController.CreateTestNamespace(testNamespace)
+// 		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
 
-		timeout = time.Minute * 10
-		interval = time.Second * 10
+// 		timeout = time.Minute * 10
+// 		interval = time.Second * 10
 
-		decodingScheme := runtime.NewScheme()
-		utilruntime.Must(v1beta1.AddToScheme(decodingScheme))
-		decoderCodecFactory := serializer.NewCodecFactory(decodingScheme)
-		decoder := decoderCodecFactory.UniversalDecoder(v1beta1.SchemeGroupVersion)
+// 		applicationName = fmt.Sprintf("jvm-build-suite-application-%s", util.GenerateRandomString(4))
+// 		_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
+// 		Expect(err).NotTo(HaveOccurred())
 
-		gitCloneTaskBytes := streamTektonYaml("https://raw.githubusercontent.com/redhat-appstudio/build-definitions/main/tasks/git-clone.yaml")
-		gitClone := &v1beta1.Task{}
-		err = runtime.DecodeInto(decoder, gitCloneTaskBytes, gitClone)
-		Expect(err).NotTo(HaveOccurred(), "error converting git clone yaml to task obj")
-		err = f.TektonController.DeleteTask(gitClone.Name, appStudioE2EApplicationsNamespace)
-		if err != nil && !errors.IsNotFound(err) {
-			Expect(err).NotTo(HaveOccurred(), "error deleting git-clone task")
-		}
-		_, err = f.TektonController.CreateTask(gitClone, appStudioE2EApplicationsNamespace)
-		Expect(err).NotTo(HaveOccurred(), "error creating git clone task")
+// 		componentName = fmt.Sprintf("jvm-build-suite-component-%s", util.GenerateRandomString(4))
+// 		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
 
-		mavenLocation := "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/deploy/base/maven-v0.2.yaml"
-		prOwner := os.Getenv("JVM_BUILD_SERVICE_PR_OWNER")
-		prCommit := os.Getenv("JVM_BUILD_SERVICE_PR_SHA")
-		if len(prOwner) > 0 && len(prCommit) > 0 {
-			mavenLocation = fmt.Sprintf("https://raw.githubusercontent.com/%s/jvm-build-service/%s/deploy/base/maven-v0.2.yaml", prOwner, prCommit)
-		}
-		klog.Infof("fetching maven def from %s", mavenLocation)
-		mavenData := streamTektonYaml(mavenLocation)
-		maven := &v1beta1.Task{}
-		err = runtime.DecodeInto(decoder, mavenData, maven)
-		Expect(err).NotTo(HaveOccurred(), "error creating maven task")
-		// override images if needed
-		analyserImage := os.Getenv("JVM_BUILD_SERVICE_ANALYZER_IMAGE")
-		if len(analyserImage) > 0 {
-			klog.Infof("PR analyzer image: %s", analyserImage)
-			for _, step := range maven.Spec.Steps {
-				if step.Name != "analyse-dependencies" {
-					continue
-				}
-				klog.Infof("Updating analyse-dependencies step with image %s", analyserImage)
-				step.Image = analyserImage
-			}
-		}
-		sidecarImage := os.Getenv("JVM_BUILD_SERVICE_SIDECAR_IMAGE")
-		if len(sidecarImage) > 0 {
-			klog.Infof("PR sidecar image: %s", sidecarImage)
-			for _, sidecar := range maven.Spec.Sidecars {
-				if sidecar.Name != "proxy" {
-					continue
-				}
-				klog.Infof("Updating proxy sidecar with image %s", sidecarImage)
-				sidecar.Image = sidecarImage
-			}
-		}
+// 		// Create a component with Git Source URL being defined
+// 		_, err = f.HasController.CreateComponentFromDevfile(applicationName, componentName, testNamespace, testProjectGitUrl, testProjectDevfileUrl, "", outputContainerImage, "")
+// 		Expect(err).ShouldNot(HaveOccurred())
 
-		err = f.TektonController.DeleteTask("maven", appStudioE2EApplicationsNamespace)
-		if err != nil && !errors.IsNotFound(err) {
-			Expect(err).NotTo(HaveOccurred(), "error cleaning up maven task before create")
-		}
-		_, err = f.TektonController.CreateTask(maven, appStudioE2EApplicationsNamespace)
-		Expect(err).NotTo(HaveOccurred(), "error creating maven task")
+// 		DeferCleanup(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
+// 	})
 
-		pipelineLocation := "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/hack/examples/pipeline.yaml"
-		if len(prOwner) > 0 && len(prCommit) > 0 {
-			pipelineLocation = fmt.Sprintf("https://raw.githubusercontent.com/%s/jvm-build-service/%s/hack/examples/pipeline.yaml", prOwner, prCommit)
-		}
-		klog.Infof("fetching pipeline def from %s", pipelineLocation)
-		pipelineData := streamTektonYaml(pipelineLocation)
-		pipeline := &v1beta1.Pipeline{}
-		err = runtime.DecodeInto(decoder, pipelineData, pipeline)
-		Expect(err).NotTo(HaveOccurred(), "error decoding pipeline")
+// 	When("the Component with s2i-java component is created", func() {
+// 		It("a PipelineRun is triggered", func() {
+// 			Eventually(func() bool {
+// 				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
+// 				if err != nil {
+// 					klog.Infoln("PipelineRun has not been created yet")
+// 					return false
+// 				}
+// 				return pipelineRun.HasStarted()
+// 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
+// 		})
 
-		err = f.TektonController.DeletePipeline(pipeline.Name, appStudioE2EApplicationsNamespace)
-		if err != nil && !errors.IsNotFound(err) {
-			Expect(err).NotTo(HaveOccurred(), "error cleaning up build pipeline before create")
-		}
-		_, err = f.TektonController.CreatePipeline(pipeline, appStudioE2EApplicationsNamespace)
-		Expect(err).NotTo(HaveOccurred(), "error creating build pipeline")
+// 		It("that PipelineRun completes successfully", func() {
+// 			Eventually(func() bool {
+// 				pr, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
+// 				if err != nil {
+// 					klog.Infof("get of pr %s returned error: %s", prGeneratedName, err.Error())
+// 					return false
+// 				}
+// 				if !pr.IsDone() {
+// 					klog.Infof("pipeline run %s not done", pr.Name)
+// 					return false
+// 				}
+// 				if !pr.GetStatusCondition().GetCondition(apis.ConditionSucceeded).IsTrue() {
+// 					// just because the condition succeeded is not set does not mean it won't be soon
+// 					prBytes, err := json.MarshalIndent(pr, "", "  ")
+// 					if err != nil {
+// 						klog.Infof("problem marshalling failed pipelinerun to bytes: %s", err.Error())
+// 						return false
+// 					}
+// 					klog.Infof("not yet successful pipeline run: %s", string(prBytes))
+// 					return false
+// 				}
+// 				return true
+// 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the pipeline run to complete")
+// 		})
+// 		It("artifactbuilds and dependencybuilds are generated", func() {
+// 			Eventually(func() bool {
+// 				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
+// 				if err != nil {
+// 					klog.Infof("error listing artifactbuilds: %s", err.Error())
+// 					return false
+// 				}
+// 				gotABs := false
+// 				if len(abList.Items) > 0 {
+// 					gotABs = true
+// 				}
+// 				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
+// 				if err != nil {
+// 					klog.Infof("error listing dependencybuilds: %s", err.Error())
+// 					return false
+// 				}
+// 				gotDBs := false
+// 				if len(dbList.Items) > 0 {
+// 					gotDBs = true
+// 				}
+// 				if gotABs && gotDBs {
+// 					return true
+// 				}
+// 				return false
+// 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the generation of artifactbuilds and dependencybuilds")
+// 		})
 
-		runLocation := "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/hack/examples/run-e2e-shaded-app.yaml"
-		if len(prOwner) > 0 && len(prCommit) > 0 {
-			runLocation = fmt.Sprintf("https://raw.githubusercontent.com/%s/jvm-build-service/%s/hack/examples/run-e2e-shaded-app.yaml", prOwner, prCommit)
-		}
-		klog.Infof("fetching pipelinerun def from %s", runLocation)
-		runData := streamTektonYaml(runLocation)
-		run := &v1beta1.PipelineRun{}
-		err = runtime.DecodeInto(decoder, runData, run)
-		Expect(err).NotTo(HaveOccurred(), "error decoding build pipelinerun")
-
-		// since we use generated name no need to cleanup before create
-		run, err = f.TektonController.CreatePipelineRun(run, appStudioE2EApplicationsNamespace)
-		Expect(err).NotTo(HaveOccurred(), "error creating build pipelinerun")
-		prGeneratedName = run.Name
-
-		klog.Infof("Generated pipeline run %s", prGeneratedName)
-	})
-
-	When("pipelinerun with the appropriate jvm-build-service repository analysis are launched", func() {
-
-		It("those pipeline runs complete successfully", func() {
-			Eventually(func() bool {
-				pr, err := f.TektonController.GetPipelineRun(prGeneratedName, appStudioE2EApplicationsNamespace)
-				if err != nil {
-					klog.Infof("get of pr %s returned error: %s", prGeneratedName, err.Error())
-					return false
-				}
-				if !pr.IsDone() {
-					klog.Infof("pipeline run %s not done", pr.Name)
-					return false
-				}
-				if !pr.GetStatusCondition().GetCondition(apis.ConditionSucceeded).IsTrue() {
-					// just because the condition succeeded is not set does not mean it won't be soon
-					prBytes, err := json.MarshalIndent(pr, "", "  ")
-					if err != nil {
-						klog.Infof("problem marshalling failed pipelinerun to bytes: %s", err.Error())
-						return false
-					}
-					klog.Infof("not yet successful pipeline run: %s", string(prBytes))
-					return false
-				}
-				return true
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the pipeline run to complete")
-		})
-		It("that artifactbuilds and dependencybuilds are generated", func() {
-			Eventually(func() bool {
-				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(appStudioE2EApplicationsNamespace)
-				if err != nil {
-					klog.Infof("error listing artifactbuilds: %s", err.Error())
-					return false
-				}
-				gotABs := false
-				if len(abList.Items) > 0 {
-					gotABs = true
-				}
-				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(appStudioE2EApplicationsNamespace)
-				if err != nil {
-					klog.Infof("error listing dependencybuilds: %s", err.Error())
-					return false
-				}
-				gotDBs := false
-				if len(dbList.Items) > 0 {
-					gotDBs = true
-				}
-				if gotABs && gotDBs {
-					return true
-				}
-				return false
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the generation of artifactbuilds and dependencybuilds")
-		})
-
-		It("that some artifactbuilds and dependencybuilds complete", func() {
-			Eventually(func() bool {
-				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(appStudioE2EApplicationsNamespace)
-				if err != nil {
-					klog.Infof("error listing artifactbuilds: %s", err.Error())
-					return false
-				}
-				abComplete := false
-				for _, ab := range abList.Items {
-					if ab.Status.State == v1alpha1.ArtifactBuildStateComplete {
-						abComplete = true
-						break
-					}
-				}
-				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(appStudioE2EApplicationsNamespace)
-				if err != nil {
-					klog.Infof("error listing dependencybuilds: %s", err.Error())
-					return false
-				}
-				dbComplete := false
-				for _, db := range dbList.Items {
-					if db.Status.State == v1alpha1.DependencyBuildStateComplete {
-						dbComplete = true
-						break
-					}
-				}
-				if abComplete && dbComplete {
-					return true
-				}
-				return false
-			}, 2*timeout, interval).Should(BeTrue(), "timed out waiting for some artifactbuilds/dependencybuilds to complete")
-		})
-	})
-})
+// 		It("some artifactbuilds and dependencybuilds complete", func() {
+// 			Eventually(func() bool {
+// 				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
+// 				if err != nil {
+// 					klog.Infof("error listing artifactbuilds: %s", err.Error())
+// 					return false
+// 				}
+// 				abComplete := false
+// 				for _, ab := range abList.Items {
+// 					if ab.Status.State == v1alpha1.ArtifactBuildStateComplete {
+// 						abComplete = true
+// 						break
+// 					}
+// 				}
+// 				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
+// 				if err != nil {
+// 					klog.Infof("error listing dependencybuilds: %s", err.Error())
+// 					return false
+// 				}
+// 				dbComplete := false
+// 				for _, db := range dbList.Items {
+// 					if db.Status.State == v1alpha1.DependencyBuildStateComplete {
+// 						dbComplete = true
+// 						break
+// 					}
+// 				}
+// 				if abComplete && dbComplete {
+// 					return true
+// 				}
+// 				return false
+// 			}, 2*timeout, interval).Should(BeTrue(), "timed out waiting for some artifactbuilds/dependencybuilds to complete")
+// 		})
+// 	})
+// })


### PR DESCRIPTION
# Description

temporarily disable jvm-build-service test because of this issue
```
[ERROR] Plugin org.apache.maven.plugins:maven-shade-plugin:3.2.4 or one of its dependencies could not be resolved: Failed to read artifact descriptor for org.apache.maven.plugins:maven-shade-plugin:jar:3.2.4: Could not transfer artifact org.apache.maven.plugins:maven-shade-plugin:pom:3.2.4 from/to mirror.default (http://localhost:2000/maven2): Transfer failed for http://localhost:2000/maven2/org/apache/maven/plugins/maven-shade-plugin/3.2.4/maven-shade-plugin-3.2.4.pom 500 Internal Server Error -> [Help 1]
```

## Issue ticket number and link
https://issues.redhat.com/browse/PLNSRVCE-533

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
ginkgo --focus="jvm-build-service" --progress -v ./cmd -- --config-suites=/Users/psturc/work/redhat-appstudio/e2e-tests/tests/e2e-demos/config/default.yaml
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated labels (if needed)
