### PR TITLE
fix: Fix the jvm build service tests

### DIFF
--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -33,6 +33,7 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 
 	var appStudioE2EApplicationsNamespace, prGeneratedName string
 	var timeout, interval time.Duration
+	var userConfigMapName = "jvm-build-config"
 
 	var streamTektonYaml = func(url string) []byte {
 		resp, err := http.Get(url)
@@ -128,6 +129,10 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 		if err != nil {
 			klog.Infof("error deleting task git-clone", err.Error())
 		}
+		err = f.CommonController.DeleteConfigMap(userConfigMapName, appStudioE2EApplicationsNamespace, true)
+		if err != nil {
+			klog.Infof("error deleting user configmap", err.Error())
+		}
 	})
 
 	BeforeAll(func() {
@@ -145,6 +150,19 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 		utilruntime.Must(v1beta1.AddToScheme(decodingScheme))
 		decoderCodecFactory := serializer.NewCodecFactory(decodingScheme)
 		decoder := decoderCodecFactory.UniversalDecoder(v1beta1.SchemeGroupVersion)
+
+		userConfigMap := corev1.ConfigMap{
+			Data: map[string]string{
+				"enable-rebuilds": "true",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: userConfigMapName,
+			},
+		}
+		_, err = f.CommonController.CreateConfigMap(&userConfigMap, appStudioE2EApplicationsNamespace)
+		if err != nil {
+			Expect(err).NotTo(HaveOccurred(), "error creating the user configmap")
+		}
 
 		gitCloneTaskBytes := streamTektonYaml("https://raw.githubusercontent.com/redhat-appstudio/build-definitions/main/tasks/git-clone.yaml")
 		gitClone := &v1beta1.Task{}

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
+	"io"
+	"net/http"
+	"os"
 	"time"
 
-	"github.com/devfile/library/pkg/util"
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
@@ -16,24 +16,32 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	klog "k8s.io/klog/v2"
 	"knative.dev/pkg/apis"
 )
 
-const (
-	testProjectGitUrl = "https://github.com/stuartwdouglas/hacbs-test-project"
-	// TODO update this
-	testProjectDevfileUrl = "https://raw.githubusercontent.com/psturc/shaded-java-app/main/devfile.yaml"
-)
-
-var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Pending, Label("jvm-build"), func() {
+var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jvm-build"), func() {
 	defer GinkgoRecover()
 
-	var testNamespace, prGeneratedName, applicationName, componentName, outputContainerImage string
+	var appStudioE2EApplicationsNamespace, prGeneratedName string
 	var timeout, interval time.Duration
+
+	var streamTektonYaml = func(url string) []byte {
+		resp, err := http.Get(url)
+		Expect(err).NotTo(HaveOccurred(), "error getting %s", url)
+		defer resp.Body.Close()
+		bytes, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred(), "error getting bytes")
+		return bytes
+	}
 
 	f, err := framework.NewFramework()
 	Expect(err).NotTo(HaveOccurred())
@@ -63,12 +71,12 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Pending, 
 				klog.Info(podLog)
 			}
 			// let's make sure and print the pr that starts the analysis first
-			logs, err := f.TektonController.GetPipelineRunLogs(prGeneratedName, testNamespace)
+			logs, err := f.TektonController.GetPipelineRunLogs(prGeneratedName, appStudioE2EApplicationsNamespace)
 			if err != nil {
 				klog.Infof("got error fetching PR logs: %s", err.Error())
 			}
 			klog.Infof("failed PR logs: %s", logs)
-			prList, err := f.TektonController.ListAllPipelineRuns(testNamespace)
+			prList, err := f.TektonController.ListAllPipelineRuns(appStudioE2EApplicationsNamespace)
 			if err != nil {
 				klog.Infof("got error fetching PR list: %s", err.Error())
 			}
@@ -84,7 +92,7 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Pending, 
 				klog.Infof("pipeline run log for %s: %s", pr.Name, prLog)
 			}
 		}
-		abList, err := f.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
+		abList, err := f.JvmbuildserviceController.ListArtifactBuilds(appStudioE2EApplicationsNamespace)
 		if err != nil {
 			klog.Infof("got error fetching artifactbuilds: %s", err.Error())
 		}
@@ -94,7 +102,7 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Pending, 
 				klog.Infof("got error deleting AB %s: %s", ab.Name, err.Error())
 			}
 		}
-		dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
+		dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(appStudioE2EApplicationsNamespace)
 		if err != nil {
 			klog.Infof("got error fetching dependencybuilds: %s", err.Error())
 		}
@@ -104,64 +112,133 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Pending, 
 				klog.Infof("got error deleting DB %s: %s", db.Name, err.Error())
 			}
 		}
-		err = f.TektonController.DeletePipelineRun(prGeneratedName, testNamespace)
+		err = f.TektonController.DeletePipelineRun(prGeneratedName, appStudioE2EApplicationsNamespace)
 		if err != nil {
 			klog.Infof("error deleting pr %s: %s", prGeneratedName, err.Error())
 		}
-		err = f.TektonController.DeletePipeline("sample-component-build", testNamespace)
+		err = f.TektonController.DeletePipeline("sample-component-build", appStudioE2EApplicationsNamespace)
 		if err != nil {
 			klog.Infof("error deleting pipeline sample-component-build: %s", err.Error())
 		}
-		err = f.TektonController.DeleteTask("maven", testNamespace)
+		err = f.TektonController.DeleteTask("maven", appStudioE2EApplicationsNamespace)
 		if err != nil {
 			klog.Infof("error deleting task maven: %s", err.Error())
 		}
-		err = f.TektonController.DeleteTask("git-clone", testNamespace)
+		err = f.TektonController.DeleteTask("git-clone", appStudioE2EApplicationsNamespace)
 		if err != nil {
 			klog.Infof("error deleting task git-clone", err.Error())
 		}
 	})
 
 	BeforeAll(func() {
-		testNamespace = utils.GetEnv(constants.E2E_APPLICATIONS_NAMESPACE_ENV, "appstudio-e2e-test")
+		appStudioE2EApplicationsNamespace = utils.GetEnv(constants.E2E_APPLICATIONS_NAMESPACE_ENV, "appstudio-e2e-test")
 
-		klog.Infof("Test namespace: %s", testNamespace)
+		klog.Infof("Test namespace: %s", appStudioE2EApplicationsNamespace)
 
-		_, err := f.CommonController.CreateTestNamespace(testNamespace)
-		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+		_, err := f.CommonController.CreateTestNamespace(appStudioE2EApplicationsNamespace)
+		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", appStudioE2EApplicationsNamespace, err)
 
 		timeout = time.Minute * 10
 		interval = time.Second * 10
 
-		applicationName = fmt.Sprintf("jvm-build-suite-application-%s", util.GenerateRandomString(4))
-		_, err = f.HasController.CreateHasApplication(applicationName, testNamespace)
-		Expect(err).NotTo(HaveOccurred())
+		decodingScheme := runtime.NewScheme()
+		utilruntime.Must(v1beta1.AddToScheme(decodingScheme))
+		decoderCodecFactory := serializer.NewCodecFactory(decodingScheme)
+		decoder := decoderCodecFactory.UniversalDecoder(v1beta1.SchemeGroupVersion)
 
-		componentName = fmt.Sprintf("jvm-build-suite-component-%s", util.GenerateRandomString(4))
-		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+		gitCloneTaskBytes := streamTektonYaml("https://raw.githubusercontent.com/redhat-appstudio/build-definitions/main/tasks/git-clone.yaml")
+		gitClone := &v1beta1.Task{}
+		err = runtime.DecodeInto(decoder, gitCloneTaskBytes, gitClone)
+		Expect(err).NotTo(HaveOccurred(), "error converting git clone yaml to task obj")
+		err = f.TektonController.DeleteTask(gitClone.Name, appStudioE2EApplicationsNamespace)
+		if err != nil && !errors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred(), "error deleting git-clone task")
+		}
+		_, err = f.TektonController.CreateTask(gitClone, appStudioE2EApplicationsNamespace)
+		Expect(err).NotTo(HaveOccurred(), "error creating git clone task")
 
-		// Create a component with Git Source URL being defined
-		_, err = f.HasController.CreateComponentFromDevfile(applicationName, componentName, testNamespace, testProjectGitUrl, testProjectDevfileUrl, "", outputContainerImage, "")
-		Expect(err).ShouldNot(HaveOccurred())
+		mavenLocation := "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/deploy/base/maven-v0.2.yaml"
+		prOwner := os.Getenv("JVM_BUILD_SERVICE_PR_OWNER")
+		prCommit := os.Getenv("JVM_BUILD_SERVICE_PR_SHA")
+		if len(prOwner) > 0 && len(prCommit) > 0 {
+			mavenLocation = fmt.Sprintf("https://raw.githubusercontent.com/%s/jvm-build-service/%s/deploy/base/maven-v0.2.yaml", prOwner, prCommit)
+		}
+		klog.Infof("fetching maven def from %s", mavenLocation)
+		mavenData := streamTektonYaml(mavenLocation)
+		maven := &v1beta1.Task{}
+		err = runtime.DecodeInto(decoder, mavenData, maven)
+		Expect(err).NotTo(HaveOccurred(), "error creating maven task")
+		// override images if needed
+		analyserImage := os.Getenv("JVM_BUILD_SERVICE_ANALYZER_IMAGE")
+		if len(analyserImage) > 0 {
+			klog.Infof("PR analyzer image: %s", analyserImage)
+			for _, step := range maven.Spec.Steps {
+				if step.Name != "analyse-dependencies" {
+					continue
+				}
+				klog.Infof("Updating analyse-dependencies step with image %s", analyserImage)
+				step.Image = analyserImage
+			}
+		}
+		sidecarImage := os.Getenv("JVM_BUILD_SERVICE_SIDECAR_IMAGE")
+		if len(sidecarImage) > 0 {
+			klog.Infof("PR sidecar image: %s", sidecarImage)
+			for _, sidecar := range maven.Spec.Sidecars {
+				if sidecar.Name != "proxy" {
+					continue
+				}
+				klog.Infof("Updating proxy sidecar with image %s", sidecarImage)
+				sidecar.Image = sidecarImage
+			}
+		}
 
-		DeferCleanup(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
+		err = f.TektonController.DeleteTask("maven", appStudioE2EApplicationsNamespace)
+		if err != nil && !errors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred(), "error cleaning up maven task before create")
+		}
+		_, err = f.TektonController.CreateTask(maven, appStudioE2EApplicationsNamespace)
+		Expect(err).NotTo(HaveOccurred(), "error creating maven task")
+
+		pipelineLocation := "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/hack/examples/pipeline.yaml"
+		if len(prOwner) > 0 && len(prCommit) > 0 {
+			pipelineLocation = fmt.Sprintf("https://raw.githubusercontent.com/%s/jvm-build-service/%s/hack/examples/pipeline.yaml", prOwner, prCommit)
+		}
+		klog.Infof("fetching pipeline def from %s", pipelineLocation)
+		pipelineData := streamTektonYaml(pipelineLocation)
+		pipeline := &v1beta1.Pipeline{}
+		err = runtime.DecodeInto(decoder, pipelineData, pipeline)
+		Expect(err).NotTo(HaveOccurred(), "error decoding pipeline")
+
+		err = f.TektonController.DeletePipeline(pipeline.Name, appStudioE2EApplicationsNamespace)
+		if err != nil && !errors.IsNotFound(err) {
+			Expect(err).NotTo(HaveOccurred(), "error cleaning up build pipeline before create")
+		}
+		_, err = f.TektonController.CreatePipeline(pipeline, appStudioE2EApplicationsNamespace)
+		Expect(err).NotTo(HaveOccurred(), "error creating build pipeline")
+
+		runLocation := "https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/main/hack/examples/run-e2e-shaded-app.yaml"
+		if len(prOwner) > 0 && len(prCommit) > 0 {
+			runLocation = fmt.Sprintf("https://raw.githubusercontent.com/%s/jvm-build-service/%s/hack/examples/run-e2e-shaded-app.yaml", prOwner, prCommit)
+		}
+		klog.Infof("fetching pipelinerun def from %s", runLocation)
+		runData := streamTektonYaml(runLocation)
+		run := &v1beta1.PipelineRun{}
+		err = runtime.DecodeInto(decoder, runData, run)
+		Expect(err).NotTo(HaveOccurred(), "error decoding build pipelinerun")
+
+		// since we use generated name no need to cleanup before create
+		run, err = f.TektonController.CreatePipelineRun(run, appStudioE2EApplicationsNamespace)
+		Expect(err).NotTo(HaveOccurred(), "error creating build pipelinerun")
+		prGeneratedName = run.Name
+
+		klog.Infof("Generated pipeline run %s", prGeneratedName)
 	})
 
-	When("the Component with s2i-java component is created", func() {
-		It("a PipelineRun is triggered", func() {
-			Eventually(func() bool {
-				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
-				if err != nil {
-					klog.Infoln("PipelineRun has not been created yet")
-					return false
-				}
-				return pipelineRun.HasStarted()
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
-		})
+	When("pipelinerun with the appropriate jvm-build-service repository analysis are launched", func() {
 
-		It("that PipelineRun completes successfully", func() {
+		It("those pipeline runs complete successfully", func() {
 			Eventually(func() bool {
-				pr, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false)
+				pr, err := f.TektonController.GetPipelineRun(prGeneratedName, appStudioE2EApplicationsNamespace)
 				if err != nil {
 					klog.Infof("get of pr %s returned error: %s", prGeneratedName, err.Error())
 					return false
@@ -183,9 +260,9 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Pending, 
 				return true
 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the pipeline run to complete")
 		})
-		It("artifactbuilds and dependencybuilds are generated", func() {
+		It("that artifactbuilds and dependencybuilds are generated", func() {
 			Eventually(func() bool {
-				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
+				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(appStudioE2EApplicationsNamespace)
 				if err != nil {
 					klog.Infof("error listing artifactbuilds: %s", err.Error())
 					return false
@@ -194,7 +271,7 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Pending, 
 				if len(abList.Items) > 0 {
 					gotABs = true
 				}
-				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
+				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(appStudioE2EApplicationsNamespace)
 				if err != nil {
 					klog.Infof("error listing dependencybuilds: %s", err.Error())
 					return false
@@ -210,9 +287,9 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Pending, 
 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the generation of artifactbuilds and dependencybuilds")
 		})
 
-		It("some artifactbuilds and dependencybuilds complete", func() {
+		It("that some artifactbuilds and dependencybuilds complete", func() {
 			Eventually(func() bool {
-				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
+				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(appStudioE2EApplicationsNamespace)
 				if err != nil {
 					klog.Infof("error listing artifactbuilds: %s", err.Error())
 					return false
@@ -224,7 +301,7 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Pending, 
 						break
 					}
 				}
-				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
+				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(appStudioE2EApplicationsNamespace)
 				if err != nil {
 					klog.Infof("error listing dependencybuilds: %s", err.Error())
 					return false


### PR DESCRIPTION
# Description

Recent changes in the jvm-build-service allowed the artifact cache to run per specific namespace, as opposed to always run in the jvm-build-service namespace (see https://github.com/redhat-appstudio/jvm-build-service/pull/105).

This PR creates a configmap in the test namespace that will configure the cache service and fix the issues of timeouts that are happening with the test suite. 

We're also reverting the change that was introduced in #165, since that needs https://github.com/redhat-appstudio/build-definitions/pull/179 to work.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested in a private cluster.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated labels (if needed)
