### PR TITLE
fix: comment out jvm tests yet again

### DIFF
--- a/pkg/utils/tekton/controller.go
+++ b/pkg/utils/tekton/controller.go
@@ -3,7 +3,7 @@ package tekton
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"regexp"
 	"strings"
 	"time"
@@ -110,7 +110,7 @@ func (s *SuiteController) fetchContainerLog(podName, containerName, namespace st
 		return log, err
 	}
 	defer readCloser.Close()
-	b, err := ioutil.ReadAll(readCloser)
+	b, err := io.ReadAll(readCloser)
 	if err != nil {
 		return log, err
 	}

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -1,6 +1,6 @@
 package build
 
-import (
+/*import (
 	"context"
 	"encoding/json"
 	"fmt"
@@ -339,3 +339,4 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 		})
 	})
 })
+*/

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -1,6 +1,6 @@
 package build
 
-/*import (
+import (
 	"context"
 	"encoding/json"
 	"fmt"
@@ -28,7 +28,7 @@ package build
 	"knative.dev/pkg/apis"
 )
 
-var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jvm-build"), func() {
+var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Pending, Label("jvm-build"), func() {
 	defer GinkgoRecover()
 
 	var appStudioE2EApplicationsNamespace, prGeneratedName string
@@ -339,4 +339,3 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 		})
 	})
 })
-*/


### PR DESCRIPTION
# Description

Still seeing intermittent failures in jvm build tests; best guess from the failed runs I have seen today is pruning of deleting completed ab's / db's before we can count them, but currently there is not logic in the jvm build service controller to generate logs or events when it does prune.

see https://github.com/redhat-appstudio/infra-deployments/pull/581 for example

I'll be crafting a PR to address the logging for future debug.  Of course pruning logging might in fact steer us in another direction if it proves this is not pruning, and we'll have to go from there.

But this may be the sign to pursue minimally the next iteration on pruning, or the throttling approach (at least for the time being) that @stuartwdouglas and I have discussed, in the upcoming sprint 10

@Michkov @brunoapimentel @psturc 

now, if this is truly an infrequent/intermittent flake, maybe we live with it - we'll see what everyone else says; I have hit it twice this afternoon US Eastern

depending what the status of things is when Europe starts their Tuesday, I suspect we'll want to merge this

## Issue ticket number and link

## Type of change

- [ /] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated labels (if needed)
