### PR TITLE
feat: Remove verify-enterprise-contract (v1) task

### DIFF
--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -181,9 +181,6 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec"), fu
 							GitRepository: &policySource,
 						},
 					},
-					Exceptions: &ecp.EnterpriseContractPolicyExceptions{
-						NonBlocking: []string{}, // verify-enterprise-contract-v1 will fail unless we have something here
-					},
 				}
 				Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, baselinePolicies)).To(Succeed())
 				printPolicyConfiguration(baselinePolicies)
@@ -210,17 +207,8 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec"), fu
 				// Refresh our copy of the PipelineRun for latest results
 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
 				Expect(err).NotTo(HaveOccurred())
-				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract")
-				Expect(err).NotTo(HaveOccurred())
-				printTaskRunStatus(tr, namespace, *fwk.CommonController)
-				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s suceeded\n", tr.PipelineTaskName, pr.Name)
-				Expect(tekton.DidTaskSucceed(tr)).To(BeTrue())
-				GinkgoWriter.Printf("Make sure EC-v1 results for PipelineRun %s are passing\n", pr.Name)
-				Expect(tr.Status.TaskRunResults).Should(ContainElements(
-					tekton.MatchTaskRunResult("PASSED", "true"),
-				))
 
-				tr, err = kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
+				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
 				Expect(err).NotTo(HaveOccurred())
 				printTaskRunStatus(tr, namespace, *fwk.CommonController)
 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s suceeded\n", tr.PipelineTaskName, pr.Name)
@@ -240,17 +228,8 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec"), fu
 				// Refresh our copy of the PipelineRun for latest results
 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
 				Expect(err).NotTo(HaveOccurred())
-				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract")
-				Expect(err).NotTo(HaveOccurred())
-				printTaskRunStatus(tr, namespace, *fwk.CommonController)
-				GinkgoWriter.Printf("Make sure TaskRun %q has not failed\n", pr.Name)
-				Expect(tekton.DidTaskSucceed(tr)).To(BeTrue())
-				GinkgoWriter.Printf("Make sure EC-v1 results for PipelineRun %s has failed\n", pr.Name)
-				Expect(tr.Status.TaskRunResults).Should(ContainElements(
-					tekton.MatchTaskRunResult("PASSED", "false"),
-				))
 
-				tr, err = kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
+				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
 				Expect(err).NotTo(HaveOccurred())
 				printTaskRunStatus(tr, namespace, *fwk.CommonController)
 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s suceeded\n", tr.PipelineTaskName, pr.Name)
@@ -270,18 +249,13 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec"), fu
 				// Refresh our copy of the PipelineRun for latest results
 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
 				Expect(err).NotTo(HaveOccurred())
-				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract")
-				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Printf("Task run status %#v\n", tr.Status)
-				GinkgoWriter.Printf("Make sure pipeline %q has not suceeded\n", pr.Name)
-				Expect(tekton.DidTaskSucceed(tr)).To(BeFalse())
-				// Because the task fails, no results are created
 
-				tr, err = kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
+				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
 				Expect(err).NotTo(HaveOccurred())
 				printTaskRunStatus(tr, namespace, *fwk.CommonController)
 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s failed\n", tr.PipelineTaskName, pr.Name)
 				Expect(tekton.DidTaskSucceed(tr)).To(BeFalse())
+				// Because the task fails, no results are created
 			})
 
 			It("fails when unexpected signature is used", func() {
@@ -302,17 +276,13 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec"), fu
 				// Refresh our copy of the PipelineRun for latest results
 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
 				Expect(err).NotTo(HaveOccurred())
-				GinkgoWriter.Printf("Make sure pipeline %q has failed\n", pr.Name)
-				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(tr.Status.GetCondition("Succeeded").IsTrue()).To(BeFalse())
-				// Because the task fails, no results are created
 
-				tr, err = kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
+				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
 				Expect(err).NotTo(HaveOccurred())
 				printTaskRunStatus(tr, namespace, *fwk.CommonController)
 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s failed\n", tr.PipelineTaskName, pr.Name)
 				Expect(tekton.DidTaskSucceed(tr)).To(BeFalse())
+				// Because the task fails, no results are created
 			})
 		})
 


### PR DESCRIPTION
# Description

This task is now deprecated and should no longer be used.

https://issues.redhat.com/browse/HACBS-536

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Arguably neither since it removes deprecated code. Marked as "new feature" since it's the least incorrect option IMO.

# How Has This Been Tested?

I tested this against my development cluster. I ran the Chains test suite in two modes: the first with the current `e2e-ec` pipeline, and the second with a modified version of `e2e-ec` that does remove the v1 task. Tests were successful (as expected) in both cases.

Once this change is merged, I'll update the `e2e-ec` pipeline to remove the v1 task which should require no changes here.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated labels (if needed)
