### PR TITLE
feat: Run chains tests on dedicated namespace

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -14,8 +14,11 @@ const (
 	// The private devfile sample git repository to use in certain HAS e2e tests
 	PRIVATE_DEVFILE_SAMPLE string = "PRIVATE_DEVFILE_SAMPLE" // #nosec
 
-	//The Tekton namespace
+	// The Tekton Chains namespace
 	TEKTON_CHAINS_NS string = "tekton-chains" // #nosec
+
+	// Namespace for running the end-to-end Tekton Chains tests
+	TEKTON_CHAINS_E2E_NS string = "tekton-chains-e2e"
 
 	//base64 Encoded docker config json value to create registry pull secret
 	DOCKER_CONFIG_JSON string = "DOCKER_CONFIG_JSON"

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -59,13 +59,14 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec"), fu
 	})
 
 	Context("test creating and signing an image and task", func() {
-		// Make the TaskRun name and namespace predictable. For convenience, the name of the
-		// TaskRun that builds an image, is the same as the repository where the image is
+		// Make the PipelineRun name and namespace predictable. For convenience, the name of the
+		// PipelineRun that builds an image, is the same as the repository where the image is
 		// pushed to.
-		namespace := constants.TEKTON_CHAINS_NS
+		namespace := constants.TEKTON_CHAINS_E2E_NS
 		buildPipelineRunName := fmt.Sprintf("buildah-demo-%s", util.GenerateRandomString(10))
 		image := fmt.Sprintf("image-registry.openshift-image-registry.svc:5000/%s/%s", namespace, buildPipelineRunName)
 		var imageWithDigest string
+		serviceAccountName := "pipeline"
 
 		pipelineRunTimeout := 360
 		attestationTimeout := time.Duration(60) * time.Second
@@ -78,8 +79,20 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec"), fu
 			kubeController = tekton.KubeController{
 				Commonctrl: *fwk.CommonController,
 				Tektonctrl: *fwk.TektonController,
-				Namespace:  constants.TEKTON_CHAINS_NS,
+				Namespace:  namespace,
 			}
+
+			// Create the e2e test namespace
+			_, err := kubeController.Commonctrl.CreateTestNamespace(namespace)
+			Expect(err).NotTo(HaveOccurred(), "Error when creating namespace %q: %v", namespace, err)
+
+			// Wait until the "pipeline" SA is created
+			GinkgoWriter.Printf("Wait until the %q SA is created in namespace %q\n", serviceAccountName, namespace)
+			Eventually(func() bool {
+				sa, err := kubeController.Commonctrl.GetServiceAccount(serviceAccountName, namespace)
+				return sa != nil && err == nil
+			}).WithTimeout(1*time.Minute).WithPolling(100*time.Millisecond).Should(
+				BeTrue(), "timed out when waiting for the %q SA to be created", serviceAccountName)
 
 			// the default policy source
 			rev := "main"
@@ -150,9 +163,9 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec"), fu
 				// Copy the public key from tekton-chains/signing-secrets to a new
 				// secret that contains just the public key to ensure that access
 				// to password and private key are not needed.
-				publicKey, err := kubeController.GetPublicKey("signing-secrets", "tekton-chains")
+				publicKey, err := kubeController.GetPublicKey("signing-secrets", constants.TEKTON_CHAINS_NS)
 				Expect(err).ToNot(HaveOccurred())
-				GinkgoWriter.Println("Copy public key from tekton-chains/signing-secrets to a new secret")
+				GinkgoWriter.Printf("Copy public key from %s/signing-secrets to a new secret\n", constants.TEKTON_CHAINS_NS)
 				Expect(kubeController.CreateOrUpdateSigningSecret(
 					publicKey, publicSecretName, namespace)).To(Succeed())
 


### PR DESCRIPTION
# Description

Currently, the Tekton Chains e2e tests run multiple Pipelines in the tekton-chains namespace. This adds clutter to that namespace which makes it harder to debug Tekton Chains issues. This commit uses a dedicated namespace for executing these tests.

## Issue ticket number and link
https://issues.redhat.com/browse/HACBS-777

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested this against my development cluster.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated labels (if needed)
