### PR TITLE
fix: jvm-build: improve logging, failure handling

### DIFF
--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -13,8 +13,8 @@ import (
 	_ "github.com/redhat-appstudio/e2e-tests/tests/cluster-registration"
 	_ "github.com/redhat-appstudio/e2e-tests/tests/e2e-demos"
 	_ "github.com/redhat-appstudio/e2e-tests/tests/has"
-	_ "github.com/redhat-appstudio/e2e-tests/tests/release"
 	_ "github.com/redhat-appstudio/e2e-tests/tests/integration-service"
+	_ "github.com/redhat-appstudio/e2e-tests/tests/release"
 
 	"flag"
 

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -121,7 +121,7 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 				if err != nil {
 					klog.Infof("error when marshalling content of %s from %s namespace: %+v", ab.Name, ab.Namespace, err)
 				} else {
-					filename := fmt.Sprintf("%s-ab-%s.yaml", ab.Namespace, ab.Name)
+					filename := fmt.Sprintf("%s-ab-%s.json", ab.Namespace, ab.Name)
 					toDebug[filename] = string(v)
 				}
 			}
@@ -130,7 +130,7 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 				if err != nil {
 					klog.Infof("error when marshalling content of %s from %s namespace: %+v", db.Name, db.Namespace, err)
 				} else {
-					filename := fmt.Sprintf("%s-db-%s.yaml", db.Namespace, db.Name)
+					filename := fmt.Sprintf("%s-db-%s.json", db.Namespace, db.Name)
 					toDebug[filename] = string(v)
 				}
 			}

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -86,7 +86,8 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 						klog.Infof("error getting logs for pod/container %s/%s: %s", pod.Name, c.Name, cerr.Error())
 						continue
 					}
-					toDebug["jvm-build-service-pod-"+pod.Name+"-"+c.Name+".log"] = cLog
+					filename := fmt.Sprintf("%s-pod-%s-%s.log", pod.Namespace, pod.Name, c.Name)
+					toDebug[filename] = cLog
 				}
 			}
 			// let's make sure and print the pr that starts the analysis first
@@ -95,7 +96,8 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 			if err != nil {
 				klog.Infof("got error fetching PR logs: %s", err.Error())
 			}
-			toDebug[testNamespace+"-pr-"+componentPipelineRun.Name+".log"] = logs
+			filename := fmt.Sprintf("%s-pr-%s.log", testNamespace, componentPipelineRun.Name)
+			toDebug[filename] = logs
 
 			prList, err := f.TektonController.ListAllPipelineRuns(testNamespace)
 			if err != nil {
@@ -110,7 +112,8 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 				if err != nil {
 					klog.Infof("got error fetching PR logs for %s: %s", pr.Name, err.Error())
 				}
-				toDebug[pr.Namespace+"-pr-"+pr.Name+".log"] = prLog
+				filename := fmt.Sprintf("%s-pr-%s.log", pr.Namespace, pr.Name)
+				toDebug[filename] = prLog
 			}
 
 			for _, ab := range abList.Items {
@@ -118,7 +121,8 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 				if err != nil {
 					klog.Infof("error when marshalling content of %s from %s namespace: %+v", ab.Name, ab.Namespace, err)
 				} else {
-					toDebug[ab.Namespace+"-ab-"+ab.Name+".yaml"] = string(v)
+					filename := fmt.Sprintf("%s-ab-%s.yaml", ab.Namespace, ab.Name)
+					toDebug[filename] = string(v)
 				}
 			}
 			for _, db := range dbList.Items {
@@ -126,7 +130,8 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 				if err != nil {
 					klog.Infof("error when marshalling content of %s from %s namespace: %+v", db.Name, db.Namespace, err)
 				} else {
-					toDebug[db.Namespace+"-db-"+db.Name+".yaml"] = string(v)
+					filename := fmt.Sprintf("%s-db-%s.yaml", db.Namespace, db.Name)
+					toDebug[filename] = string(v)
 				}
 			}
 


### PR DESCRIPTION
# Description

Follow-up on a discussion about analysing jvm-build-service failure

Couple of improvements
* store logs and CR contents in files if $ARTIFACT_DIR env var is not empty
* log the content of artifactBuilds and dependecyBuilds CRs
* in case the component PipelineRun is finished (`pr.IsDone() == true`), fail immediately if its condition != succeeded

## Issue ticket number and link
https://issues.redhat.com/browse/PLNSRVCE-533

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Set up the test environment in a wrong way, for example don't create a pull secret in build-templates namespace and run
```bash
# The logs and CR contents should be printed out (stdout)
ginkgo --focus="jvm-build-service" --progress -v ./cmd -- --config-suites=/path/to/e2e-tests/tests/e2e-demos/config/default.yaml
# All logs and CR contents should be stored in `$PWD/artifacts/jvm-build-service-test`
export ARTIFACT_DIR="${PWD}/artifacts"
ginkgo --focus="jvm-build-service" --progress -v ./cmd -- --config-suites=/path/to/e2e-tests/tests/e2e-demos/config/default.yaml
```

![Screenshot 2022-08-25 at 14 42 46](https://user-images.githubusercontent.com/4881144/186667626-7d7929da-acec-499f-9dea-7cc7c2936672.png)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated labels (if needed)
