### PR TITLE
fix: JVM Build Service Tests

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -58,4 +58,7 @@ const (
 	OSAPIServerWorkload  string = "apiserver"
 
 	RegistryAuthSecretName = "redhat-appstudio-registry-pull-secret"
+
+	JVMUserConfigMapName = "jvm-build-config"
+	JVMEnableRebuilds    = "enable-rebuilds"
 )


### PR DESCRIPTION
# Description

The JVM build service tests don't actually create the config map to enable rebuilds. 

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

CI will test it.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated labels (if needed)
