### PR TITLE
fix: load policies from the policy directory

### DIFF
--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -97,7 +97,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec"), fu
 			// the default policy source
 			rev := "main"
 			policySource = ecp.GitPolicySource{
-				Repository: "https://github.com/hacbs-contract/ec-policies.git",
+				Repository: "https://github.com/hacbs-contract/ec-policies/policy",
 				Revision:   &rev,
 			}
 


### PR DESCRIPTION
# Description

We don't want to load policies from directories outside of the `policy` directory in the `ec-policies` repository.

## Issue ticket number and link

https://issues.redhat.com/browse/HACBS-1125

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Reproduced the problem locally and tested with this modified configuration, see https://issues.redhat.com/browse/HACBS-1125 for details.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated labels (if needed)
