### PR TITLE
fix: build: avoid creating conflicts in test repo

### DIFF
--- a/pkg/apis/github/repositories.go
+++ b/pkg/apis/github/repositories.go
@@ -18,7 +18,22 @@ func (g *Github) CheckIfRepositoryExist(repository string) bool {
 	return resp.StatusCode == 200
 }
 
-func (g *Github) UpdateFile(repository, pathToFile, newContent, branchName string) (*github.RepositoryContentResponse, error) {
+func (g *Github) CreateFile(repository, pathToFile, fileContent, branchName string) (*github.RepositoryContentResponse, error) {
+	opts := &github.RepositoryContentFileOptions{
+		Message: github.String("e2e test commit message"),
+		Content: []byte(fileContent),
+		Branch:  github.String(branchName),
+	}
+
+	file, _, err := g.client.Repositories.CreateFile(context.Background(), g.organization, repository, pathToFile, opts)
+	if err != nil {
+		return nil, fmt.Errorf("error when creating file contents: %v", err)
+	}
+
+	return file, nil
+}
+
+func (g *Github) GetFile(repository, pathToFile, branchName string) (*github.RepositoryContent, error) {
 	opts := &github.RepositoryContentGetOptions{}
 	if branchName != "" {
 		opts.Ref = fmt.Sprintf("heads/%s", branchName)
@@ -27,10 +42,18 @@ func (g *Github) UpdateFile(repository, pathToFile, newContent, branchName strin
 	if err != nil {
 		return nil, fmt.Errorf("error when listing file contents: %v", err)
 	}
-	fileSha := file.GetSHA()
+
+	return file, nil
+}
+
+func (g *Github) UpdateFile(repository, pathToFile, newContent, branchName, fileSHA string) (*github.RepositoryContentResponse, error) {
+	opts := &github.RepositoryContentGetOptions{}
+	if branchName != "" {
+		opts.Ref = fmt.Sprintf("heads/%s", branchName)
+	}
 	newFileContent := &github.RepositoryContentFileOptions{
 		Message: github.String("e2e test commit message"),
-		SHA:     github.String(fileSha),
+		SHA:     github.String(fileSHA),
 		Content: []byte(newContent),
 		Branch:  github.String(branchName),
 	}

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -92,6 +92,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			pacInitTestFiles := []string{
 				fmt.Sprintf(".tekton/%s-pull-request.yaml", componentName),
 				fmt.Sprintf(".tekton/%s-push.yaml", componentName),
+				fmt.Sprintf(".tekton/%s-readme.md", componentName),
 			}
 
 			for _, file := range pacInitTestFiles {
@@ -200,16 +201,16 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		When("the PaC init branch is updated", func() {
 
 			var branchUpdateTimestamp time.Time
-			var updatedFileSHA string
+			var createdFileSHA string
 
 			BeforeAll(func() {
-
+				fileToCreatePath := fmt.Sprintf(".tekton/%s-readme.md", componentName)
 				branchUpdateTimestamp = time.Now()
-				updatedFile, err := f.CommonController.Github.UpdateFile(helloWorldComponentGitSourceRepoName, "README.md", fmt.Sprintf("test PaC branch %s update", pacBranchName), pacBranchName)
+				createdFile, err := f.CommonController.Github.CreateFile(helloWorldComponentGitSourceRepoName, fileToCreatePath, fmt.Sprintf("test PaC branch %s update", pacBranchName), pacBranchName)
 				Expect(err).NotTo(HaveOccurred())
 
-				updatedFileSHA = updatedFile.GetSHA()
-				klog.Infoln("updated file sha:", updatedFileSHA)
+				createdFileSHA = createdFile.GetSHA()
+				klog.Infoln("created file sha:", createdFileSHA)
 
 			})
 
@@ -218,7 +219,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 1
 
 				Eventually(func() bool {
-					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, updatedFileSHA)
+					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, createdFileSHA)
 					if err != nil {
 						klog.Infoln("PipelineRun has not been created yet")
 						return false
@@ -231,7 +232,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 10
 
 				Eventually(func() bool {
-					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, updatedFileSHA)
+					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, createdFileSHA)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, condition := range pipelineRun.Status.Conditions {


### PR DESCRIPTION
# Description

Previously the "PaC build test" was set up in a way that it might have created merge conflicts by updating the [README.md file](https://github.com/redhat-appstudio-qe/devfile-sample-hello-world/blob/main/README.md) if there was another instance of the same test running at the same time

This PR solves this issue by creating a new file in the branch (which name is unique for each test instance): `.tekton/<component-unique-name>-readme.md`

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated labels (if needed)
