### PR TITLE
feat: centralized config for sending webhooks

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -243,15 +243,17 @@ func (CI) isPRPairingRequired() bool {
 }
 
 func (CI) sendWebhook() error {
-	// TODO we will need to distinguish between webhookTargets for AppStudio QE and HACBS QE
-	const saltSecret = "123456789"
-	const webhookTarget = "https://smee.io/JgVqn2oYFPY1CF"
+	// AppStudio QE webhook configuration values will be used by default (if none are provided via env vars)
+	const appstudioQESaltSecret = "123456789"
+	const appstudioQEWebhookTargetURL = "https://smee.io/JgVqn2oYFPY1CF"
 
 	var repoURL string
 
 	var repoOwner = os.Getenv("REPO_OWNER")
 	var repoName = os.Getenv("REPO_NAME")
 	var prNumber = os.Getenv("PULL_NUMBER")
+	var saltSecret = utils.GetEnv("WEBHOOK_SALT_SECRET", appstudioQESaltSecret)
+	var webhookTargetURL = utils.GetEnv("WEBHOOK_TARGET_URL", appstudioQEWebhookTargetURL)
 
 	if strings.Contains(jobName, "hacbs-e2e-periodic") {
 		// TODO configure webhook channel for sending HACBS test results
@@ -284,7 +286,7 @@ func (CI) sendWebhook() error {
 		},
 		RepositoryURL: repoURL,
 	}
-	resp, err := wh.CreateAndSend(saltSecret, webhookTarget)
+	resp, err := wh.CreateAndSend(saltSecret, webhookTargetURL)
 	if err != nil {
 		return fmt.Errorf("error sending webhook: %+v", err)
 	}

--- a/magefiles/types.go
+++ b/magefiles/types.go
@@ -9,6 +9,7 @@ type OpenshiftJobSpec struct {
 	Refs Refs `json:"refs"`
 }
 type Refs struct {
+	RepoLink     string `json:"repo_link"`
 	Repo         string `json:"repo"`
 	Organization string `json:"org"`
 	Pulls        []Pull `json:"pulls"`
@@ -46,4 +47,17 @@ type PullRequestMetadata struct {
 	CommitSHA    string
 	Number       int
 	RemoteName   string
+}
+
+// Webhook struct used for sending webhooks to https://smee.io/
+type Webhook struct {
+	Path          string `json:"path"`
+	RepositoryURL string `json:"repository_url"`
+	Repository    `json:"repository"`
+}
+
+// Repository struct - part of Webhook struct
+type Repository struct {
+	FullName   string `json:"full_name"`
+	PullNumber string `json:"pull_number"`
 }

--- a/magefiles/types.go
+++ b/magefiles/types.go
@@ -48,16 +48,3 @@ type PullRequestMetadata struct {
 	Number       int
 	RemoteName   string
 }
-
-// Webhook struct used for sending webhooks to https://smee.io/
-type Webhook struct {
-	Path          string `json:"path"`
-	RepositoryURL string `json:"repository_url"`
-	Repository    `json:"repository"`
-}
-
-// Repository struct - part of Webhook struct
-type Repository struct {
-	FullName   string `json:"full_name"`
-	PullNumber string `json:"pull_number"`
-}

--- a/magefiles/webhook.go
+++ b/magefiles/webhook.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"github.com/averageflow/gohooks/v2/gohooks"
+	"net/http"
+)
+
+// Webhook struct used for sending webhooks to https://smee.io/
+type Webhook struct {
+	Path          string `json:"path"`
+	RepositoryURL string `json:"repository_url"`
+	Repository    `json:"repository"`
+}
+
+// Repository struct - part of Webhook struct
+type Repository struct {
+	FullName   string `json:"full_name"`
+	PullNumber string `json:"pull_number"`
+}
+
+func (w *Webhook) CreateAndSend(saltSecret, webhookTarget string) (*http.Response, error) {
+	hook := &gohooks.GoHook{}
+	hook.Create(w, w.Path, saltSecret)
+	resp, err := hook.Send(webhookTarget)
+	if err != nil {
+		return nil, fmt.Errorf("error sending webhook: %+v", err)
+	}
+	return resp, nil
+}


### PR DESCRIPTION
# Description

Enable sending webhooks via centralized script (using mage)

With this change merged, webhooks should be send with every PR created for e2e-tests repo. It will also allow sending webhook with appstudio periodic e2e job once we update the job definition in openshift/release repo to use centralized scripts.
It will ignore sending webhooks for: hacbs e2e periodic job, PRs in openshift/release repo (so called rehearsal jobs)

Follow-up PR: https://github.com/redhat-appstudio/e2e-tests/pull/205

## Issue ticket number and link
https://issues.redhat.com/browse/HACBS-988

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Let's see how it works in CI

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated labels (if needed)
