### PR TITLE
fix: condition for E2E_TESTS_COMMIT_SHA env var

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -218,11 +218,14 @@ func (CI) createOpenshiftUser() error {
 }
 
 func BootstrapCluster() error {
-	envVars := map[string]string{
+	envVars := map[string]string{}
+
+	if os.Getenv("CI") == "true" && os.Getenv("REPO_NAME") == "e2e-tests" {
 		// Some scripts in infra-deployments repo are referencing scripts/utils in e2e-tests repo
 		// This env var allows to test changes introduced in "e2e-tests" repo PRs in CI
-		"E2E_TESTS_COMMIT_SHA": utils.GetEnv("PULL_PULL_SHA", "main"),
+		envVars["E2E_TESTS_COMMIT_SHA"] = os.Getenv("PULL_PULL_SHA")
 	}
+
 	return sh.RunWith(envVars, "./scripts/install-appstudio.sh")
 }
 

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -34,7 +34,7 @@ var (
 	testProjectRevision = utils.GetEnv("JVM_BUILD_SERVICE_TEST_REPO_REVISION", "main")
 )
 
-var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jvm-build", "HACBS"), func() {
+var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jvm-build", "HACBS"), Pending, func() {
 	defer GinkgoRecover()
 
 	var testNamespace, applicationName, componentName, outputContainerImage string


### PR DESCRIPTION
# Description
PR jobs for components that are using centralized scripts (build-service, application-service etc) were passing the env var `E2E_TESTS_COMMIT_SHA` to the bootstrap script, whilst this env vars should be provided only for e2e-tests PRs

This PR also contains a change that makes the jvm-build suite to be skipped ([as suggested to do so in the comment](https://github.com/redhat-appstudio/e2e-tests/pull/208#issuecomment-1259449579))

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated labels (if needed)
