### PR TITLE
fix: remove e2e tests for disabled SAST tasks

### DIFF
--- a/pkg/utils/build/hacbs.go
+++ b/pkg/utils/build/hacbs.go
@@ -57,20 +57,6 @@ func ValidateTaskRunResults(taskname string, result string) bool {
 	if err != nil {
 		Fail(fmt.Sprintf("Taskrun '%s' has failed with '%s'", taskname, err))
 	}
-	// If the test result isn't either SUCCESS or SKIPPED, the overall outcome is a failure
-	if taskname == "sast-go" {
-		if !(testOutput["result"] == "SUCCESS" || testOutput["result"] == "SKIPPED") {
-			Fail(fmt.Sprintf("Expected Result for Taskrun '%s' is SUCCESS, failed with '%s'", taskname, testOutput["failures"]))
-		}
-		return true
-	}
-	// If the test result isn't either SUCCESS or SKIPPED, the overall outcome is a failure
-	if taskname == "sast-java-sec-check" {
-		if !(testOutput["result"] == "SUCCESS" || testOutput["result"] == "SKIPPED") {
-			Fail(fmt.Sprintf("Expected Result for Taskrun '%s' is SUCCESS, failed with '%s'", taskname, testOutput["failures"]))
-		}
-		return true
-	}
 	// conftest-clair taskruns are expected to FAIL
 	if taskname == "conftest-clair" {
 		if testOutput["result"] == "FAILURE" {

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -536,7 +536,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 			It("should validate HACBS taskrun results", func() {
 				// List Of Taskruns Expected to Get Taskrun Results
-				gatherResult := []string{"conftest-clair", "sanity-inspect-image", "sanity-label-check", "sast-go", "sast-java-sec-check"}
+				gatherResult := []string{"conftest-clair", "sanity-inspect-image", "sanity-label-check"}
 				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false, "")
 				Expect(err).ShouldNot(HaveOccurred())
 


### PR DESCRIPTION
* Remove the sast-go and sast-java-sec-check tests

Signed-off-by: dirgim <kpavic@redhat.com>

# Description

This change removes the sast-go and sast-java-sec-check e2e tests because they've been disabled in the HACBS build pipeline.

## Issue ticket number and link
[HACBS-1072](https://issues.redhat.com/browse/HACBS-1072)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
