### PR TITLE
Don't change pipeline bundle name

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -390,7 +390,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 					bundlePullSpec := defaultBundleConfigMap.Data["default_build_bundle"]
 					hacbsBundleConfigMap := &v1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
-						Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
+						Data:       map[string]string{"default_build_bundle": bundlePullSpec},
 					}
 					_, err = f.CommonController.CreateConfigMap(hacbsBundleConfigMap, testNamespace)
 					Expect(err).ToNot(HaveOccurred())
@@ -402,7 +402,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				bundlePullSpec := customBundleConfigMap.Data["default_build_bundle"]
 				hacbsBundleConfigMap := &v1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
-					Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
+					Data:       map[string]string{"default_build_bundle": bundlePullSpec},
 				}
 
 				_, err = f.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -185,7 +185,7 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 				bundlePullSpec := defaultBundleConfigMap.Data["default_build_bundle"]
 				hacbsBundleConfigMap := &v1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
-					Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
+					Data:       map[string]string{"default_build_bundle": bundlePullSpec},
 				}
 				_, err = f.CommonController.CreateConfigMap(hacbsBundleConfigMap, testNamespace)
 				Expect(err).ToNot(HaveOccurred())
@@ -197,7 +197,7 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 			bundlePullSpec := customBundleConfigMap.Data["default_build_bundle"]
 			hacbsBundleConfigMap := &v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
-				Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
+				Data:       map[string]string{"default_build_bundle": bundlePullSpec},
 			}
 
 			_, err = f.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)


### PR DESCRIPTION
This is related to build-definitions#226. Pipeline bundle name will not include any word specific to appstudio or hacbs.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
