### PR TITLE
fix: RHPD-557 use volumeClaim Template instead of persistentVolumeClaim

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -19,6 +19,10 @@ spec:
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
   workspaces:
     - name: workspace
-      persistentVolumeClaim:
-        claimName: app-studio-default-workspace
-      subPath: e2e-tests-check-{{ revision }}
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -23,6 +23,10 @@ spec:
     bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
   workspaces:
     - name: workspace
-      persistentVolumeClaim:
-        claimName: app-studio-default-workspace
-      subPath: e2e-tests-push-{{ revision }}
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi


### PR DESCRIPTION
Signed-off-by: Radim Hopp <rhopp@redhat.com>

# Description

Using single PVC for all pipeline runs of PR checks (and post merge checks) does not scale (some artifacts are not deleted for some reason). Switching to using separate PVC for each run should solve this problem.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

It wasnt. Should be tested as part of the PR check.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [x] I have updated labels (if needed)
