### PR TITLE
refactor: add controllers for workspaces & ocp

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,25 +91,13 @@ are in the [infra-deployments](https://github.com/redhat-appstudio/infra-deploym
 ## Building and running the e2e tests
 You can use scripts to build and run the tests:
    ```bash
+      export CLUSTER_KUBECONFIG=/path/to/workload/cluster/kubeconfig
+      # WORKSPACE_ID=abc assumes workspaces have the suffix -abc
+      # i.e. appstudio-abc, redhat-hacbs-abc etc.
+      # if empty, workspaces without suffix are expected, i.e. appstudio, redhat-hacbs etc.
+      export WORKSPACE_ID=<ID>
+      go mod vendor
       make local/test/e2e
-   ```
-Or build and run the tests without scripts:
-1. Install dependencies and build the tests:
-
-   ``` bash
-   # Install dependencies
-   $ go mod tidy
-   # Copy the dependencies to vendor folder
-   $ go mod vendor
-   # Create `e2e-appstudio` binary in bin folder. Please add the binary to the path or just execute `./bin/e2e-appstudio`
-   $ make build
-   ```
-
-2. Run the e2e tests:
-The `e2e-appstudio` command is the root command that executes all test functionality. To obtain all available flags for the binary please use `--help` flags. All ginkgo flags and go tests are available in `e2e-appstudio` binary.
-
-   ```bash
-    `./bin/e2e-appstudio`
    ```
 
 The instructions for every test suite can be found in the [tests folder](tests), e.g. [has Readme.md](tests/has/README.md). 

--- a/cmd/loadTests.go
+++ b/cmd/loadTests.go
@@ -97,7 +97,7 @@ func setup(cmd *cobra.Command, args []string) {
 	if len(token) == 0 {
 		token, err = auth.GetTokenFromOC()
 		if err != nil {
-			tokenRequestURI, err := auth.GetTokenRequestURI(framework.CommonController.KubeRest()) // authorization.FindTokenRequestURI(framework.CommonController.KubeRest())
+			tokenRequestURI, err := auth.GetTokenRequestURI(framework.Cluster.CommonController.KubeRest()) // authorization.FindTokenRequestURI(framework.CommonController.KubeRest())
 			if err != nil {
 				klog.Fatalf("a token is required to capture metrics, use oc login to log into the cluster: %v", err)
 			}
@@ -105,9 +105,9 @@ func setup(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	metricsInstance := metrics.NewEmpty(term, framework.CommonController.KubeRest(), 5*time.Minute)
+	metricsInstance := metrics.NewEmpty(term, framework.Cluster.CommonController.KubeRest(), 5*time.Minute)
 
-	prometheusClient := metrics.GetPrometheusClient(term, framework.CommonController.KubeRest(), token)
+	prometheusClient := metrics.GetPrometheusClient(term, framework.Cluster.CommonController.KubeRest(), token)
 
 	metricsInstance.AddQueries(
 		queries.QueryClusterCPUUtilisation(prometheusClient),
@@ -154,13 +154,13 @@ func setup(cmd *cobra.Command, args []string) {
 		for AppStudioUsersBar.Incr() {
 			startTime := time.Now()
 			username := fmt.Sprintf("%s-%04d", usernamePrefix, AppStudioUsersBar.Current())
-			if err := users.Create(framework.CommonController.KubeRest(), username, constants.HostOperatorNamespace, constants.MemberOperatorNamespace); err != nil {
+			if err := users.Create(framework.Cluster.CommonController.KubeRest(), username, constants.HostOperatorNamespace, constants.MemberOperatorNamespace); err != nil {
 				klog.Fatalf("failed to provision user '%s'", username)
 				klog.Errorf(err.Error())
 			}
 			if AppStudioUsersBar.Current()%userBatches == 0 {
 				for i := AppStudioUsersBar.Current() - userBatches + 1; i < AppStudioUsersBar.Current(); i++ {
-					if err := wait.ForNamespace(framework.CommonController.KubeRest(), username); err != nil {
+					if err := wait.ForNamespace(framework.Cluster.CommonController.KubeRest(), username); err != nil {
 						klog.Fatalf("failed to find namespace '%s'", username)
 						klog.Errorf(err.Error())
 					}
@@ -180,7 +180,7 @@ func setup(cmd *cobra.Command, args []string) {
 		for ResourcesBar.Incr() {
 			startTime := time.Now()
 			username := fmt.Sprintf("%s-%04d", usernamePrefix, ResourcesBar.Current())
-			_, errors := framework.CommonController.CreateRegistryAuthSecret(
+			_, errors := framework.Cluster.CommonController.CreateRegistryAuthSecret(
 				"redhat-appstudio-registry-pull-secret",
 				username,
 				utils.GetDockerConfigJson(),
@@ -190,16 +190,16 @@ func setup(cmd *cobra.Command, args []string) {
 			}
 			// time.Sleep(time.Second * 2)
 			ApplicationName := fmt.Sprintf("%s-app", username)
-			app, err := framework.HasController.CreateHasApplication(ApplicationName, username)
+			app, err := framework.Appstudio.HasController.CreateHasApplication(ApplicationName, username)
 			if err != nil {
 				klog.Fatalf("Problem Creating the Application: %v", err)
 			}
-			if err := utils.WaitUntil(framework.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second); err != nil {
+			if err := utils.WaitUntil(framework.Appstudio.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second); err != nil {
 				klog.Fatalf("timed out waiting for application gitops repo to be created: %v", err)
 			}
 			ComponentName := fmt.Sprintf("%s-component", username)
 			ComponentContainerImage := fmt.Sprintf("image-registry.openshift-image-registry.svc:5000/%s/devfile-sample-code-with-quarkus:%s", username, strings.Replace(uuid.New().String(), "-", "", -1))
-			component, err := framework.HasController.CreateComponent(
+			component, err := framework.Appstudio.HasController.CreateComponent(
 				ApplicationName,
 				ComponentName,
 				username,
@@ -238,7 +238,7 @@ func setup(cmd *cobra.Command, args []string) {
 				DefaultRetryInterval := time.Millisecond * 200
 				DefaultTimeout := time.Minute * 17
 				error := k8swait.Poll(DefaultRetryInterval, DefaultTimeout, func() (done bool, err error) {
-					pipelineRun, err := framework.HasController.GetComponentPipelineRun(ComponentName, ApplicationName, username, false, "")
+					pipelineRun, err := framework.Appstudio.HasController.GetComponentPipelineRun(ComponentName, ApplicationName, username, false, "")
 					if err != nil {
 						return false, err
 					}

--- a/cmd/loadTests.go
+++ b/cmd/loadTests.go
@@ -97,7 +97,7 @@ func setup(cmd *cobra.Command, args []string) {
 	if len(token) == 0 {
 		token, err = auth.GetTokenFromOC()
 		if err != nil {
-			tokenRequestURI, err := auth.GetTokenRequestURI(framework.Cluster.CommonController.KubeRest()) // authorization.FindTokenRequestURI(framework.CommonController.KubeRest())
+			tokenRequestURI, err := auth.GetTokenRequestURI(framework.WorkloadCluster.CommonController.KubeRest()) // authorization.FindTokenRequestURI(framework.CommonController.KubeRest())
 			if err != nil {
 				klog.Fatalf("a token is required to capture metrics, use oc login to log into the cluster: %v", err)
 			}
@@ -105,9 +105,9 @@ func setup(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	metricsInstance := metrics.NewEmpty(term, framework.Cluster.CommonController.KubeRest(), 5*time.Minute)
+	metricsInstance := metrics.NewEmpty(term, framework.WorkloadCluster.CommonController.KubeRest(), 5*time.Minute)
 
-	prometheusClient := metrics.GetPrometheusClient(term, framework.Cluster.CommonController.KubeRest(), token)
+	prometheusClient := metrics.GetPrometheusClient(term, framework.WorkloadCluster.CommonController.KubeRest(), token)
 
 	metricsInstance.AddQueries(
 		queries.QueryClusterCPUUtilisation(prometheusClient),
@@ -154,13 +154,13 @@ func setup(cmd *cobra.Command, args []string) {
 		for AppStudioUsersBar.Incr() {
 			startTime := time.Now()
 			username := fmt.Sprintf("%s-%04d", usernamePrefix, AppStudioUsersBar.Current())
-			if err := users.Create(framework.Cluster.CommonController.KubeRest(), username, constants.HostOperatorNamespace, constants.MemberOperatorNamespace); err != nil {
+			if err := users.Create(framework.WorkloadCluster.CommonController.KubeRest(), username, constants.HostOperatorNamespace, constants.MemberOperatorNamespace); err != nil {
 				klog.Fatalf("failed to provision user '%s'", username)
 				klog.Errorf(err.Error())
 			}
 			if AppStudioUsersBar.Current()%userBatches == 0 {
 				for i := AppStudioUsersBar.Current() - userBatches + 1; i < AppStudioUsersBar.Current(); i++ {
-					if err := wait.ForNamespace(framework.Cluster.CommonController.KubeRest(), username); err != nil {
+					if err := wait.ForNamespace(framework.WorkloadCluster.CommonController.KubeRest(), username); err != nil {
 						klog.Fatalf("failed to find namespace '%s'", username)
 						klog.Errorf(err.Error())
 					}
@@ -180,7 +180,7 @@ func setup(cmd *cobra.Command, args []string) {
 		for ResourcesBar.Incr() {
 			startTime := time.Now()
 			username := fmt.Sprintf("%s-%04d", usernamePrefix, ResourcesBar.Current())
-			_, errors := framework.Cluster.CommonController.CreateRegistryAuthSecret(
+			_, errors := framework.WorkloadCluster.CommonController.CreateRegistryAuthSecret(
 				"redhat-appstudio-registry-pull-secret",
 				username,
 				utils.GetDockerConfigJson(),
@@ -190,16 +190,16 @@ func setup(cmd *cobra.Command, args []string) {
 			}
 			// time.Sleep(time.Second * 2)
 			ApplicationName := fmt.Sprintf("%s-app", username)
-			app, err := framework.Appstudio.HasController.CreateHasApplication(ApplicationName, username)
+			app, err := framework.AppstudioWs.HasController.CreateHasApplication(ApplicationName, username)
 			if err != nil {
 				klog.Fatalf("Problem Creating the Application: %v", err)
 			}
-			if err := utils.WaitUntil(framework.Appstudio.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second); err != nil {
+			if err := utils.WaitUntil(framework.AppstudioWs.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second); err != nil {
 				klog.Fatalf("timed out waiting for application gitops repo to be created: %v", err)
 			}
 			ComponentName := fmt.Sprintf("%s-component", username)
 			ComponentContainerImage := fmt.Sprintf("image-registry.openshift-image-registry.svc:5000/%s/devfile-sample-code-with-quarkus:%s", username, strings.Replace(uuid.New().String(), "-", "", -1))
-			component, err := framework.Appstudio.HasController.CreateComponent(
+			component, err := framework.AppstudioWs.HasController.CreateComponent(
 				ApplicationName,
 				ComponentName,
 				username,
@@ -238,7 +238,7 @@ func setup(cmd *cobra.Command, args []string) {
 				DefaultRetryInterval := time.Millisecond * 200
 				DefaultTimeout := time.Minute * 17
 				error := k8swait.Poll(DefaultRetryInterval, DefaultTimeout, func() (done bool, err error) {
-					pipelineRun, err := framework.Appstudio.HasController.GetComponentPipelineRun(ComponentName, ApplicationName, username, false, "")
+					pipelineRun, err := framework.AppstudioWs.HasController.GetComponentPipelineRun(ComponentName, ApplicationName, username, false, "")
 					if err != nil {
 						return false, err
 					}

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.0
-	github.com/tektoncd/pipeline v0.35.0
+	github.com/tektoncd/pipeline v0.37.0
 	golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.24.3

--- a/go.sum
+++ b/go.sum
@@ -2229,8 +2229,8 @@ github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ
 github.com/tchap/go-patricia v2.3.0+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tektoncd/pipeline v0.33.0/go.mod h1:FAxcjW5FRSBUDmNVXxv1Lq4YlT6Qjgh85TC9JKcxdX4=
-github.com/tektoncd/pipeline v0.35.0 h1:6yy2CjW3HsPydc/WLydnFvTxwhRPbRNm13mUoSTmTnI=
-github.com/tektoncd/pipeline v0.35.0/go.mod h1:+Jc1ESROXrzosXmpAKMWY8CJhUu52mK+wigjpVMgOio=
+github.com/tektoncd/pipeline v0.37.0 h1:Fhxd9y1XRK3ugcuuOvLHxqYj+JDk/Ilksf22qKqHpjo=
+github.com/tektoncd/pipeline v0.37.0/go.mod h1:ZZOSGj1vCeK/xONQGcxBs+m17NzCXNNOqglCDhOPwjY=
 github.com/tektoncd/plumbing v0.0.0-20211012143332-c7cc43d9bc0c/go.mod h1:b9esRuV1absBvaPzKkjYdKXjC5Tgs8/vh1sz++RiTdc=
 github.com/tektoncd/triggers v0.19.1/go.mod h1:o1LZztX+exY/MbwRJbgbeTv1exn9rDnepX2vM2CD2q0=
 github.com/tencentcloud/tencentcloud-sdk-go v1.0.162/go.mod h1:asUz5BPXxgoPGaRgZaVm1iGcUAuHyYUo1nXqKa83cvI=

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -195,7 +195,9 @@ func (ci CI) TestE2E() error {
 
 func RunE2ETests() error {
 	cwd, _ := os.Getwd()
-
+	if err := sh.RunV("kubectl", "ws", "~"); err != nil {
+		return fmt.Errorf("error when running tests: error when trying to switch to a HOME workspace: %+v", err)
+	}
 	return sh.RunV("ginkgo", "-p", "--timeout=90m", fmt.Sprintf("--output-dir=%s", artifactDir), "--junit-report=e2e-report.xml", "--v", "--progress", "--label-filter=$E2E_TEST_SUITE_LABEL", "./cmd", "--", fmt.Sprintf("--config-suites=%s/tests/e2e-demos/config/default.yaml", cwd))
 }
 

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -95,12 +95,12 @@ func commandExists(cmd string) bool {
 }
 
 func initKCPController() (*kcp.SuiteController, error) {
-	kubeClient, err := kubeCl.NewK8SClient()
+	kubeClients, err := kubeCl.NewK8SClients()
 	if err != nil {
 		return &kcp.SuiteController{}, fmt.Errorf("error creating client-go %v", err)
 	}
 
-	kcpController, err := kcp.NewSuiteController(kubeClient)
+	kcpController, err := kcp.NewSuiteController(kubeClients.AppstudioUserClient)
 	if err != nil {
 		return &kcp.SuiteController{}, err
 	}

--- a/pkg/apis/kubernetes/client.go
+++ b/pkg/apis/kubernetes/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"os"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -93,6 +94,9 @@ func (c *CustomClient) DynamicClient() dynamic.Interface {
 func NewK8SClients() (*K8sClients, error) {
 	// Init (workload) cluster client
 	clusterKubeconfigPath := os.Getenv("CLUSTER_KUBECONFIG")
+	if clusterKubeconfigPath == "" {
+		return nil, fmt.Errorf("'CLUSTER_KUBECONFIG' env var needs to be exported and has to point to a workload cluster")
+	}
 	cfgCluster, err := clientcmd.BuildConfigFromFlags("", clusterKubeconfigPath)
 	if err != nil {
 		return nil, err

--- a/pkg/apis/kubernetes/client.go
+++ b/pkg/apis/kubernetes/client.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"os"
+
 	routev1 "github.com/openshift/api/route/v1"
 	applicationservice "github.com/redhat-appstudio/application-service/api/v1alpha1"
 	gitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
@@ -22,16 +24,25 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
-type K8sClient struct {
+type CustomClient struct {
 	kubeClient            *kubernetes.Clientset
 	crClient              crclient.Client
 	pipelineClient        pipelineclientset.Interface
 	dynamicClient         dynamic.Interface
 	jvmbuildserviceClient jvmbuildserviceclientset.Interface
+}
+type K8sClients struct {
+	ClusterClient       *CustomClient
+	AppstudioClient     *CustomClient
+	HacbsClient         *CustomClient
+	AppstudioUserClient *CustomClient
+	HacbsUserClient     *CustomClient
 }
 
 var (
@@ -55,68 +66,123 @@ func init() {
 }
 
 // Kube returns the clientset for Kubernetes upstream.
-func (c *K8sClient) KubeInterface() kubernetes.Interface {
+func (c *CustomClient) KubeInterface() kubernetes.Interface {
 	return c.kubeClient
 }
 
 // Return a rest client to perform CRUD operations on Kubernetes objects
-func (c *K8sClient) KubeRest() crclient.Client {
+func (c *CustomClient) KubeRest() crclient.Client {
 	return c.crClient
 }
 
-func (c *K8sClient) PipelineClient() pipelineclientset.Interface {
+func (c *CustomClient) PipelineClient() pipelineclientset.Interface {
 	return c.pipelineClient
 }
 
-func (c *K8sClient) JvmbuildserviceClient() jvmbuildserviceclientset.Interface {
+func (c *CustomClient) JvmbuildserviceClient() jvmbuildserviceclientset.Interface {
 	return c.jvmbuildserviceClient
 }
 
 // Returns a DynamicClient interface.
 // Note: other client interfaces are likely preferred, except in rare cases.
-func (c *K8sClient) DynamicClient() dynamic.Interface {
+func (c *CustomClient) DynamicClient() dynamic.Interface {
 	return c.dynamicClient
 }
 
-// NewHASClient creates kubernetes client wrapper
-func NewK8SClient() (*K8sClient, error) {
+// NewK8SClients creates kubernetes client wrapper
+func NewK8SClients() (*K8sClients, error) {
+	// Init (workload) cluster client
+	clusterKubeconfigPath := os.Getenv("CLUSTER_KUBECONFIG")
+	cfgCluster, err := clientcmd.BuildConfigFromFlags("", clusterKubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	clusterClient, err := createCustomClient(*cfgCluster)
+	if err != nil {
+		return nil, err
+	}
+
+	// Init clients for appstudio, redhat-appstudio, hacbs, redhat-hacbs workspaces
+	wsID := os.Getenv("WORKSPACE_ID")
+	if wsID != "" {
+		wsID = "-" + wsID
+	}
+
 	cfg, err := config.GetConfig()
 	if err != nil {
 		return nil, err
 	}
+	kcpHome := cfg.Host
 
-	client, err := kubernetes.NewForConfig(cfg)
+	// :appstudio ws client
+	cfg.Host = kcpHome + ":appstudio" + wsID
+	auc, err := createCustomClient(*cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	dynamicClient, err := dynamic.NewForConfig(cfg)
+	// :hacbs ws client
+	cfg.Host = kcpHome + ":hacbs" + wsID
+	huc, err := createCustomClient(*cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	crClient, err := crclient.New(cfg, crclient.Options{
+	// :redhat-appstudio ws client
+	cfg.Host = kcpHome + ":redhat-appstudio" + wsID
+	ac, err := createCustomClient(*cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// :redhat-hacbs ws client
+	cfg.Host = kcpHome + ":redhat-hacbs" + wsID
+	hc, err := createCustomClient(*cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &K8sClients{
+		ClusterClient:       clusterClient,
+		AppstudioClient:     ac,
+		HacbsClient:         hc,
+		AppstudioUserClient: auc,
+		HacbsUserClient:     huc,
+	}, nil
+}
+
+func createCustomClient(cfg rest.Config) (*CustomClient, error) {
+	client, err := kubernetes.NewForConfig(&cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(&cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	crClient, err := crclient.New(&cfg, crclient.Options{
 		Scheme: scheme,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	pipelineClient, err := pipelineclientset.NewForConfig(cfg)
+	pipelineClient, err := pipelineclientset.NewForConfig(&cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	jvmbildserviceClient, err := jvmbuildserviceclientset.NewForConfig(cfg)
+	jvmbuildserviceClient, err := jvmbuildserviceclientset.NewForConfig(&cfg)
 	if err != nil {
 		return nil, err
 	}
-
-	return &K8sClient{
+	return &CustomClient{
 		kubeClient:            client,
 		crClient:              crClient,
 		pipelineClient:        pipelineClient,
-		jvmbuildserviceClient: jvmbildserviceClient,
 		dynamicClient:         dynamicClient,
+		jvmbuildserviceClient: jvmbuildserviceClient,
 	}, nil
 }

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -27,11 +27,11 @@ type ControllerHub struct {
 }
 
 type Framework struct {
-	Appstudio     *ControllerHub
-	Hacbs         *ControllerHub
-	AppstudioUser *ControllerHub
-	HacbsUser     *ControllerHub
-	Cluster       *ControllerHub
+	AppstudioWs     *ControllerHub
+	HacbsWs         *ControllerHub
+	AppstudioUserWs *ControllerHub
+	HacbsUserWs     *ControllerHub
+	WorkloadCluster *ControllerHub
 }
 
 // Initialize all test controllers and return them in a Framework
@@ -45,35 +45,35 @@ func NewFramework() (*Framework, error) {
 
 	a, err := initControllerHub(k.AppstudioClient)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize appstudio workspace controller hub: %v", err)
 	}
 
 	h, err := initControllerHub(k.HacbsClient)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize hacbs workspace controller hub: %v", err)
 	}
 
 	au, err := initControllerHub(k.AppstudioUserClient)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize appstudio user workspace controller hub: %v", err)
 	}
 
 	hu, err := initControllerHub(k.HacbsUserClient)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize hacbs user workspace controller hub: %v", err)
 	}
 
 	cl, err := initControllerHub(k.ClusterClient)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize workload cluster controller hub: %v", err)
 	}
 
 	return &Framework{
-		Appstudio:     a,
-		Hacbs:         h,
-		AppstudioUser: au,
-		HacbsUser:     hu,
-		Cluster:       cl,
+		AppstudioWs:     a,
+		HacbsWs:         h,
+		AppstudioUserWs: au,
+		HacbsUserWs:     hu,
+		WorkloadCluster: cl,
 	}, nil
 }
 

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Framework struct to store all controllers
-type Framework struct {
+type ControllerHub struct {
 	HasController             *has.SuiteController
 	CommonController          *common.SuiteController
 	TektonController          *tekton.SuiteController
@@ -26,28 +26,71 @@ type Framework struct {
 	JvmbuildserviceController *jvmbuildservice.SuiteController
 }
 
+type Framework struct {
+	Appstudio     *ControllerHub
+	Hacbs         *ControllerHub
+	AppstudioUser *ControllerHub
+	HacbsUser     *ControllerHub
+	Cluster       *ControllerHub
+}
+
 // Initialize all test controllers and return them in a Framework
 func NewFramework() (*Framework, error) {
 
 	// Initialize a common kubernetes client to be passed to the test controllers
-	kubeClient, err := kubeCl.NewK8SClient()
+	k, err := kubeCl.NewK8SClients()
 	if err != nil {
-		return nil, fmt.Errorf("error creating client-go %v", err)
+		return nil, fmt.Errorf("error when initializing kubernetes clients: %+v", err)
 	}
 
+	a, err := initControllerHub(k.AppstudioClient)
+	if err != nil {
+		return nil, err
+	}
+
+	h, err := initControllerHub(k.HacbsClient)
+	if err != nil {
+		return nil, err
+	}
+
+	au, err := initControllerHub(k.AppstudioUserClient)
+	if err != nil {
+		return nil, err
+	}
+
+	hu, err := initControllerHub(k.HacbsUserClient)
+	if err != nil {
+		return nil, err
+	}
+
+	cl, err := initControllerHub(k.ClusterClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Framework{
+		Appstudio:     a,
+		Hacbs:         h,
+		AppstudioUser: au,
+		HacbsUser:     hu,
+		Cluster:       cl,
+	}, nil
+}
+
+func initControllerHub(cc *kubeCl.CustomClient) (*ControllerHub, error) {
 	// Initialize Common controller
-	commonCtrl, err := common.NewSuiteController(kubeClient)
+	commonCtrl, err := common.NewSuiteController(cc)
 	if err != nil {
 		return nil, err
 	}
 
 	// Initialize Has controller
-	hasController, err := has.NewSuiteController(kubeClient)
+	hasController, err := has.NewSuiteController(cc)
 	if err != nil {
 		return nil, err
 	}
 
-	spiController, err := spi.NewSuiteController(kubeClient)
+	spiController, err := spi.NewSuiteController(cc)
 	if err != nil {
 		return nil, err
 	}
@@ -88,9 +131,9 @@ func NewFramework() (*Framework, error) {
 		return nil, err
 	}*/
 
-	return &Framework{
-		CommonController: commonCtrl,
+	return &ControllerHub{
 		HasController:    hasController,
+		CommonController: commonCtrl,
 		SPIController:    spiController,
 		// TODO: Once all controllers are working on KCP activate all the clients.
 		//TektonController: tektonController,

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -95,13 +95,13 @@ func initControllerHub(cc *kubeCl.CustomClient) (*ControllerHub, error) {
 		return nil, err
 	}
 
-	// TODO: Once all controllers are working on KCP activate all the clients.
 	// Initialize Tekton controller
-	/*tektonController, err := tekton.NewSuiteController(kubeClient)
+	tektonController, err := tekton.NewSuiteController(cc)
 	if err != nil {
 		return nil, err
-	}*/
+	}
 
+	// TODO: Once all controllers are working on KCP activate all the clients.
 	/*// Initialize GitOps controller
 	gitopsController, err := gitops.NewSuiteController(kubeClient)
 	if err != nil {
@@ -135,8 +135,8 @@ func initControllerHub(cc *kubeCl.CustomClient) (*ControllerHub, error) {
 		HasController:    hasController,
 		CommonController: commonCtrl,
 		SPIController:    spiController,
+		TektonController: tektonController,
 		// TODO: Once all controllers are working on KCP activate all the clients.
-		//TektonController: tektonController,
 		//GitOpsController:  gitopsController,
 		//ReleaseController: releaseController,
 		//IntegrationController: integrationController,

--- a/pkg/utils/build/hacbs.go
+++ b/pkg/utils/build/hacbs.go
@@ -17,7 +17,7 @@ func FetchTaskRunResult(pr *v1beta1.PipelineRun, pipelineTaskName string, result
 		}
 		for _, trResult := range tr.Status.TaskRunResults {
 			if trResult.Name == result {
-				return strings.TrimSuffix(trResult.Value, "\n"), nil
+				return strings.TrimSuffix(trResult.Value.StringVal, "\n"), nil
 			}
 		}
 	}
@@ -33,7 +33,7 @@ func FetchImageTaskRunResult(pr *v1beta1.PipelineRun, pipelineTaskName string, r
 		for _, trResult := range tr.Status.TaskRunResults {
 
 			if trResult.Name == "BASE_IMAGE_REPOSITORY" || trResult.Name == result {
-				return (trResult.Value), nil
+				return trResult.Value.StringVal, nil
 			}
 		}
 	}

--- a/pkg/utils/common/controller.go
+++ b/pkg/utils/common/controller.go
@@ -31,12 +31,12 @@ import (
 
 // Create the struct for kubernetes clients
 type SuiteController struct {
-	*kubeCl.K8sClient
+	*kubeCl.CustomClient
 	Github *github.Github
 }
 
 // Create controller for Application/Component crud operations
-func NewSuiteController(kubeC *kubeCl.K8sClient) (*SuiteController, error) {
+func NewSuiteController(kubeC *kubeCl.CustomClient) (*SuiteController, error) {
 	// Check if a github organization env var is set, if not use by default the redhat-appstudio-qe org. See: https://github.com/redhat-appstudio-qe
 	org := utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe")
 	token := utils.GetEnv(constants.GITHUB_TOKEN_ENV, "")

--- a/pkg/utils/gitops/controller.go
+++ b/pkg/utils/gitops/controller.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	"net/http"
 	"time"
+
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 
 	routev1 "github.com/openshift/api/route/v1"
 	kubeCl "github.com/redhat-appstudio/e2e-tests/pkg/apis/kubernetes"
@@ -17,10 +18,10 @@ import (
 )
 
 type SuiteController struct {
-	*kubeCl.K8sClient
+	*kubeCl.CustomClient
 }
 
-func NewSuiteController(kube *kubeCl.K8sClient) (*SuiteController, error) {
+func NewSuiteController(kube *kubeCl.CustomClient) (*SuiteController, error) {
 	return &SuiteController{
 		kube,
 	}, nil

--- a/pkg/utils/has/controller.go
+++ b/pkg/utils/has/controller.go
@@ -3,9 +3,10 @@ package has
 import (
 	"context"
 	"fmt"
-	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	"strings"
 	"time"
+
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 
 	routev1 "github.com/openshift/api/route/v1"
 	appservice "github.com/redhat-appstudio/application-service/api/v1alpha1"
@@ -23,10 +24,10 @@ import (
 )
 
 type SuiteController struct {
-	*kubeCl.K8sClient
+	*kubeCl.CustomClient
 }
 
-func NewSuiteController(kube *kubeCl.K8sClient) (*SuiteController, error) {
+func NewSuiteController(kube *kubeCl.CustomClient) (*SuiteController, error) {
 	return &SuiteController{
 		kube,
 	}, nil

--- a/pkg/utils/integration/controller.go
+++ b/pkg/utils/integration/controller.go
@@ -2,30 +2,31 @@ package integration
 
 import (
 	"context"
-//	"fmt"
-//	"time"
+	//	"fmt"
+	//	"time"
 
-//	routev1 "github.com/openshift/api/route/v1"
-	integrationservice "github.com/redhat-appstudio/integration-service/api/v1alpha1"
+	//	routev1 "github.com/openshift/api/route/v1"
 	kubeCl "github.com/redhat-appstudio/e2e-tests/pkg/apis/kubernetes"
+	integrationservice "github.com/redhat-appstudio/integration-service/api/v1alpha1"
 	appstudioshared "github.com/redhat-appstudio/managed-gitops/appstudio-shared/apis/appstudio.redhat.com/v1alpha1"
-//	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-//	appsv1 "k8s.io/api/apps/v1"
-//	corev1 "k8s.io/api/core/v1"
-//	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-//	"k8s.io/apimachinery/pkg/labels"
-//	"k8s.io/apimachinery/pkg/types"
-//	"k8s.io/apimachinery/pkg/util/wait"
-//	"k8s.io/klog/v2"
+
+	//	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	//	appsv1 "k8s.io/api/apps/v1"
+	//	corev1 "k8s.io/api/core/v1"
+	//	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	//	"k8s.io/apimachinery/pkg/labels"
+	//	"k8s.io/apimachinery/pkg/types"
+	//	"k8s.io/apimachinery/pkg/util/wait"
+	//	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-//	rclient "sigs.k8s.io/controller-runtime/pkg/client"
+	// rclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type SuiteController struct {
-	*kubeCl.K8sClient
+	*kubeCl.CustomClient
 }
 
-func NewSuiteController(kube *kubeCl.K8sClient) (*SuiteController, error) {
+func NewSuiteController(kube *kubeCl.CustomClient) (*SuiteController, error) {
 	return &SuiteController{
 		kube,
 	}, nil
@@ -50,33 +51,33 @@ func (h *SuiteController) GetAllApplicationSnapshots(applicationName, namespace 
 // Get return the status from the Application Custom Resource object
 func (h *SuiteController) GetIntegrationTestScenarios(applicationName, namespace string) (*[]integrationservice.IntegrationTestScenario, error) {
 	opts := []client.ListOption{
-                client.InNamespace(namespace),
-        }
+		client.InNamespace(namespace),
+	}
 
 	integrationTestScenarioList := &integrationservice.IntegrationTestScenarioList{}
-        err := h.KubeRest().List(context.TODO(), integrationTestScenarioList, opts...)
-        if err != nil {
-                return nil, err
-        }
-        return &integrationTestScenarioList.Items, nil
+	err := h.KubeRest().List(context.TODO(), integrationTestScenarioList, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &integrationTestScenarioList.Items, nil
 }
 
 func (h *SuiteController) WaitForIntegrationPipelineToBeFinished(testScenario *integrationservice.IntegrationTestScenario, applicationSnapshots *[]appstudioshared.ApplicationSnapshot, applicationName string, appNamespace string) error {
-//	return wait.PollImmediate(20*time.Second, 10*time.Minute, func() (done bool, err error) {
-//		pipelineRun, _ := h.GetIntegrationPipelineRun(testScenario.Name, applicationName, appNamespace, false)
+	//	return wait.PollImmediate(20*time.Second, 10*time.Minute, func() (done bool, err error) {
+	//		pipelineRun, _ := h.GetIntegrationPipelineRun(testScenario.Name, applicationName, appNamespace, false)
 
-//		for _, condition := range pipelineRun.Status.Conditions {
-//			klog.Infof("PipelineRun %s reason: %s", pipelineRun.Name, condition.Reason)
-//
-//			if condition.Reason == "Failed" {
-//				return false, fmt.Errorf("component %s pipeline failed", pipelineRun.Name)
-//			}
-//
-//			if condition.Status == corev1.ConditionTrue {
-//				return true, nil
-//			}
-////		}
-//		return false, nil
-//	})
+	//		for _, condition := range pipelineRun.Status.Conditions {
+	//			klog.Infof("PipelineRun %s reason: %s", pipelineRun.Name, condition.Reason)
+	//
+	//			if condition.Reason == "Failed" {
+	//				return false, fmt.Errorf("component %s pipeline failed", pipelineRun.Name)
+	//			}
+	//
+	//			if condition.Status == corev1.ConditionTrue {
+	//				return true, nil
+	//			}
+	////		}
+	//		return false, nil
+	//	})
 	return nil
 }

--- a/pkg/utils/jvmbuildservice/controller.go
+++ b/pkg/utils/jvmbuildservice/controller.go
@@ -10,10 +10,10 @@ import (
 )
 
 type SuiteController struct {
-	*kubeCl.K8sClient
+	*kubeCl.CustomClient
 }
 
-func NewSuiteControler(kube *kubeCl.K8sClient) (*SuiteController, error) {
+func NewSuiteControler(kube *kubeCl.CustomClient) (*SuiteController, error) {
 	return &SuiteController{
 		kube,
 	}, nil

--- a/pkg/utils/kcp/controller.go
+++ b/pkg/utils/kcp/controller.go
@@ -12,10 +12,10 @@ import (
 )
 
 type SuiteController struct {
-	*kubeCl.K8sClient
+	*kubeCl.CustomClient
 }
 
-func NewSuiteController(kubeC *kubeCl.K8sClient) (*SuiteController, error) {
+func NewSuiteController(kubeC *kubeCl.CustomClient) (*SuiteController, error) {
 	return &SuiteController{
 		kubeC,
 	}, nil

--- a/pkg/utils/release/controller.go
+++ b/pkg/utils/release/controller.go
@@ -13,10 +13,10 @@ import (
 )
 
 type SuiteController struct {
-	*kubeCl.K8sClient
+	*kubeCl.CustomClient
 }
 
-func NewSuiteController(kube *kubeCl.K8sClient) (*SuiteController, error) {
+func NewSuiteController(kube *kubeCl.CustomClient) (*SuiteController, error) {
 	return &SuiteController{
 		kube,
 	}, nil

--- a/pkg/utils/spi/controller.go
+++ b/pkg/utils/spi/controller.go
@@ -25,10 +25,10 @@ const (
 )
 
 type SuiteController struct {
-	*kubeCl.K8sClient
+	*kubeCl.CustomClient
 }
 
-func NewSuiteController(kube *kubeCl.K8sClient) (*SuiteController, error) {
+func NewSuiteController(kube *kubeCl.CustomClient) (*SuiteController, error) {
 	// Initialize a new SPI controller with just the kube client
 	return &SuiteController{
 		kube,

--- a/pkg/utils/tekton/controller.go
+++ b/pkg/utils/tekton/controller.go
@@ -3,11 +3,12 @@ package tekton
 import (
 	"context"
 	"fmt"
-	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	"io"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 
 	ecp "github.com/hacbs-contract/enterprise-contract-controller/api/v1alpha1"
 	kubeCl "github.com/redhat-appstudio/e2e-tests/pkg/apis/kubernetes"
@@ -57,7 +58,7 @@ func newBundles(client kubernetes.Interface) (*Bundles, error) {
 
 // Create the struct for kubernetes clients
 type SuiteController struct {
-	*kubeCl.K8sClient
+	*kubeCl.CustomClient
 
 	Bundles Bundles
 }
@@ -85,7 +86,7 @@ func (c CosignResult) Missing(prefix string) string {
 }
 
 // Create controller for Application/Component crud operations
-func NewSuiteController(kube *kubeCl.K8sClient) (*SuiteController, error) {
+func NewSuiteController(kube *kubeCl.CustomClient) (*SuiteController, error) {
 
 	bundles, err := newBundles(kube.KubeInterface())
 	if err != nil {
@@ -103,7 +104,7 @@ func (s *SuiteController) GetPipelineRun(pipelineRunName, namespace string) (*v1
 }
 
 func (s *SuiteController) fetchContainerLog(podName, containerName, namespace string) (string, error) {
-	podClient := s.K8sClient.KubeInterface().CoreV1().Pods(namespace)
+	podClient := s.KubeInterface().CoreV1().Pods(namespace)
 	req := podClient.GetLogs(podName, &corev1.PodLogOptions{Container: containerName})
 	readCloser, err := req.Stream(context.TODO())
 	log := ""
@@ -119,7 +120,7 @@ func (s *SuiteController) fetchContainerLog(podName, containerName, namespace st
 }
 
 func (s *SuiteController) GetPipelineRunLogs(pipelineRunName, namespace string) (string, error) {
-	podClient := s.K8sClient.KubeInterface().CoreV1().Pods(namespace)
+	podClient := s.KubeInterface().CoreV1().Pods(namespace)
 	podList, err := podClient.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return "", err
@@ -295,7 +296,7 @@ func (s *SuiteController) DeleteAllPipelineRunsInASpecificNamespace(ns string) e
 					Namespace: ns,
 				},
 			}
-			if err := s.K8sClient.KubeRest().Get(context.TODO(), crclient.ObjectKeyFromObject(&pipelineRunCR), &pipelineRunCR); err != nil {
+			if err := s.KubeRest().Get(context.TODO(), crclient.ObjectKeyFromObject(&pipelineRunCR), &pipelineRunCR); err != nil {
 				if errors.IsNotFound(err) {
 					// PipelinerRun CR is already removed
 					return true, nil
@@ -307,12 +308,12 @@ func (s *SuiteController) DeleteAllPipelineRunsInASpecificNamespace(ns string) e
 
 			// Remove the finalizer, so that it can be deleted.
 			pipelineRunCR.Finalizers = []string{}
-			if err := s.K8sClient.KubeRest().Update(context.TODO(), &pipelineRunCR); err != nil {
+			if err := s.KubeRest().Update(context.TODO(), &pipelineRunCR); err != nil {
 				g.GinkgoWriter.Printf("unable to remove finalizers from PipelineRun '%s' in '%s': %v", pipelineRunCR.Name, pipelineRunCR.Namespace, err)
 				return false, nil
 			}
 
-			if err := s.K8sClient.KubeRest().Delete(context.TODO(), &pipelineRunCR); err != nil {
+			if err := s.KubeRest().Delete(context.TODO(), &pipelineRunCR); err != nil {
 				g.GinkgoWriter.Printf("unable to delete PipelineRun '%s' in '%s': %v", pipelineRunCR.Name, pipelineRunCR.Namespace, err)
 				return false, nil
 			}
@@ -446,7 +447,7 @@ func findTagWithName(client crclient.Client, namespace, name string) (*unstructu
 }
 
 func (k KubeController) CreateOrUpdateSigningSecret(publicKey []byte, name, namespace string) (err error) {
-	api := k.Tektonctrl.K8sClient.KubeInterface().CoreV1().Secrets(namespace)
+	api := k.Tektonctrl.KubeInterface().CoreV1().Secrets(namespace)
 	ctx := context.TODO()
 
 	expectedSecret := &corev1.Secret{
@@ -473,7 +474,7 @@ func (k KubeController) CreateOrUpdateSigningSecret(publicKey []byte, name, name
 }
 
 func (k KubeController) GetPublicKey(name, namespace string) (publicKey []byte, err error) {
-	api := k.Tektonctrl.K8sClient.KubeInterface().CoreV1().Secrets(namespace)
+	api := k.Tektonctrl.KubeInterface().CoreV1().Secrets(namespace)
 	ctx := context.TODO()
 
 	secret, err := api.Get(ctx, name, metav1.GetOptions{})
@@ -494,7 +495,7 @@ func (k KubeController) CreateOrUpdatePolicyConfiguration(namespace string, poli
 	}
 
 	// fetch to see if it exists
-	err := k.Tektonctrl.K8sClient.KubeRest().Get(context.TODO(), crclient.ObjectKey{
+	err := k.Tektonctrl.KubeRest().Get(context.TODO(), crclient.ObjectKey{
 		Namespace: namespace,
 		Name:      "ec-policy",
 	}, &ecPolicy)
@@ -511,12 +512,12 @@ func (k KubeController) CreateOrUpdatePolicyConfiguration(namespace string, poli
 	ecPolicy.Spec = policy
 	if !exists {
 		// it doesn't, so create
-		if err := k.Tektonctrl.K8sClient.KubeRest().Create(context.TODO(), &ecPolicy); err != nil {
+		if err := k.Tektonctrl.KubeRest().Create(context.TODO(), &ecPolicy); err != nil {
 			return err
 		}
 	} else {
 		// it does, so update
-		if err := k.Tektonctrl.K8sClient.KubeRest().Update(context.TODO(), &ecPolicy); err != nil {
+		if err := k.Tektonctrl.KubeRest().Update(context.TODO(), &ecPolicy); err != nil {
 			return err
 		}
 	}
@@ -525,7 +526,7 @@ func (k KubeController) CreateOrUpdatePolicyConfiguration(namespace string, poli
 }
 
 func (k KubeController) GetRekorHost() (rekorHost string, err error) {
-	api := k.Tektonctrl.K8sClient.KubeInterface().CoreV1().ConfigMaps("tekton-chains")
+	api := k.Tektonctrl.KubeInterface().CoreV1().ConfigMaps("tekton-chains")
 	ctx := context.TODO()
 
 	cm, err := api.Get(ctx, "chains-config", metav1.GetOptions{})

--- a/pkg/utils/tekton/controller.go
+++ b/pkg/utils/tekton/controller.go
@@ -42,7 +42,7 @@ type Bundles struct {
 
 func newBundles(client kubernetes.Interface) (*Bundles, error) {
 	buildPipelineDefaults, err := client.CoreV1().ConfigMaps("build-templates").Get(context.TODO(), "build-pipelines-defaults", metav1.GetOptions{})
-	if err != nil {
+	if err != nil && !errors.IsNotFound(err) {
 		return nil, err
 	}
 
@@ -87,7 +87,6 @@ func (c CosignResult) Missing(prefix string) string {
 
 // Create controller for Application/Component crud operations
 func NewSuiteController(kube *kubeCl.CustomClient) (*SuiteController, error) {
-
 	bundles, err := newBundles(kube.KubeInterface())
 	if err != nil {
 		return nil, err
@@ -240,7 +239,7 @@ func (k KubeController) GetTaskRunResult(pr *v1beta1.PipelineRun, pipelineTaskNa
 		for _, trResult := range tr.Status.TaskRunResults {
 			if trResult.Name == result {
 				// for some reason the result might contain \n suffix
-				return strings.TrimSuffix(trResult.Value, "\n"), nil
+				return strings.TrimSuffix(trResult.Value.StringVal, "\n"), nil
 			}
 		}
 	}

--- a/pkg/utils/tekton/matchers.go
+++ b/pkg/utils/tekton/matchers.go
@@ -25,7 +25,7 @@ func (matcher *TaskRunResultMatcher) FailureMessage(actual interface{}) (message
 	if matcher.value != nil {
 		return fmt.Sprintf("%v to equal %v", actual, v1beta1.TaskRunResult{
 			Name:  matcher.name,
-			Value: *matcher.value,
+			Value: *v1beta1.NewArrayOrString(*matcher.value),
 		})
 	}
 
@@ -49,7 +49,7 @@ func (matcher *TaskRunResultMatcher) Match(actual interface{}) (success bool, er
 			}
 
 			var v interface{}
-			if err := json.Unmarshal([]byte(given), &v); err != nil {
+			if err := json.Unmarshal([]byte(given.StringVal), &v); err != nil {
 				return false, err
 			}
 
@@ -74,20 +74,20 @@ func (matcher *TaskRunResultMatcher) Match(actual interface{}) (success bool, er
 				if b, err := json.Marshal(values[0]); err != nil {
 					return false, err
 				} else {
-					given = string(b)
+					given = *v1beta1.NewArrayOrString(string(b))
 				}
 			} else if b, err := json.Marshal(values); err != nil {
 				return false, err
 			} else {
-				given = string(b)
+				given = *v1beta1.NewArrayOrString(string(b))
 			}
 		}
 
 		if matcher.value != nil {
-			return strings.TrimSpace(given) == *matcher.value, nil
+			return strings.TrimSpace(given.StringVal) == *matcher.value, nil
 		} else {
 			matcher.jsonMatcher = gomega.MatchJSON(*matcher.jsonValue)
-			return matcher.jsonMatcher.Match(given)
+			return matcher.jsonMatcher.Match(given.StringVal)
 		}
 	}
 }
@@ -99,7 +99,7 @@ func (matcher *TaskRunResultMatcher) NegatedFailureMessage(actual interface{}) (
 	if matcher.value != nil {
 		return fmt.Sprintf("%v not to equal %v", actual, v1beta1.TaskRunResult{
 			Name:  matcher.name,
-			Value: strings.TrimSpace(*matcher.value),
+			Value: *v1beta1.NewArrayOrString(strings.TrimSpace(*matcher.value)),
 		})
 	}
 

--- a/pkg/utils/tekton/matchers_test.go
+++ b/pkg/utils/tekton/matchers_test.go
@@ -10,7 +10,7 @@ import (
 func TestTaskRunResultMatcherStringValue(t *testing.T) {
 	match, err := MatchTaskRunResult("a", "b").Match(v1beta1.TaskRunResult{
 		Name:  "a",
-		Value: "b",
+		Value: *v1beta1.NewArrayOrString("b"),
 	})
 
 	assert.True(t, match)
@@ -20,7 +20,7 @@ func TestTaskRunResultMatcherStringValue(t *testing.T) {
 func TestTaskRunResultMatcherJSONValue(t *testing.T) {
 	match, err := MatchTaskRunResultWithJSONValue("a", `{"b":1}`).Match(v1beta1.TaskRunResult{
 		Name:  "a",
-		Value: `{ "b" : 1 }`,
+		Value: *v1beta1.NewArrayOrString(`{ "b" : 1 }`),
 	})
 
 	assert.True(t, match)
@@ -30,7 +30,7 @@ func TestTaskRunResultMatcherJSONValue(t *testing.T) {
 func TestMatchTaskRunResultWithJSONPathValue(t *testing.T) {
 	match, err := MatchTaskRunResultWithJSONPathValue("a", "{$.c[0].d}", "[2]").Match(v1beta1.TaskRunResult{
 		Name:  "a",
-		Value: `{"b":1, "c": [{"d": 2}]}`,
+		Value: *v1beta1.NewArrayOrString(`{"b":1, "c": [{"d": 2}]}`),
 	})
 
 	assert.True(t, match)
@@ -40,7 +40,7 @@ func TestMatchTaskRunResultWithJSONPathValue(t *testing.T) {
 func TestMatchTaskRunResultWithJSONPathValueMultiple(t *testing.T) {
 	match, err := MatchTaskRunResultWithJSONPathValue("a", "{$.c[*].d}", "[2, 1]").Match(v1beta1.TaskRunResult{
 		Name:  "a",
-		Value: `{"b":1, "c": [{"d": 2}, {"d": 1}]}`,
+		Value: *v1beta1.NewArrayOrString(`{"b":1, "c": [{"d": 2}, {"d": 1}]}`),
 	})
 
 	assert.True(t, match)

--- a/scripts/install-appstudio-kcp.sh
+++ b/scripts/install-appstudio-kcp.sh
@@ -12,7 +12,7 @@ command -v oc >/dev/null 2>&1 || { echo "oc cli is not installed. Aborting."; ex
 
 # tr is not working by default in MacOs. Exporting LC_CTYPE=C seems like solve the problem
 case "$(uname -s)" in
-    Darwin*)    export LC_CTYPE=C;;
+    Darwin*)    export LC_ALL=C;;
     Linux*)     echo -e "Running on Linux system";;
     *)          echo -e "UNKNOWN System."
 esac

--- a/scripts/install-appstudio-kcp.sh
+++ b/scripts/install-appstudio-kcp.sh
@@ -305,9 +305,6 @@ createAppStudioRootWorkspace
 createPreviewEnvFile
 startRedHatAppStudioInstallation
 
-# Switch to home workspace
-kubectl ws "~"
-
 if [[ $RUN_E2E == "true" ]]
 then
     runE2Etests

--- a/scripts/install-appstudio-kcp.sh
+++ b/scripts/install-appstudio-kcp.sh
@@ -305,8 +305,8 @@ createAppStudioRootWorkspace
 createPreviewEnvFile
 startRedHatAppStudioInstallation
 
-# Switch to user workspace
-kubectl ws "${USER_APPSTUDIO_WORKSPACE}"
+# Switch to home workspace
+kubectl ws "~"
 
 if [[ $RUN_E2E == "true" ]]
 then

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -51,7 +51,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		var prCreationTime time.Time
 
 		BeforeAll(func() {
-			consoleRoute, err := f.CommonController.GetOpenshiftRoute("console", "openshift-console")
+			consoleRoute, err := f.HacbsUser.CommonController.GetOpenshiftRoute("console", "openshift-console")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			if utils.IsPrivateHostname(consoleRoute.Spec.Host) {
@@ -59,19 +59,19 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			}
 
 			// Used for identifying related webhook on GitHub - in order to delete it
-			pacControllerRoute, err := f.CommonController.GetOpenshiftRoute("pipelines-as-code-controller", "pipelines-as-code")
+			pacControllerRoute, err := f.HacbsUser.CommonController.GetOpenshiftRoute("pipelines-as-code-controller", "pipelines-as-code")
 			Expect(err).ShouldNot(HaveOccurred())
 			pacControllerHost = pacControllerRoute.Spec.Host
 
 			applicationName = fmt.Sprintf("build-suite-test-application-%s", util.GenerateRandomString(4))
 			testNamespace = utils.GetGeneratedNamespace("build-e2e")
 
-			_, err = f.CommonController.CreateTestNamespace(testNamespace)
+			_, err = f.HacbsUser.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
 
-			app, err := f.HasController.CreateHasApplication(applicationName, testNamespace)
+			app, err := f.HacbsUser.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(utils.WaitUntil(f.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+			Expect(utils.WaitUntil(f.HacbsUser.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 			)
 
@@ -82,14 +82,14 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			// outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
 
 			// Create a component with Git Source URL being defined
-			_, err = f.HasController.CreateComponentWithPaCEnabled(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, outputContainerImage)
+			_, err = f.HacbsUser.HasController.CreateComponentWithPaCEnabled(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, outputContainerImage)
 			Expect(err).ShouldNot(HaveOccurred())
 
 		})
 
 		AfterAll(func() {
-			Expect(f.HasController.DeleteHasApplication(applicationName, testNamespace, false)).To(Succeed())
-			Expect(f.HasController.DeleteHasComponent(componentName, testNamespace, false)).To(Succeed())
+			Expect(f.HacbsUser.HasController.DeleteHasApplication(applicationName, testNamespace, false)).To(Succeed())
+			Expect(f.HacbsUser.HasController.DeleteHasComponent(componentName, testNamespace, false)).To(Succeed())
 			pacInitTestFiles := []string{
 				fmt.Sprintf(".tekton/%s-pull-request.yaml", componentName),
 				fmt.Sprintf(".tekton/%s-push.yaml", componentName),
@@ -97,26 +97,26 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			}
 
 			for _, file := range pacInitTestFiles {
-				err := f.CommonController.Github.DeleteFile(helloWorldComponentGitSourceRepoName, file, "main")
+				err := f.HacbsUser.CommonController.Github.DeleteFile(helloWorldComponentGitSourceRepoName, file, "main")
 				if err != nil {
 					Expect(err.Error()).To(ContainSubstring("404 Not Found"))
 				}
 			}
 
-			err = f.CommonController.Github.DeleteRef(helloWorldComponentGitSourceRepoName, pacBranchName)
+			err = f.HacbsUser.CommonController.Github.DeleteRef(helloWorldComponentGitSourceRepoName, pacBranchName)
 			if err != nil {
 				Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
 			}
 
 			// Delete created webhook from GitHub
-			hooks, err := f.CommonController.Github.ListRepoWebhooks(helloWorldComponentGitSourceRepoName)
+			hooks, err := f.HacbsUser.CommonController.Github.ListRepoWebhooks(helloWorldComponentGitSourceRepoName)
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, h := range hooks {
 				hookUrl := h.Config["url"].(string)
 				klog.Infoln(hookUrl, pacControllerHost)
 				if strings.Contains(hookUrl, pacControllerHost) {
-					Expect(f.CommonController.Github.DeleteWebhook(helloWorldComponentGitSourceRepoName, h.GetID())).To(Succeed())
+					Expect(f.HacbsUser.CommonController.Github.DeleteWebhook(helloWorldComponentGitSourceRepoName, h.GetID())).To(Succeed())
 					break
 				}
 			}
@@ -127,7 +127,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			timeout = time.Second * 120
 			interval = time.Second * 1
 			Eventually(func() bool {
-				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, "")
+				pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, "")
 				if err != nil {
 					klog.Infoln("PipelineRun has not been created yet")
 					return false
@@ -142,7 +142,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 1
 
 				Eventually(func() bool {
-					prs, err := f.CommonController.Github.ListPullRequests(helloWorldComponentGitSourceRepoName)
+					prs, err := f.HacbsUser.CommonController.Github.ListPullRequests(helloWorldComponentGitSourceRepoName)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, pr := range prs {
@@ -162,7 +162,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 10
 				Eventually(func() bool {
 
-					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, "")
+					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, "")
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, condition := range pipelineRun.Status.Conditions {
@@ -170,7 +170,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 						if condition.Reason == string(v1beta1.PipelineRunReasonFailed) {
 							d := utils.GetFailedPipelineRunDetails(pipelineRun)
-							logs, _ := f.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
+							logs, _ := f.HacbsUser.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
 							Fail(fmt.Sprintf("Pipelinerun '%s' has failed. Logs from failed container '%s': \n%s", pipelineRun.Name, d.FailedContainerName, logs))
 						}
 					}
@@ -187,7 +187,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 10
 
 				Eventually(func() bool {
-					comments, err = f.CommonController.Github.ListPullRequestCommentsSince(helloWorldComponentGitSourceRepoName, prNumber, prCreationTime)
+					comments, err = f.HacbsUser.CommonController.Github.ListPullRequestCommentsSince(helloWorldComponentGitSourceRepoName, prNumber, prCreationTime)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					return len(comments) != 0
@@ -207,7 +207,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			BeforeAll(func() {
 				fileToCreatePath := fmt.Sprintf(".tekton/%s-readme.md", componentName)
 				branchUpdateTimestamp = time.Now()
-				createdFile, err := f.CommonController.Github.CreateFile(helloWorldComponentGitSourceRepoName, fileToCreatePath, fmt.Sprintf("test PaC branch %s update", pacBranchName), pacBranchName)
+				createdFile, err := f.HacbsUser.CommonController.Github.CreateFile(helloWorldComponentGitSourceRepoName, fileToCreatePath, fmt.Sprintf("test PaC branch %s update", pacBranchName), pacBranchName)
 				Expect(err).NotTo(HaveOccurred())
 
 				createdFileSHA = createdFile.GetSHA()
@@ -220,7 +220,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 1
 
 				Eventually(func() bool {
-					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, createdFileSHA)
+					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, createdFileSHA)
 					if err != nil {
 						klog.Infoln("PipelineRun has not been created yet")
 						return false
@@ -233,7 +233,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 10
 
 				Eventually(func() bool {
-					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, createdFileSHA)
+					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, createdFileSHA)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, condition := range pipelineRun.Status.Conditions {
@@ -241,7 +241,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 						if condition.Reason == string(v1beta1.PipelineRunReasonFailed) {
 							d := utils.GetFailedPipelineRunDetails(pipelineRun)
-							logs, _ := f.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
+							logs, _ := f.HacbsUser.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
 							Fail(fmt.Sprintf("Pipelinerun '%s' has failed. Logs from failed container '%s': \n%s", pipelineRun.Name, d.FailedContainerName, logs))
 						}
 					}
@@ -256,7 +256,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 5
 
 				Eventually(func() bool {
-					comments, err = f.CommonController.Github.ListPullRequestCommentsSince(helloWorldComponentGitSourceRepoName, prNumber, branchUpdateTimestamp)
+					comments, err = f.HacbsUser.CommonController.Github.ListPullRequestCommentsSince(helloWorldComponentGitSourceRepoName, prNumber, branchUpdateTimestamp)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					return len(comments) != 0
@@ -275,7 +275,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 			BeforeAll(func() {
 				Eventually(func() error {
-					mergeResult, err = f.CommonController.Github.MergePullRequest(helloWorldComponentGitSourceRepoName, prNumber)
+					mergeResult, err = f.HacbsUser.CommonController.Github.MergePullRequest(helloWorldComponentGitSourceRepoName, prNumber)
 					return err
 				}, time.Minute).Should(BeNil(), fmt.Sprintf("error when merging PaC pull request: %+v", err))
 
@@ -288,7 +288,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 1
 
 				Eventually(func() bool {
-					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, mergeResultSha)
+					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, mergeResultSha)
 					if err != nil {
 						klog.Infoln("PipelineRun has not been created yet")
 						return false
@@ -301,7 +301,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 10
 
 				Eventually(func() bool {
-					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, mergeResultSha)
+					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, mergeResultSha)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, condition := range pipelineRun.Status.Conditions {
@@ -309,7 +309,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 						if condition.Reason == string(v1beta1.PipelineRunReasonFailed) {
 							d := utils.GetFailedPipelineRunDetails(pipelineRun)
-							logs, _ := f.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
+							logs, _ := f.HacbsUser.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
 							Fail(fmt.Sprintf("Pipelinerun '%s' has failed. Logs from failed container '%s': \n%s", pipelineRun.Name, d.FailedContainerName, logs))
 						}
 					}
@@ -320,14 +320,14 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 		When("the component is removed and recreated (with the same name in the same namespace)", func() {
 			BeforeAll(func() {
-				Expect(f.HasController.DeleteHasComponent(componentName, testNamespace, false)).To(Succeed())
+				Expect(f.HacbsUser.HasController.DeleteHasComponent(componentName, testNamespace, false)).To(Succeed())
 
 				Eventually(func() bool {
-					_, err := f.HasController.GetHasComponent(componentName, testNamespace)
+					_, err := f.HacbsUser.HasController.GetHasComponent(componentName, testNamespace)
 					return errors.IsNotFound(err)
 				}, time.Minute*1, time.Second*1).Should(BeTrue(), "timed out when waiting for the app %s to be deleted in %s namespace", applicationName, testNamespace)
 
-				_, err = f.HasController.CreateComponentWithPaCEnabled(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, outputContainerImage)
+				_, err = f.HacbsUser.HasController.CreateComponentWithPaCEnabled(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, outputContainerImage)
 
 			})
 
@@ -335,7 +335,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				timeout = time.Second * 10
 				interval = time.Second * 2
 				Consistently(func() bool {
-					prs, err := f.CommonController.Github.ListPullRequests(helloWorldComponentGitSourceRepoName)
+					prs, err := f.HacbsUser.CommonController.Github.ListPullRequests(helloWorldComponentGitSourceRepoName)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, pr := range prs {
@@ -363,28 +363,28 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			}
 			testNamespace = utils.GetEnv(constants.E2E_APPLICATIONS_NAMESPACE_ENV, fmt.Sprintf("build-e2e-hacbs-%s", util.GenerateRandomString(4)))
 
-			_, err := f.CommonController.CreateTestNamespace(testNamespace)
+			_, err := f.HacbsUser.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
 
-			_, err = f.HasController.GetHasApplication(applicationName, testNamespace)
+			_, err = f.HacbsUser.HasController.GetHasApplication(applicationName, testNamespace)
 			// In case the app with the same name exist in the selected namespace, delete it first
 			if err == nil {
-				Expect(f.HasController.DeleteHasApplication(applicationName, testNamespace, false)).To(Succeed())
+				Expect(f.HacbsUser.HasController.DeleteHasApplication(applicationName, testNamespace, false)).To(Succeed())
 				Eventually(func() bool {
-					_, err := f.HasController.GetHasApplication(applicationName, testNamespace)
+					_, err := f.HacbsUser.HasController.GetHasApplication(applicationName, testNamespace)
 					return errors.IsNotFound(err)
 				}, time.Minute*5, time.Second*1).Should(BeTrue(), "timed out when waiting for the app %s to be deleted in %s namespace", applicationName, testNamespace)
 			}
-			app, err := f.HasController.CreateHasApplication(applicationName, testNamespace)
+			app, err := f.HacbsUser.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(utils.WaitUntil(f.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+			Expect(utils.WaitUntil(f.HacbsUser.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 			)
 
-			customBundleConfigMap, err := f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, testNamespace)
+			customBundleConfigMap, err := f.HacbsUser.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, testNamespace)
 			if err != nil {
 				if errors.IsNotFound(err) {
-					defaultBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
+					defaultBundleConfigMap, err = f.HacbsUser.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
 					Expect(err).ToNot(HaveOccurred())
 
 					bundlePullSpec := defaultBundleConfigMap.Data["default_build_bundle"]
@@ -392,9 +392,9 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 						ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
 						Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
 					}
-					_, err = f.CommonController.CreateConfigMap(hacbsBundleConfigMap, testNamespace)
+					_, err = f.HacbsUser.CommonController.CreateConfigMap(hacbsBundleConfigMap, testNamespace)
 					Expect(err).ToNot(HaveOccurred())
-					DeferCleanup(f.CommonController.DeleteConfigMap, constants.BuildPipelinesConfigMapName, testNamespace, false)
+					DeferCleanup(f.HacbsUser.CommonController.DeleteConfigMap, constants.BuildPipelinesConfigMapName, testNamespace, false)
 				} else {
 					Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, testNamespace, err))
 				}
@@ -405,11 +405,11 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 					Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
 				}
 
-				_, err = f.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
+				_, err = f.HacbsUser.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
 					hacbsBundleConfigMap.Data = customBundleConfigMap.Data
-					_, err := f.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
+					_, err := f.HacbsUser.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
 					if err != nil {
 						return err
 					}
@@ -423,7 +423,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				componentNames = append(componentNames, componentName)
 				outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
 				// Create a component with Git Source URL being defined
-				_, err := f.HasController.CreateComponent(applicationName, componentName, testNamespace, gitUrl, "", "", outputContainerImage, "")
+				_, err := f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, gitUrl, "", "", outputContainerImage, "")
 				Expect(err).ShouldNot(HaveOccurred())
 			}
 		})
@@ -434,17 +434,17 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				// Clean up only Application CR (Component and Pipelines are included) in case we are targeting specific namespace
 				// Used e.g. in build-defintions e2e tests, where we are targeting build-templates-e2e namespace
 				if os.Getenv(constants.E2E_APPLICATIONS_NAMESPACE_ENV) != "" {
-					DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace, false)
+					DeferCleanup(f.HacbsUser.HasController.DeleteHasApplication, applicationName, testNamespace, false)
 				} else {
-					Expect(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(Succeed())
-					Expect(f.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
+					Expect(f.HacbsUser.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(Succeed())
+					Expect(f.HacbsUser.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
 				}
 			} else {
 				// Workaround: We cannot keep applications/components present in the specific namespace due to
 				// an issue reported here: https://issues.redhat.com/browse/PLNSRVCE-484
 				// TODO: delete the whole 'else' block after the issue is resolved
 				if os.Getenv(constants.E2E_APPLICATIONS_NAMESPACE_ENV) != "" {
-					DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace, false)
+					DeferCleanup(f.HacbsUser.HasController.DeleteHasApplication, applicationName, testNamespace, false)
 				}
 			}
 
@@ -457,7 +457,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval := time.Second * 1
 
 				Eventually(func() bool {
-					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false, "")
+					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false, "")
 					if err != nil {
 						klog.Infoln("PipelineRun has not been created yet")
 						return false
@@ -468,7 +468,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		}
 
 		It("should reference the custom pipeline bundle in a PipelineRun", Label("build-templates-e2e"), func() {
-			customBundleConfigMap, err := f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, testNamespace)
+			customBundleConfigMap, err := f.HacbsUser.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, testNamespace)
 			if err != nil {
 				if errors.IsNotFound(err) {
 					klog.Infof("configmap with custom pipeline bundle not found in %s namespace\n", testNamespace)
@@ -482,14 +482,14 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			if customBundleRef == "" {
 				Skip("skipping the specs - custom pipeline bundle is not defined")
 			}
-			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false, "")
+			pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false, "")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(customBundleRef))
 		})
 
 		It("should reference the default pipeline bundle in a PipelineRun", func() {
-			defaultBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
+			defaultBundleConfigMap, err = f.HacbsUser.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
 			if err != nil {
 				if errors.IsForbidden(err) {
 					klog.Infof("don't have enough permissions to get a configmap with default pipeline in %s namespace\n", constants.BuildPipelinesConfigMapDefaultNamespace)
@@ -506,7 +506,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			if defaultBundleRef == "" {
 				Skip("skipping - default pipeline bundle cannot be fetched")
 			}
-			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false, "")
+			pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(defaultBundleRef))
 		})
@@ -518,7 +518,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				timeout := time.Second * 600
 				interval := time.Second * 10
 				Eventually(func() bool {
-					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false, "")
+					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false, "")
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, condition := range pipelineRun.Status.Conditions {
@@ -526,7 +526,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 						if condition.Reason == string(v1beta1.PipelineRunReasonFailed) {
 							d := utils.GetFailedPipelineRunDetails(pipelineRun)
-							logs, _ := f.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
+							logs, _ := f.HacbsUser.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
 							Fail(fmt.Sprintf("Pipelinerun '%s' has failed. Logs from failed container '%s': \n%s", pipelineRun.Name, d.FailedContainerName, logs))
 						}
 					}
@@ -537,7 +537,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			It("should validate HACBS taskrun results", func() {
 				// List Of Taskruns Expected to Get Taskrun Results
 				gatherResult := []string{"conftest-clair", "sanity-inspect-image", "sanity-label-check", "sast-go", "sast-java-sec-check", "clamav-scan"}
-				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false, "")
+				pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false, "")
 				Expect(err).ShouldNot(HaveOccurred())
 
 				for i := range gatherResult {
@@ -557,7 +557,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 			When("the container image is created and pushed to container registry", Label("sbom", "slow"), func() {
 				It("contains non-empty sbom files", func() {
-					component, err := f.HasController.GetHasComponent(componentName, testNamespace)
+					component, err := f.HacbsUser.HasController.GetHasComponent(componentName, testNamespace)
 					Expect(err).ShouldNot(HaveOccurred())
 					purl, cyclonedx, err := build.GetParsedSbomFilesContentFromImage(component.Spec.ContainerImage)
 					Expect(err).NotTo(HaveOccurred())
@@ -600,30 +600,30 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
 			testNamespace = fmt.Sprintf("build-e2e-container-image-source-%s", util.GenerateRandomString(4))
 
-			_, err = f.CommonController.CreateTestNamespace(testNamespace)
+			_, err = f.HacbsUser.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
-			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+			DeferCleanup(f.HacbsUser.CommonController.DeleteNamespace, testNamespace)
 
-			app, err := f.HasController.CreateHasApplication(applicationName, testNamespace)
+			app, err := f.HacbsUser.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(utils.WaitUntil(f.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+			Expect(utils.WaitUntil(f.HacbsUser.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 			)
-			DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace, false)
+			DeferCleanup(f.HacbsUser.HasController.DeleteHasApplication, applicationName, testNamespace, false)
 
 			componentName = fmt.Sprintf("build-suite-test-component-image-source-%s", util.GenerateRandomString(4))
 			outputContainerImage := ""
 			timeout = time.Second * 180
 			interval = time.Second * 1
 			// Create a component with containerImageSource being defined
-			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, "", "", containerImageSource, outputContainerImage, "")
+			_, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, "", "", containerImageSource, outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			DeferCleanup(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
+			DeferCleanup(f.HacbsUser.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
 		})
 
 		It("should not trigger a PipelineRun", func() {
 			Consistently(func() bool {
-				_, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+				_, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
 				Expect(err).NotTo(BeNil())
 				return strings.Contains(err.Error(), "no pipelinerun found")
 			}, timeout, interval).Should(BeTrue(), fmt.Sprintf("expected no PipelineRun to be triggered for the component %s in %s namespace", componentName, testNamespace))
@@ -640,13 +640,13 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			testNamespace := fmt.Sprintf("build-e2e-dummy-custom-pipeline-%s", util.GenerateRandomString(4))
 			applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
 
-			_, err = f.CommonController.CreateTestNamespace(testNamespace)
+			_, err = f.HacbsUser.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
-			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+			DeferCleanup(f.HacbsUser.CommonController.DeleteNamespace, testNamespace)
 
-			app, err := f.HasController.CreateHasApplication(applicationName, testNamespace)
+			app, err := f.HacbsUser.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(utils.WaitUntil(f.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+			Expect(utils.WaitUntil(f.HacbsUser.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 			)
 
@@ -654,14 +654,14 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
 				Data:       map[string]string{"default_build_bundle": dummyPipelineBundleRef},
 			}
-			_, err = f.CommonController.CreateConfigMap(cm, testNamespace)
+			_, err = f.HacbsUser.CommonController.CreateConfigMap(cm, testNamespace)
 			Expect(err).ToNot(HaveOccurred())
 
 			componentName = "build-suite-test-bundle-overriding"
 			outputContainerImage := fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
+			_, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			DeferCleanup(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
+			DeferCleanup(f.HacbsUser.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
 
 			timeout = time.Second * 360
 			interval = time.Second * 1
@@ -669,12 +669,12 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		})
 
 		// AfterAll(func() {
-		// 	f.CommonController.DeleteNamespace(testNamespace)
+		// 	f.HacbsUser.CommonController.DeleteNamespace(testNamespace)
 		// })
 
 		It("should be referenced in a PipelineRun", Label("build-bundle-overriding"), func() {
 			Eventually(func() bool {
-				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+				pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
 				if err != nil {
 					klog.Infoln("PipelineRun has not been created yet")
 					return false
@@ -682,7 +682,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				return pipelineRun.HasStarted()
 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
 
-			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+			pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(dummyPipelineBundleRef))
 		})
@@ -697,11 +697,11 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 			testNamespace = fmt.Sprintf("build-e2e-dummy-quay-creds-%s", util.GenerateRandomString(4))
 
-			_, err = f.CommonController.CreateTestNamespace(testNamespace)
+			_, err = f.HacbsUser.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
-			DeferCleanup(f.CommonController.DeleteNamespace, testNamespace)
+			DeferCleanup(f.HacbsUser.CommonController.DeleteNamespace, testNamespace)
 
-			_, err := f.CommonController.GetSecret(testNamespace, constants.RegistryAuthSecretName)
+			_, err := f.HacbsUser.CommonController.GetSecret(testNamespace, constants.RegistryAuthSecretName)
 			if err != nil {
 				// If we have an error when getting RegistryAuthSecretName, it should be IsNotFound err
 				Expect(errors.IsNotFound(err)).To(BeTrue())
@@ -711,12 +711,12 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 			applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
 
-			app, err := f.HasController.CreateHasApplication(applicationName, testNamespace)
+			app, err := f.HacbsUser.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(utils.WaitUntil(f.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+			Expect(utils.WaitUntil(f.HacbsUser.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 			)
-			DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace, false)
+			DeferCleanup(f.HacbsUser.HasController.DeleteHasApplication, applicationName, testNamespace, false)
 
 			timeout = time.Minute * 5
 			interval = time.Second * 1
@@ -727,20 +727,20 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				Data:       map[string][]byte{".dockerconfigjson": []byte("{\"auths\":{\"quay.io\":{\"username\":\"test\",\"password\":\"test\",\"auth\":\"dGVzdDp0ZXN0\",\"email\":\"\"}}}")},
 			}
 
-			_, err = f.CommonController.CreateSecret(testNamespace, dummySecret)
+			_, err = f.HacbsUser.CommonController.CreateSecret(testNamespace, dummySecret)
 			Expect(err).ToNot(HaveOccurred())
 
 			componentName = "build-suite-test-secret-overriding"
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
+			_, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			DeferCleanup(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
+			DeferCleanup(f.HacbsUser.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
 
 		})
 
 		It("should override the shared secret", func() {
 			Eventually(func() bool {
-				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+				pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
 				if err != nil {
 					klog.Infoln("PipelineRun has not been created yet")
 					return false
@@ -748,7 +748,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				return pipelineRun.HasStarted()
 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
 
-			pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+			pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(pipelineRun.Spec.Workspaces).To(HaveLen(2))
 			registryAuthWorkspace := &v1beta1.WorkspaceBinding{
@@ -764,7 +764,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			timeout = time.Minute * 10
 			interval = time.Second * 5
 			Eventually(func() bool {
-				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+				pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
 				Expect(err).ShouldNot(HaveOccurred())
 
 				for _, condition := range pipelineRun.Status.Conditions {
@@ -785,21 +785,21 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
 			testNamespace = fmt.Sprintf("build-e2e-specific-image-url-%s", util.GenerateRandomString(4))
 
-			_, err = f.CommonController.CreateTestNamespace(testNamespace)
+			_, err = f.HacbsUser.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
-			app, err := f.HasController.CreateHasApplication(applicationName, testNamespace)
+			app, err := f.HacbsUser.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(utils.WaitUntil(f.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+			Expect(utils.WaitUntil(f.HacbsUser.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 			)
 
 		})
 
 		AfterAll(func() {
-			Expect(f.HasController.DeleteAllComponentsInASpecificNamespace(testNamespace, 30*time.Second)).To(Succeed())
-			Expect(f.HasController.DeleteAllApplicationsInASpecificNamespace(testNamespace, 30*time.Second)).To(Succeed())
-			Expect(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(Succeed())
-			Expect(f.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
+			Expect(f.HacbsUser.HasController.DeleteAllComponentsInASpecificNamespace(testNamespace, 30*time.Second)).To(Succeed())
+			Expect(f.HacbsUser.HasController.DeleteAllApplicationsInASpecificNamespace(testNamespace, 30*time.Second)).To(Succeed())
+			Expect(f.HacbsUser.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(Succeed())
+			Expect(f.HacbsUser.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
 		})
 
 		JustBeforeEach(func() {
@@ -807,23 +807,23 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		})
 		It("should fail for ContainerImage field set to a protected repository (without an image tag)", func() {
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected", utils.GetQuayIOOrganization())
-			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
+			_, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
 			Expect(err).ToNot(BeNil())
 
 		})
 		It("should fail for ContainerImage field set to a protected repository followed by a random tag", func() {
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
+			_, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
 			Expect(err).ToNot(BeNil())
 		})
 		It("should succeed for ContainerImage field set to a protected repository followed by a namespace prefix + dash + string", func() {
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected:%s-%s", utils.GetQuayIOOrganization(), testNamespace, strings.Replace(uuid.New().String(), "-", "", -1))
-			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
+			_, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("should succeed for ContainerImage field set to a custom (unprotected) repository without a tag being specified", func() {
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images", utils.GetQuayIOOrganization())
-			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
+			_, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -51,7 +51,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		var prCreationTime time.Time
 
 		BeforeAll(func() {
-			consoleRoute, err := f.HacbsUser.CommonController.GetOpenshiftRoute("console", "openshift-console")
+			consoleRoute, err := f.HacbsUserWs.CommonController.GetOpenshiftRoute("console", "openshift-console")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			if utils.IsPrivateHostname(consoleRoute.Spec.Host) {
@@ -59,19 +59,19 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			}
 
 			// Used for identifying related webhook on GitHub - in order to delete it
-			pacControllerRoute, err := f.HacbsUser.CommonController.GetOpenshiftRoute("pipelines-as-code-controller", "pipelines-as-code")
+			pacControllerRoute, err := f.HacbsUserWs.CommonController.GetOpenshiftRoute("pipelines-as-code-controller", "pipelines-as-code")
 			Expect(err).ShouldNot(HaveOccurred())
 			pacControllerHost = pacControllerRoute.Spec.Host
 
 			applicationName = fmt.Sprintf("build-suite-test-application-%s", util.GenerateRandomString(4))
 			testNamespace = utils.GetGeneratedNamespace("build-e2e")
 
-			_, err = f.HacbsUser.CommonController.CreateTestNamespace(testNamespace)
+			_, err = f.HacbsUserWs.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
 
-			app, err := f.HacbsUser.HasController.CreateHasApplication(applicationName, testNamespace)
+			app, err := f.HacbsUserWs.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(utils.WaitUntil(f.HacbsUser.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+			Expect(utils.WaitUntil(f.HacbsUserWs.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 			)
 
@@ -82,14 +82,14 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			// outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
 
 			// Create a component with Git Source URL being defined
-			_, err = f.HacbsUser.HasController.CreateComponentWithPaCEnabled(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, outputContainerImage)
+			_, err = f.HacbsUserWs.HasController.CreateComponentWithPaCEnabled(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, outputContainerImage)
 			Expect(err).ShouldNot(HaveOccurred())
 
 		})
 
 		AfterAll(func() {
-			Expect(f.HacbsUser.HasController.DeleteHasApplication(applicationName, testNamespace, false)).To(Succeed())
-			Expect(f.HacbsUser.HasController.DeleteHasComponent(componentName, testNamespace, false)).To(Succeed())
+			Expect(f.HacbsUserWs.HasController.DeleteHasApplication(applicationName, testNamespace, false)).To(Succeed())
+			Expect(f.HacbsUserWs.HasController.DeleteHasComponent(componentName, testNamespace, false)).To(Succeed())
 			pacInitTestFiles := []string{
 				fmt.Sprintf(".tekton/%s-pull-request.yaml", componentName),
 				fmt.Sprintf(".tekton/%s-push.yaml", componentName),
@@ -97,26 +97,26 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			}
 
 			for _, file := range pacInitTestFiles {
-				err := f.HacbsUser.CommonController.Github.DeleteFile(helloWorldComponentGitSourceRepoName, file, "main")
+				err := f.HacbsUserWs.CommonController.Github.DeleteFile(helloWorldComponentGitSourceRepoName, file, "main")
 				if err != nil {
 					Expect(err.Error()).To(ContainSubstring("404 Not Found"))
 				}
 			}
 
-			err = f.HacbsUser.CommonController.Github.DeleteRef(helloWorldComponentGitSourceRepoName, pacBranchName)
+			err = f.HacbsUserWs.CommonController.Github.DeleteRef(helloWorldComponentGitSourceRepoName, pacBranchName)
 			if err != nil {
 				Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
 			}
 
 			// Delete created webhook from GitHub
-			hooks, err := f.HacbsUser.CommonController.Github.ListRepoWebhooks(helloWorldComponentGitSourceRepoName)
+			hooks, err := f.HacbsUserWs.CommonController.Github.ListRepoWebhooks(helloWorldComponentGitSourceRepoName)
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, h := range hooks {
 				hookUrl := h.Config["url"].(string)
 				klog.Infoln(hookUrl, pacControllerHost)
 				if strings.Contains(hookUrl, pacControllerHost) {
-					Expect(f.HacbsUser.CommonController.Github.DeleteWebhook(helloWorldComponentGitSourceRepoName, h.GetID())).To(Succeed())
+					Expect(f.HacbsUserWs.CommonController.Github.DeleteWebhook(helloWorldComponentGitSourceRepoName, h.GetID())).To(Succeed())
 					break
 				}
 			}
@@ -127,7 +127,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			timeout = time.Second * 120
 			interval = time.Second * 1
 			Eventually(func() bool {
-				pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, "")
+				pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, "")
 				if err != nil {
 					klog.Infoln("PipelineRun has not been created yet")
 					return false
@@ -142,7 +142,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 1
 
 				Eventually(func() bool {
-					prs, err := f.HacbsUser.CommonController.Github.ListPullRequests(helloWorldComponentGitSourceRepoName)
+					prs, err := f.HacbsUserWs.CommonController.Github.ListPullRequests(helloWorldComponentGitSourceRepoName)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, pr := range prs {
@@ -162,7 +162,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 10
 				Eventually(func() bool {
 
-					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, "")
+					pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, "")
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, condition := range pipelineRun.Status.Conditions {
@@ -170,7 +170,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 						if condition.Reason == string(v1beta1.PipelineRunReasonFailed) {
 							d := utils.GetFailedPipelineRunDetails(pipelineRun)
-							logs, _ := f.HacbsUser.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
+							logs, _ := f.HacbsUserWs.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
 							Fail(fmt.Sprintf("Pipelinerun '%s' has failed. Logs from failed container '%s': \n%s", pipelineRun.Name, d.FailedContainerName, logs))
 						}
 					}
@@ -187,7 +187,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 10
 
 				Eventually(func() bool {
-					comments, err = f.HacbsUser.CommonController.Github.ListPullRequestCommentsSince(helloWorldComponentGitSourceRepoName, prNumber, prCreationTime)
+					comments, err = f.HacbsUserWs.CommonController.Github.ListPullRequestCommentsSince(helloWorldComponentGitSourceRepoName, prNumber, prCreationTime)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					return len(comments) != 0
@@ -207,7 +207,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			BeforeAll(func() {
 				fileToCreatePath := fmt.Sprintf(".tekton/%s-readme.md", componentName)
 				branchUpdateTimestamp = time.Now()
-				createdFile, err := f.HacbsUser.CommonController.Github.CreateFile(helloWorldComponentGitSourceRepoName, fileToCreatePath, fmt.Sprintf("test PaC branch %s update", pacBranchName), pacBranchName)
+				createdFile, err := f.HacbsUserWs.CommonController.Github.CreateFile(helloWorldComponentGitSourceRepoName, fileToCreatePath, fmt.Sprintf("test PaC branch %s update", pacBranchName), pacBranchName)
 				Expect(err).NotTo(HaveOccurred())
 
 				createdFileSHA = createdFile.GetSHA()
@@ -220,7 +220,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 1
 
 				Eventually(func() bool {
-					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, createdFileSHA)
+					pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, createdFileSHA)
 					if err != nil {
 						klog.Infoln("PipelineRun has not been created yet")
 						return false
@@ -233,7 +233,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 10
 
 				Eventually(func() bool {
-					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, createdFileSHA)
+					pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, createdFileSHA)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, condition := range pipelineRun.Status.Conditions {
@@ -241,7 +241,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 						if condition.Reason == string(v1beta1.PipelineRunReasonFailed) {
 							d := utils.GetFailedPipelineRunDetails(pipelineRun)
-							logs, _ := f.HacbsUser.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
+							logs, _ := f.HacbsUserWs.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
 							Fail(fmt.Sprintf("Pipelinerun '%s' has failed. Logs from failed container '%s': \n%s", pipelineRun.Name, d.FailedContainerName, logs))
 						}
 					}
@@ -256,7 +256,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 5
 
 				Eventually(func() bool {
-					comments, err = f.HacbsUser.CommonController.Github.ListPullRequestCommentsSince(helloWorldComponentGitSourceRepoName, prNumber, branchUpdateTimestamp)
+					comments, err = f.HacbsUserWs.CommonController.Github.ListPullRequestCommentsSince(helloWorldComponentGitSourceRepoName, prNumber, branchUpdateTimestamp)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					return len(comments) != 0
@@ -275,7 +275,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 			BeforeAll(func() {
 				Eventually(func() error {
-					mergeResult, err = f.HacbsUser.CommonController.Github.MergePullRequest(helloWorldComponentGitSourceRepoName, prNumber)
+					mergeResult, err = f.HacbsUserWs.CommonController.Github.MergePullRequest(helloWorldComponentGitSourceRepoName, prNumber)
 					return err
 				}, time.Minute).Should(BeNil(), fmt.Sprintf("error when merging PaC pull request: %+v", err))
 
@@ -288,7 +288,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 1
 
 				Eventually(func() bool {
-					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, mergeResultSha)
+					pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, mergeResultSha)
 					if err != nil {
 						klog.Infoln("PipelineRun has not been created yet")
 						return false
@@ -301,7 +301,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 10
 
 				Eventually(func() bool {
-					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, mergeResultSha)
+					pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, mergeResultSha)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, condition := range pipelineRun.Status.Conditions {
@@ -309,7 +309,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 						if condition.Reason == string(v1beta1.PipelineRunReasonFailed) {
 							d := utils.GetFailedPipelineRunDetails(pipelineRun)
-							logs, _ := f.HacbsUser.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
+							logs, _ := f.HacbsUserWs.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
 							Fail(fmt.Sprintf("Pipelinerun '%s' has failed. Logs from failed container '%s': \n%s", pipelineRun.Name, d.FailedContainerName, logs))
 						}
 					}
@@ -320,14 +320,14 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 		When("the component is removed and recreated (with the same name in the same namespace)", func() {
 			BeforeAll(func() {
-				Expect(f.HacbsUser.HasController.DeleteHasComponent(componentName, testNamespace, false)).To(Succeed())
+				Expect(f.HacbsUserWs.HasController.DeleteHasComponent(componentName, testNamespace, false)).To(Succeed())
 
 				Eventually(func() bool {
-					_, err := f.HacbsUser.HasController.GetHasComponent(componentName, testNamespace)
+					_, err := f.HacbsUserWs.HasController.GetHasComponent(componentName, testNamespace)
 					return errors.IsNotFound(err)
 				}, time.Minute*1, time.Second*1).Should(BeTrue(), "timed out when waiting for the app %s to be deleted in %s namespace", applicationName, testNamespace)
 
-				_, err = f.HacbsUser.HasController.CreateComponentWithPaCEnabled(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, outputContainerImage)
+				_, err = f.HacbsUserWs.HasController.CreateComponentWithPaCEnabled(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, outputContainerImage)
 
 			})
 
@@ -335,7 +335,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				timeout = time.Second * 10
 				interval = time.Second * 2
 				Consistently(func() bool {
-					prs, err := f.HacbsUser.CommonController.Github.ListPullRequests(helloWorldComponentGitSourceRepoName)
+					prs, err := f.HacbsUserWs.CommonController.Github.ListPullRequests(helloWorldComponentGitSourceRepoName)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, pr := range prs {
@@ -363,28 +363,28 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			}
 			testNamespace = utils.GetEnv(constants.E2E_APPLICATIONS_NAMESPACE_ENV, fmt.Sprintf("build-e2e-hacbs-%s", util.GenerateRandomString(4)))
 
-			_, err := f.HacbsUser.CommonController.CreateTestNamespace(testNamespace)
+			_, err := f.HacbsUserWs.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
 
-			_, err = f.HacbsUser.HasController.GetHasApplication(applicationName, testNamespace)
+			_, err = f.HacbsUserWs.HasController.GetHasApplication(applicationName, testNamespace)
 			// In case the app with the same name exist in the selected namespace, delete it first
 			if err == nil {
-				Expect(f.HacbsUser.HasController.DeleteHasApplication(applicationName, testNamespace, false)).To(Succeed())
+				Expect(f.HacbsUserWs.HasController.DeleteHasApplication(applicationName, testNamespace, false)).To(Succeed())
 				Eventually(func() bool {
-					_, err := f.HacbsUser.HasController.GetHasApplication(applicationName, testNamespace)
+					_, err := f.HacbsUserWs.HasController.GetHasApplication(applicationName, testNamespace)
 					return errors.IsNotFound(err)
 				}, time.Minute*5, time.Second*1).Should(BeTrue(), "timed out when waiting for the app %s to be deleted in %s namespace", applicationName, testNamespace)
 			}
-			app, err := f.HacbsUser.HasController.CreateHasApplication(applicationName, testNamespace)
+			app, err := f.HacbsUserWs.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(utils.WaitUntil(f.HacbsUser.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+			Expect(utils.WaitUntil(f.HacbsUserWs.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 			)
 
-			customBundleConfigMap, err := f.HacbsUser.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, testNamespace)
+			customBundleConfigMap, err := f.HacbsUserWs.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, testNamespace)
 			if err != nil {
 				if errors.IsNotFound(err) {
-					defaultBundleConfigMap, err = f.HacbsUser.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
+					defaultBundleConfigMap, err = f.HacbsUserWs.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
 					Expect(err).ToNot(HaveOccurred())
 
 					bundlePullSpec := defaultBundleConfigMap.Data["default_build_bundle"]
@@ -392,9 +392,9 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 						ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
 						Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
 					}
-					_, err = f.HacbsUser.CommonController.CreateConfigMap(hacbsBundleConfigMap, testNamespace)
+					_, err = f.HacbsUserWs.CommonController.CreateConfigMap(hacbsBundleConfigMap, testNamespace)
 					Expect(err).ToNot(HaveOccurred())
-					DeferCleanup(f.HacbsUser.CommonController.DeleteConfigMap, constants.BuildPipelinesConfigMapName, testNamespace, false)
+					DeferCleanup(f.HacbsUserWs.CommonController.DeleteConfigMap, constants.BuildPipelinesConfigMapName, testNamespace, false)
 				} else {
 					Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, testNamespace, err))
 				}
@@ -405,11 +405,11 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 					Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
 				}
 
-				_, err = f.HacbsUser.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
+				_, err = f.HacbsUserWs.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(func() error {
 					hacbsBundleConfigMap.Data = customBundleConfigMap.Data
-					_, err := f.HacbsUser.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
+					_, err := f.HacbsUserWs.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
 					if err != nil {
 						return err
 					}
@@ -423,7 +423,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				componentNames = append(componentNames, componentName)
 				outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
 				// Create a component with Git Source URL being defined
-				_, err := f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, gitUrl, "", "", outputContainerImage, "")
+				_, err := f.HacbsUserWs.HasController.CreateComponent(applicationName, componentName, testNamespace, gitUrl, "", "", outputContainerImage, "")
 				Expect(err).ShouldNot(HaveOccurred())
 			}
 		})
@@ -434,17 +434,17 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				// Clean up only Application CR (Component and Pipelines are included) in case we are targeting specific namespace
 				// Used e.g. in build-defintions e2e tests, where we are targeting build-templates-e2e namespace
 				if os.Getenv(constants.E2E_APPLICATIONS_NAMESPACE_ENV) != "" {
-					DeferCleanup(f.HacbsUser.HasController.DeleteHasApplication, applicationName, testNamespace, false)
+					DeferCleanup(f.HacbsUserWs.HasController.DeleteHasApplication, applicationName, testNamespace, false)
 				} else {
-					Expect(f.HacbsUser.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(Succeed())
-					Expect(f.HacbsUser.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
+					Expect(f.HacbsUserWs.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(Succeed())
+					Expect(f.HacbsUserWs.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
 				}
 			} else {
 				// Workaround: We cannot keep applications/components present in the specific namespace due to
 				// an issue reported here: https://issues.redhat.com/browse/PLNSRVCE-484
 				// TODO: delete the whole 'else' block after the issue is resolved
 				if os.Getenv(constants.E2E_APPLICATIONS_NAMESPACE_ENV) != "" {
-					DeferCleanup(f.HacbsUser.HasController.DeleteHasApplication, applicationName, testNamespace, false)
+					DeferCleanup(f.HacbsUserWs.HasController.DeleteHasApplication, applicationName, testNamespace, false)
 				}
 			}
 
@@ -457,7 +457,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval := time.Second * 1
 
 				Eventually(func() bool {
-					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false, "")
+					pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false, "")
 					if err != nil {
 						klog.Infoln("PipelineRun has not been created yet")
 						return false
@@ -468,7 +468,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		}
 
 		It("should reference the custom pipeline bundle in a PipelineRun", Label("build-templates-e2e"), func() {
-			customBundleConfigMap, err := f.HacbsUser.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, testNamespace)
+			customBundleConfigMap, err := f.HacbsUserWs.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, testNamespace)
 			if err != nil {
 				if errors.IsNotFound(err) {
 					klog.Infof("configmap with custom pipeline bundle not found in %s namespace\n", testNamespace)
@@ -482,14 +482,14 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			if customBundleRef == "" {
 				Skip("skipping the specs - custom pipeline bundle is not defined")
 			}
-			pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false, "")
+			pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false, "")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(customBundleRef))
 		})
 
 		It("should reference the default pipeline bundle in a PipelineRun", func() {
-			defaultBundleConfigMap, err = f.HacbsUser.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
+			defaultBundleConfigMap, err = f.HacbsUserWs.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
 			if err != nil {
 				if errors.IsForbidden(err) {
 					klog.Infof("don't have enough permissions to get a configmap with default pipeline in %s namespace\n", constants.BuildPipelinesConfigMapDefaultNamespace)
@@ -506,7 +506,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			if defaultBundleRef == "" {
 				Skip("skipping - default pipeline bundle cannot be fetched")
 			}
-			pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false, "")
+			pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(defaultBundleRef))
 		})
@@ -518,7 +518,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				timeout := time.Second * 600
 				interval := time.Second * 10
 				Eventually(func() bool {
-					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false, "")
+					pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false, "")
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, condition := range pipelineRun.Status.Conditions {
@@ -526,7 +526,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 						if condition.Reason == string(v1beta1.PipelineRunReasonFailed) {
 							d := utils.GetFailedPipelineRunDetails(pipelineRun)
-							logs, _ := f.HacbsUser.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
+							logs, _ := f.HacbsUserWs.CommonController.GetContainerLogs(d.PodName, d.FailedContainerName, testNamespace)
 							Fail(fmt.Sprintf("Pipelinerun '%s' has failed. Logs from failed container '%s': \n%s", pipelineRun.Name, d.FailedContainerName, logs))
 						}
 					}
@@ -537,7 +537,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			It("should validate HACBS taskrun results", func() {
 				// List Of Taskruns Expected to Get Taskrun Results
 				gatherResult := []string{"conftest-clair", "sanity-inspect-image", "sanity-label-check", "sast-go", "sast-java-sec-check", "clamav-scan"}
-				pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false, "")
+				pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentNames[0], applicationName, testNamespace, false, "")
 				Expect(err).ShouldNot(HaveOccurred())
 
 				for i := range gatherResult {
@@ -557,7 +557,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 			When("the container image is created and pushed to container registry", Label("sbom", "slow"), func() {
 				It("contains non-empty sbom files", func() {
-					component, err := f.HacbsUser.HasController.GetHasComponent(componentName, testNamespace)
+					component, err := f.HacbsUserWs.HasController.GetHasComponent(componentName, testNamespace)
 					Expect(err).ShouldNot(HaveOccurred())
 					purl, cyclonedx, err := build.GetParsedSbomFilesContentFromImage(component.Spec.ContainerImage)
 					Expect(err).NotTo(HaveOccurred())
@@ -600,30 +600,30 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
 			testNamespace = fmt.Sprintf("build-e2e-container-image-source-%s", util.GenerateRandomString(4))
 
-			_, err = f.HacbsUser.CommonController.CreateTestNamespace(testNamespace)
+			_, err = f.HacbsUserWs.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
-			DeferCleanup(f.HacbsUser.CommonController.DeleteNamespace, testNamespace)
+			DeferCleanup(f.HacbsUserWs.CommonController.DeleteNamespace, testNamespace)
 
-			app, err := f.HacbsUser.HasController.CreateHasApplication(applicationName, testNamespace)
+			app, err := f.HacbsUserWs.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(utils.WaitUntil(f.HacbsUser.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+			Expect(utils.WaitUntil(f.HacbsUserWs.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 			)
-			DeferCleanup(f.HacbsUser.HasController.DeleteHasApplication, applicationName, testNamespace, false)
+			DeferCleanup(f.HacbsUserWs.HasController.DeleteHasApplication, applicationName, testNamespace, false)
 
 			componentName = fmt.Sprintf("build-suite-test-component-image-source-%s", util.GenerateRandomString(4))
 			outputContainerImage := ""
 			timeout = time.Second * 180
 			interval = time.Second * 1
 			// Create a component with containerImageSource being defined
-			_, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, "", "", containerImageSource, outputContainerImage, "")
+			_, err = f.HacbsUserWs.HasController.CreateComponent(applicationName, componentName, testNamespace, "", "", containerImageSource, outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			DeferCleanup(f.HacbsUser.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
+			DeferCleanup(f.HacbsUserWs.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
 		})
 
 		It("should not trigger a PipelineRun", func() {
 			Consistently(func() bool {
-				_, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+				_, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
 				Expect(err).NotTo(BeNil())
 				return strings.Contains(err.Error(), "no pipelinerun found")
 			}, timeout, interval).Should(BeTrue(), fmt.Sprintf("expected no PipelineRun to be triggered for the component %s in %s namespace", componentName, testNamespace))
@@ -640,13 +640,13 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			testNamespace := fmt.Sprintf("build-e2e-dummy-custom-pipeline-%s", util.GenerateRandomString(4))
 			applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
 
-			_, err = f.HacbsUser.CommonController.CreateTestNamespace(testNamespace)
+			_, err = f.HacbsUserWs.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
-			DeferCleanup(f.HacbsUser.CommonController.DeleteNamespace, testNamespace)
+			DeferCleanup(f.HacbsUserWs.CommonController.DeleteNamespace, testNamespace)
 
-			app, err := f.HacbsUser.HasController.CreateHasApplication(applicationName, testNamespace)
+			app, err := f.HacbsUserWs.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(utils.WaitUntil(f.HacbsUser.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+			Expect(utils.WaitUntil(f.HacbsUserWs.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 			)
 
@@ -654,14 +654,14 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
 				Data:       map[string]string{"default_build_bundle": dummyPipelineBundleRef},
 			}
-			_, err = f.HacbsUser.CommonController.CreateConfigMap(cm, testNamespace)
+			_, err = f.HacbsUserWs.CommonController.CreateConfigMap(cm, testNamespace)
 			Expect(err).ToNot(HaveOccurred())
 
 			componentName = "build-suite-test-bundle-overriding"
 			outputContainerImage := fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-			_, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
+			_, err = f.HacbsUserWs.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			DeferCleanup(f.HacbsUser.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
+			DeferCleanup(f.HacbsUserWs.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
 
 			timeout = time.Second * 360
 			interval = time.Second * 1
@@ -669,12 +669,12 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		})
 
 		// AfterAll(func() {
-		// 	f.HacbsUser.CommonController.DeleteNamespace(testNamespace)
+		// 	f.HacbsUserWs.CommonController.DeleteNamespace(testNamespace)
 		// })
 
 		It("should be referenced in a PipelineRun", Label("build-bundle-overriding"), func() {
 			Eventually(func() bool {
-				pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+				pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
 				if err != nil {
 					klog.Infoln("PipelineRun has not been created yet")
 					return false
@@ -682,7 +682,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				return pipelineRun.HasStarted()
 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
 
-			pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+			pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(pipelineRun.Spec.PipelineRef.Bundle).To(Equal(dummyPipelineBundleRef))
 		})
@@ -697,11 +697,11 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 			testNamespace = fmt.Sprintf("build-e2e-dummy-quay-creds-%s", util.GenerateRandomString(4))
 
-			_, err = f.HacbsUser.CommonController.CreateTestNamespace(testNamespace)
+			_, err = f.HacbsUserWs.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
-			DeferCleanup(f.HacbsUser.CommonController.DeleteNamespace, testNamespace)
+			DeferCleanup(f.HacbsUserWs.CommonController.DeleteNamespace, testNamespace)
 
-			_, err := f.HacbsUser.CommonController.GetSecret(testNamespace, constants.RegistryAuthSecretName)
+			_, err := f.HacbsUserWs.CommonController.GetSecret(testNamespace, constants.RegistryAuthSecretName)
 			if err != nil {
 				// If we have an error when getting RegistryAuthSecretName, it should be IsNotFound err
 				Expect(errors.IsNotFound(err)).To(BeTrue())
@@ -711,12 +711,12 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 			applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
 
-			app, err := f.HacbsUser.HasController.CreateHasApplication(applicationName, testNamespace)
+			app, err := f.HacbsUserWs.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(utils.WaitUntil(f.HacbsUser.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+			Expect(utils.WaitUntil(f.HacbsUserWs.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 			)
-			DeferCleanup(f.HacbsUser.HasController.DeleteHasApplication, applicationName, testNamespace, false)
+			DeferCleanup(f.HacbsUserWs.HasController.DeleteHasApplication, applicationName, testNamespace, false)
 
 			timeout = time.Minute * 5
 			interval = time.Second * 1
@@ -727,20 +727,20 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				Data:       map[string][]byte{".dockerconfigjson": []byte("{\"auths\":{\"quay.io\":{\"username\":\"test\",\"password\":\"test\",\"auth\":\"dGVzdDp0ZXN0\",\"email\":\"\"}}}")},
 			}
 
-			_, err = f.HacbsUser.CommonController.CreateSecret(testNamespace, dummySecret)
+			_, err = f.HacbsUserWs.CommonController.CreateSecret(testNamespace, dummySecret)
 			Expect(err).ToNot(HaveOccurred())
 
 			componentName = "build-suite-test-secret-overriding"
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-			_, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
+			_, err = f.HacbsUserWs.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			DeferCleanup(f.HacbsUser.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
+			DeferCleanup(f.HacbsUserWs.TektonController.DeleteAllPipelineRunsInASpecificNamespace, testNamespace)
 
 		})
 
 		It("should override the shared secret", func() {
 			Eventually(func() bool {
-				pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+				pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
 				if err != nil {
 					klog.Infoln("PipelineRun has not been created yet")
 					return false
@@ -748,7 +748,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				return pipelineRun.HasStarted()
 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
 
-			pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+			pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(pipelineRun.Spec.Workspaces).To(HaveLen(2))
 			registryAuthWorkspace := &v1beta1.WorkspaceBinding{
@@ -764,7 +764,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			timeout = time.Minute * 10
 			interval = time.Second * 5
 			Eventually(func() bool {
-				pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+				pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
 				Expect(err).ShouldNot(HaveOccurred())
 
 				for _, condition := range pipelineRun.Status.Conditions {
@@ -785,21 +785,21 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			applicationName = fmt.Sprintf("test-app-%s", util.GenerateRandomString(4))
 			testNamespace = fmt.Sprintf("build-e2e-specific-image-url-%s", util.GenerateRandomString(4))
 
-			_, err = f.HacbsUser.CommonController.CreateTestNamespace(testNamespace)
+			_, err = f.HacbsUserWs.CommonController.CreateTestNamespace(testNamespace)
 			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
-			app, err := f.HacbsUser.HasController.CreateHasApplication(applicationName, testNamespace)
+			app, err := f.HacbsUserWs.HasController.CreateHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(utils.WaitUntil(f.HacbsUser.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+			Expect(utils.WaitUntil(f.HacbsUserWs.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 			)
 
 		})
 
 		AfterAll(func() {
-			Expect(f.HacbsUser.HasController.DeleteAllComponentsInASpecificNamespace(testNamespace, 30*time.Second)).To(Succeed())
-			Expect(f.HacbsUser.HasController.DeleteAllApplicationsInASpecificNamespace(testNamespace, 30*time.Second)).To(Succeed())
-			Expect(f.HacbsUser.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(Succeed())
-			Expect(f.HacbsUser.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
+			Expect(f.HacbsUserWs.HasController.DeleteAllComponentsInASpecificNamespace(testNamespace, 30*time.Second)).To(Succeed())
+			Expect(f.HacbsUserWs.HasController.DeleteAllApplicationsInASpecificNamespace(testNamespace, 30*time.Second)).To(Succeed())
+			Expect(f.HacbsUserWs.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(Succeed())
+			Expect(f.HacbsUserWs.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
 		})
 
 		JustBeforeEach(func() {
@@ -807,23 +807,23 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		})
 		It("should fail for ContainerImage field set to a protected repository (without an image tag)", func() {
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected", utils.GetQuayIOOrganization())
-			_, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
+			_, err = f.HacbsUserWs.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
 			Expect(err).ToNot(BeNil())
 
 		})
 		It("should fail for ContainerImage field set to a protected repository followed by a random tag", func() {
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-			_, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
+			_, err = f.HacbsUserWs.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
 			Expect(err).ToNot(BeNil())
 		})
 		It("should succeed for ContainerImage field set to a protected repository followed by a namespace prefix + dash + string", func() {
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images-protected:%s-%s", utils.GetQuayIOOrganization(), testNamespace, strings.Replace(uuid.New().String(), "-", "", -1))
-			_, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
+			_, err = f.HacbsUserWs.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("should succeed for ContainerImage field set to a custom (unprotected) repository without a tag being specified", func() {
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images", utils.GetQuayIOOrganization())
-			_, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
+			_, err = f.HacbsUserWs.HasController.CreateComponent(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, "", "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -1,354 +1,354 @@
 package build
 
-import (
-	"context"
-	"fmt"
-	"time"
+// import (
+// 	"context"
+// 	"fmt"
+// 	"time"
 
-	"github.com/devfile/library/pkg/util"
-	ecp "github.com/hacbs-contract/enterprise-contract-controller/api/v1alpha1"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
+// 	"github.com/devfile/library/pkg/util"
+// 	ecp "github.com/hacbs-contract/enterprise-contract-controller/api/v1alpha1"
+// 	. "github.com/onsi/ginkgo/v2"
+// 	. "github.com/onsi/gomega"
+// 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+// 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+// 	"sigs.k8s.io/yaml"
 
-	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
-	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
-	"github.com/redhat-appstudio/e2e-tests/pkg/utils/common"
-	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
-)
+// 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
+// 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
+// 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/common"
+// 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
+// )
 
-var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HACBS"), func() {
-	defer GinkgoRecover()
+// var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HACBS"), func() {
+// 	defer GinkgoRecover()
 
-	var fwk *framework.Framework
+// 	var fwk *framework.Framework
 
-	BeforeAll(func() {
-		// Initialize the tests controllers
-		var err error
-		fwk, err = framework.NewFramework()
-		Expect(err).NotTo(HaveOccurred())
-	})
+// 	BeforeAll(func() {
+// 		// Initialize the tests controllers
+// 		var err error
+// 		fwk, err = framework.NewFramework()
+// 		Expect(err).NotTo(HaveOccurred())
+// 	})
 
-	Context("infrastructure is running", func() {
-		It("verify the chains controller is running", func() {
-			err := fwk.CommonController.WaitForPodSelector(fwk.CommonController.IsPodRunning, constants.TEKTON_CHAINS_NS, "app", "tekton-chains-controller", 60, 100)
-			Expect(err).NotTo(HaveOccurred())
-		})
-		It("verify the correct secrets have been created", func() {
-			_, err := fwk.CommonController.GetSecret(constants.TEKTON_CHAINS_NS, "chains-ca-cert")
-			Expect(err).NotTo(HaveOccurred())
-		})
-		It("verify the correct roles are created", func() {
-			_, csaErr := fwk.CommonController.GetRole("chains-secret-admin", constants.TEKTON_CHAINS_NS)
-			Expect(csaErr).NotTo(HaveOccurred())
-			_, srErr := fwk.CommonController.GetRole("secret-reader", "openshift-ingress-operator")
-			Expect(srErr).NotTo(HaveOccurred())
-		})
-		It("verify the correct rolebindings are created", func() {
-			_, csaErr := fwk.CommonController.GetRoleBinding("chains-secret-admin", constants.TEKTON_CHAINS_NS)
-			Expect(csaErr).NotTo(HaveOccurred())
-			_, csrErr := fwk.CommonController.GetRoleBinding("chains-secret-reader", "openshift-ingress-operator")
-			Expect(csrErr).NotTo(HaveOccurred())
-		})
-		It("verify the correct service account is created", func() {
-			_, err := fwk.CommonController.GetServiceAccount("chains-secrets-admin", constants.TEKTON_CHAINS_NS)
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
+// 	Context("infrastructure is running", func() {
+// 		It("verify the chains controller is running", func() {
+// 			err := fwk.CommonController.WaitForPodSelector(fwk.CommonController.IsPodRunning, constants.TEKTON_CHAINS_NS, "app", "tekton-chains-controller", 60, 100)
+// 			Expect(err).NotTo(HaveOccurred())
+// 		})
+// 		It("verify the correct secrets have been created", func() {
+// 			_, err := fwk.CommonController.GetSecret(constants.TEKTON_CHAINS_NS, "chains-ca-cert")
+// 			Expect(err).NotTo(HaveOccurred())
+// 		})
+// 		It("verify the correct roles are created", func() {
+// 			_, csaErr := fwk.CommonController.GetRole("chains-secret-admin", constants.TEKTON_CHAINS_NS)
+// 			Expect(csaErr).NotTo(HaveOccurred())
+// 			_, srErr := fwk.CommonController.GetRole("secret-reader", "openshift-ingress-operator")
+// 			Expect(srErr).NotTo(HaveOccurred())
+// 		})
+// 		It("verify the correct rolebindings are created", func() {
+// 			_, csaErr := fwk.CommonController.GetRoleBinding("chains-secret-admin", constants.TEKTON_CHAINS_NS)
+// 			Expect(csaErr).NotTo(HaveOccurred())
+// 			_, csrErr := fwk.CommonController.GetRoleBinding("chains-secret-reader", "openshift-ingress-operator")
+// 			Expect(csrErr).NotTo(HaveOccurred())
+// 		})
+// 		It("verify the correct service account is created", func() {
+// 			_, err := fwk.CommonController.GetServiceAccount("chains-secrets-admin", constants.TEKTON_CHAINS_NS)
+// 			Expect(err).NotTo(HaveOccurred())
+// 		})
+// 	})
 
-	Context("test creating and signing an image and task", func() {
-		// Make the PipelineRun name and namespace predictable. For convenience, the name of the
-		// PipelineRun that builds an image, is the same as the repository where the image is
-		// pushed to.
-		namespace := constants.TEKTON_CHAINS_E2E_NS
-		buildPipelineRunName := fmt.Sprintf("buildah-demo-%s", util.GenerateRandomString(10))
-		image := fmt.Sprintf("image-registry.openshift-image-registry.svc:5000/%s/%s", namespace, buildPipelineRunName)
-		var imageWithDigest string
-		serviceAccountName := "pipeline"
+// 	Context("test creating and signing an image and task", func() {
+// 		// Make the PipelineRun name and namespace predictable. For convenience, the name of the
+// 		// PipelineRun that builds an image, is the same as the repository where the image is
+// 		// pushed to.
+// 		namespace := constants.TEKTON_CHAINS_E2E_NS
+// 		buildPipelineRunName := fmt.Sprintf("buildah-demo-%s", util.GenerateRandomString(10))
+// 		image := fmt.Sprintf("image-registry.openshift-image-registry.svc:5000/%s/%s", namespace, buildPipelineRunName)
+// 		var imageWithDigest string
+// 		serviceAccountName := "pipeline"
 
-		pipelineRunTimeout := 360
-		attestationTimeout := time.Duration(60) * time.Second
+// 		pipelineRunTimeout := 360
+// 		attestationTimeout := time.Duration(60) * time.Second
 
-		var kubeController tekton.KubeController
+// 		var kubeController tekton.KubeController
 
-		var policySource ecp.GitPolicySource
+// 		var policySource ecp.GitPolicySource
 
-		BeforeAll(func() {
-			kubeController = tekton.KubeController{
-				Commonctrl: *fwk.CommonController,
-				Tektonctrl: *fwk.TektonController,
-				Namespace:  namespace,
-			}
+// 		BeforeAll(func() {
+// 			kubeController = tekton.KubeController{
+// 				Commonctrl: *fwk.CommonController,
+// 				Tektonctrl: *fwk.TektonController,
+// 				Namespace:  namespace,
+// 			}
 
-			// Create the e2e test namespace
-			_, err := kubeController.Commonctrl.CreateTestNamespace(namespace)
-			Expect(err).NotTo(HaveOccurred(), "Error when creating namespace %q: %v", namespace, err)
+// 			// Create the e2e test namespace
+// 			_, err := kubeController.Commonctrl.CreateTestNamespace(namespace)
+// 			Expect(err).NotTo(HaveOccurred(), "Error when creating namespace %q: %v", namespace, err)
 
-			// Wait until the "pipeline" SA is created
-			GinkgoWriter.Printf("Wait until the %q SA is created in namespace %q\n", serviceAccountName, namespace)
-			Eventually(func() bool {
-				sa, err := kubeController.Commonctrl.GetServiceAccount(serviceAccountName, namespace)
-				return sa != nil && err == nil
-			}).WithTimeout(1*time.Minute).WithPolling(100*time.Millisecond).Should(
-				BeTrue(), "timed out when waiting for the %q SA to be created", serviceAccountName)
+// 			// Wait until the "pipeline" SA is created
+// 			GinkgoWriter.Printf("Wait until the %q SA is created in namespace %q\n", serviceAccountName, namespace)
+// 			Eventually(func() bool {
+// 				sa, err := kubeController.Commonctrl.GetServiceAccount(serviceAccountName, namespace)
+// 				return sa != nil && err == nil
+// 			}).WithTimeout(1*time.Minute).WithPolling(100*time.Millisecond).Should(
+// 				BeTrue(), "timed out when waiting for the %q SA to be created", serviceAccountName)
 
-			// the default policy source
-			rev := "main"
-			policySource = ecp.GitPolicySource{
-				Repository: "https://github.com/hacbs-contract/ec-policies/policy",
-				Revision:   &rev,
-			}
+// 			// the default policy source
+// 			rev := "main"
+// 			policySource = ecp.GitPolicySource{
+// 				Repository: "https://github.com/hacbs-contract/ec-policies/policy",
+// 				Revision:   &rev,
+// 			}
 
-			// if there is a ConfigMap e2e-tests/ec-config with keys `revision` and
-			// `repository` values from those will replace the default policy source
-			// this gives us a way to set the tests to use a different policy if we
-			// break the tests in the default policy source
-			if config, err := fwk.CommonController.K8sClient.KubeInterface().CoreV1().ConfigMaps("e2e-tests").Get(context.TODO(), "ec-config", v1.GetOptions{}); err != nil {
-				if v, ok := config.Data["revision"]; ok {
-					policySource.Revision = &v
-				}
-				if v, ok := config.Data["repository"]; ok {
-					policySource.Repository = v
-				}
-			}
+// 			// if there is a ConfigMap e2e-tests/ec-config with keys `revision` and
+// 			// `repository` values from those will replace the default policy source
+// 			// this gives us a way to set the tests to use a different policy if we
+// 			// break the tests in the default policy source
+// 			if config, err := fwk.CommonController.K8sClient.KubeInterface().CoreV1().ConfigMaps("e2e-tests").Get(context.TODO(), "ec-config", v1.GetOptions{}); err != nil {
+// 				if v, ok := config.Data["revision"]; ok {
+// 					policySource.Revision = &v
+// 				}
+// 				if v, ok := config.Data["repository"]; ok {
+// 					policySource.Repository = v
+// 				}
+// 			}
 
-			// At a bare minimum, each spec within this context relies on the existence of
-			// an image that has been signed by Tekton Chains. Trigger a demo task to fulfill
-			// this purpose.
-			pr, err := kubeController.RunPipeline(tekton.BuildahDemo{Image: image, Bundle: fwk.TektonController.Bundles.BuildTemplatesBundle}, pipelineRunTimeout)
-			Expect(err).NotTo(HaveOccurred())
-			// Verify that the build task was created as expected.
-			Expect(pr.ObjectMeta.Name).To(Equal(buildPipelineRunName))
-			Expect(pr.ObjectMeta.Namespace).To(Equal(namespace))
-			Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
-			GinkgoWriter.Printf("The pipeline named %q in namespace %q suceeded\n", pr.ObjectMeta.Name, pr.ObjectMeta.Namespace)
+// 			// At a bare minimum, each spec within this context relies on the existence of
+// 			// an image that has been signed by Tekton Chains. Trigger a demo task to fulfill
+// 			// this purpose.
+// 			pr, err := kubeController.RunPipeline(tekton.BuildahDemo{Image: image, Bundle: fwk.TektonController.Bundles.BuildTemplatesBundle}, pipelineRunTimeout)
+// 			Expect(err).NotTo(HaveOccurred())
+// 			// Verify that the build task was created as expected.
+// 			Expect(pr.ObjectMeta.Name).To(Equal(buildPipelineRunName))
+// 			Expect(pr.ObjectMeta.Namespace).To(Equal(namespace))
+// 			Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
+// 			GinkgoWriter.Printf("The pipeline named %q in namespace %q suceeded\n", pr.ObjectMeta.Name, pr.ObjectMeta.Namespace)
 
-			// The TaskRun resource has been updated, refresh our reference.
-			pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.ObjectMeta.Name, pr.ObjectMeta.Namespace)
-			Expect(err).NotTo(HaveOccurred())
+// 			// The TaskRun resource has been updated, refresh our reference.
+// 			pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.ObjectMeta.Name, pr.ObjectMeta.Namespace)
+// 			Expect(err).NotTo(HaveOccurred())
 
-			// Verify TaskRun has the type hinting required by Tekton Chains
-			digest, err := kubeController.GetTaskRunResult(pr, "build-container", "IMAGE_DIGEST")
-			Expect(err).NotTo(HaveOccurred())
-			i, err := kubeController.GetTaskRunResult(pr, "build-container", "IMAGE_URL")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(i).To(Equal(image))
+// 			// Verify TaskRun has the type hinting required by Tekton Chains
+// 			digest, err := kubeController.GetTaskRunResult(pr, "build-container", "IMAGE_DIGEST")
+// 			Expect(err).NotTo(HaveOccurred())
+// 			i, err := kubeController.GetTaskRunResult(pr, "build-container", "IMAGE_URL")
+// 			Expect(err).NotTo(HaveOccurred())
+// 			Expect(i).To(Equal(image))
 
-			// Specs now have a deterministic image reference for validation \o/
-			imageWithDigest = fmt.Sprintf("%s@%s", image, digest)
+// 			// Specs now have a deterministic image reference for validation \o/
+// 			imageWithDigest = fmt.Sprintf("%s@%s", image, digest)
 
-			GinkgoWriter.Printf("The image signed by Tekton Chains is %s\n", imageWithDigest)
-		})
+// 			GinkgoWriter.Printf("The image signed by Tekton Chains is %s\n", imageWithDigest)
+// 		})
 
-		It("creates signature and attestation", func() {
-			err := kubeController.AwaitAttestationAndSignature(imageWithDigest, attestationTimeout)
-			Expect(err).NotTo(
-				HaveOccurred(),
-				"Could not find .att or .sig ImageStreamTags within the %s timeout. "+
-					"Most likely the chains-controller did not create those in time. "+
-					"Look at the chains-controller logs.",
-				attestationTimeout.String(),
-			)
-			GinkgoWriter.Printf("Cosign verify pass with .att and .sig ImageStreamTags found for %s\n", imageWithDigest)
-		})
+// 		It("creates signature and attestation", func() {
+// 			err := kubeController.AwaitAttestationAndSignature(imageWithDigest, attestationTimeout)
+// 			Expect(err).NotTo(
+// 				HaveOccurred(),
+// 				"Could not find .att or .sig ImageStreamTags within the %s timeout. "+
+// 					"Most likely the chains-controller did not create those in time. "+
+// 					"Look at the chains-controller logs.",
+// 				attestationTimeout.String(),
+// 			)
+// 			GinkgoWriter.Printf("Cosign verify pass with .att and .sig ImageStreamTags found for %s\n", imageWithDigest)
+// 		})
 
-		Context("verify-enterprise-contract task", func() {
-			var generator tekton.VerifyEnterpriseContract
-			var rekorHost string
-			publicSecretName := "cosign-public-key"
+// 		Context("verify-enterprise-contract task", func() {
+// 			var generator tekton.VerifyEnterpriseContract
+// 			var rekorHost string
+// 			publicSecretName := "cosign-public-key"
 
-			BeforeAll(func() {
-				// Copy the public key from tekton-chains/signing-secrets to a new
-				// secret that contains just the public key to ensure that access
-				// to password and private key are not needed.
-				publicKey, err := kubeController.GetPublicKey("signing-secrets", constants.TEKTON_CHAINS_NS)
-				Expect(err).ToNot(HaveOccurred())
-				GinkgoWriter.Printf("Copy public key from %s/signing-secrets to a new secret\n", constants.TEKTON_CHAINS_NS)
-				Expect(kubeController.CreateOrUpdateSigningSecret(
-					publicKey, publicSecretName, namespace)).To(Succeed())
+// 			BeforeAll(func() {
+// 				// Copy the public key from tekton-chains/signing-secrets to a new
+// 				// secret that contains just the public key to ensure that access
+// 				// to password and private key are not needed.
+// 				publicKey, err := kubeController.GetPublicKey("signing-secrets", constants.TEKTON_CHAINS_NS)
+// 				Expect(err).ToNot(HaveOccurred())
+// 				GinkgoWriter.Printf("Copy public key from %s/signing-secrets to a new secret\n", constants.TEKTON_CHAINS_NS)
+// 				Expect(kubeController.CreateOrUpdateSigningSecret(
+// 					publicKey, publicSecretName, namespace)).To(Succeed())
 
-				rekorHost, err = kubeController.GetRekorHost()
-				Expect(err).ToNot(HaveOccurred())
-				GinkgoWriter.Printf("Configured Rekor host: %s\n", rekorHost)
-			})
+// 				rekorHost, err = kubeController.GetRekorHost()
+// 				Expect(err).ToNot(HaveOccurred())
+// 				GinkgoWriter.Printf("Configured Rekor host: %s\n", rekorHost)
+// 			})
 
-			BeforeEach(func() {
-				generator = tekton.VerifyEnterpriseContract{
-					PipelineRunName: "verify-enterprise-contract",
-					ImageRef:        imageWithDigest,
-					PublicSecret:    fmt.Sprintf("k8s://%s/%s", namespace, publicSecretName),
-					PipelineName:    "pipeline-run-that-does-not-exist",
-					RekorHost:       rekorHost,
-					SslCertDir:      "/var/run/secrets/kubernetes.io/serviceaccount",
-					StrictPolicy:    true,
-					Bundle:          fwk.TektonController.Bundles.HACBSTemplatesBundle,
-				}
+// 			BeforeEach(func() {
+// 				generator = tekton.VerifyEnterpriseContract{
+// 					PipelineRunName: "verify-enterprise-contract",
+// 					ImageRef:        imageWithDigest,
+// 					PublicSecret:    fmt.Sprintf("k8s://%s/%s", namespace, publicSecretName),
+// 					PipelineName:    "pipeline-run-that-does-not-exist",
+// 					RekorHost:       rekorHost,
+// 					SslCertDir:      "/var/run/secrets/kubernetes.io/serviceaccount",
+// 					StrictPolicy:    true,
+// 					Bundle:          fwk.TektonController.Bundles.HACBSTemplatesBundle,
+// 				}
 
-				// Since specs could update the config policy, make sure it has a consistent
-				// baseline at the start of each spec.
-				baselinePolicies := ecp.EnterpriseContractPolicySpec{
-					Sources: []ecp.PolicySource{
-						{
-							GitRepository: &policySource,
-						},
-					},
-				}
-				Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, baselinePolicies)).To(Succeed())
-				printPolicyConfiguration(baselinePolicies)
-			})
+// 				// Since specs could update the config policy, make sure it has a consistent
+// 				// baseline at the start of each spec.
+// 				baselinePolicies := ecp.EnterpriseContractPolicySpec{
+// 					Sources: []ecp.PolicySource{
+// 						{
+// 							GitRepository: &policySource,
+// 						},
+// 					},
+// 				}
+// 				Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, baselinePolicies)).To(Succeed())
+// 				printPolicyConfiguration(baselinePolicies)
+// 			})
 
-			It("succeeds when policy is met", func() {
-				// Setup a policy config to ignore the policy check for tests
-				policy := ecp.EnterpriseContractPolicySpec{
-					Sources: []ecp.PolicySource{
-						{
-							GitRepository: &policySource,
-						},
-					},
-					Exceptions: &ecp.EnterpriseContractPolicyExceptions{
-						NonBlocking: []string{"not_useful", "test", "tasks", "attestation_task_bundle"}, // add more exceptions here as needed
-					},
-				}
-				Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
-				printPolicyConfiguration(policy)
-				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
+// 			It("succeeds when policy is met", func() {
+// 				// Setup a policy config to ignore the policy check for tests
+// 				policy := ecp.EnterpriseContractPolicySpec{
+// 					Sources: []ecp.PolicySource{
+// 						{
+// 							GitRepository: &policySource,
+// 						},
+// 					},
+// 					Exceptions: &ecp.EnterpriseContractPolicyExceptions{
+// 						NonBlocking: []string{"not_useful", "test", "tasks", "attestation_task_bundle"}, // add more exceptions here as needed
+// 					},
+// 				}
+// 				Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
+// 				printPolicyConfiguration(policy)
+// 				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
+// 				Expect(err).NotTo(HaveOccurred())
+// 				Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
 
-				// Refresh our copy of the PipelineRun for latest results
-				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
-				Expect(err).NotTo(HaveOccurred())
+// 				// Refresh our copy of the PipelineRun for latest results
+// 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
+// 				Expect(err).NotTo(HaveOccurred())
 
-				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
-				Expect(err).NotTo(HaveOccurred())
-				printTaskRunStatus(tr, namespace, *fwk.CommonController)
-				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s suceeded\n", tr.PipelineTaskName, pr.Name)
-				Expect(tekton.DidTaskSucceed(tr)).To(BeTrue())
-				GinkgoWriter.Printf("Make sure EC-v2 results for PipelineRun %s are succeeding\n", pr.Name)
-				Expect(tr.Status.TaskRunResults).Should(ContainElements(
-					tekton.MatchTaskRunResultWithJSONPathValue("REPORT", "{$.success}", "[true]"),
-				))
-			})
+// 				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
+// 				Expect(err).NotTo(HaveOccurred())
+// 				printTaskRunStatus(tr, namespace, *fwk.CommonController)
+// 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s suceeded\n", tr.PipelineTaskName, pr.Name)
+// 				Expect(tekton.DidTaskSucceed(tr)).To(BeTrue())
+// 				GinkgoWriter.Printf("Make sure EC-v2 results for PipelineRun %s are succeeding\n", pr.Name)
+// 				Expect(tr.Status.TaskRunResults).Should(ContainElements(
+// 					tekton.MatchTaskRunResultWithJSONPathValue("REPORT", "{$.success}", "[true]"),
+// 				))
+// 			})
 
-			It("does not pass when tests are not satisfied on non-strict mode", func() {
-				// Setup a policy config to minimize the amount of policy violations. Otherwise,
-				// the report may exceed the 4k max and Tekton does not create the task result.
-				policy := ecp.EnterpriseContractPolicySpec{
-					Sources: []ecp.PolicySource{{GitRepository: &policySource}},
-					Exceptions: &ecp.EnterpriseContractPolicyExceptions{
-						NonBlocking: []string{"tasks", "attestation_task_bundle"},
-					},
-				}
-				Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
-				printPolicyConfiguration(policy)
-				generator.StrictPolicy = false
-				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
+// 			It("does not pass when tests are not satisfied on non-strict mode", func() {
+// 				// Setup a policy config to minimize the amount of policy violations. Otherwise,
+// 				// the report may exceed the 4k max and Tekton does not create the task result.
+// 				policy := ecp.EnterpriseContractPolicySpec{
+// 					Sources: []ecp.PolicySource{{GitRepository: &policySource}},
+// 					Exceptions: &ecp.EnterpriseContractPolicyExceptions{
+// 						NonBlocking: []string{"tasks", "attestation_task_bundle"},
+// 					},
+// 				}
+// 				Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
+// 				printPolicyConfiguration(policy)
+// 				generator.StrictPolicy = false
+// 				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
+// 				Expect(err).NotTo(HaveOccurred())
+// 				Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
 
-				// Refresh our copy of the PipelineRun for latest results
-				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
-				Expect(err).NotTo(HaveOccurred())
+// 				// Refresh our copy of the PipelineRun for latest results
+// 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
+// 				Expect(err).NotTo(HaveOccurred())
 
-				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
-				Expect(err).NotTo(HaveOccurred())
-				printTaskRunStatus(tr, namespace, *fwk.CommonController)
-				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s suceeded\n", tr.PipelineTaskName, pr.Name)
-				Expect(tekton.DidTaskSucceed(tr)).To(BeTrue())
-				GinkgoWriter.Printf("Make sure EC-v2 results for PipelineRun %s are failing\n", pr.Name)
-				Expect(tr.Status.TaskRunResults).Should(ContainElements(
-					tekton.MatchTaskRunResultWithJSONPathValue("REPORT", "{$.success}", "[false]"),
-				))
-			})
+// 				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
+// 				Expect(err).NotTo(HaveOccurred())
+// 				printTaskRunStatus(tr, namespace, *fwk.CommonController)
+// 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s suceeded\n", tr.PipelineTaskName, pr.Name)
+// 				Expect(tekton.DidTaskSucceed(tr)).To(BeTrue())
+// 				GinkgoWriter.Printf("Make sure EC-v2 results for PipelineRun %s are failing\n", pr.Name)
+// 				Expect(tr.Status.TaskRunResults).Should(ContainElements(
+// 					tekton.MatchTaskRunResultWithJSONPathValue("REPORT", "{$.success}", "[false]"),
+// 				))
+// 			})
 
-			It("fails when tests are not satisfied on strict mode", func() {
-				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
-				Expect(err).NotTo(HaveOccurred())
-				err = kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)
-				Expect(err).NotTo(HaveOccurred())
+// 			It("fails when tests are not satisfied on strict mode", func() {
+// 				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
+// 				Expect(err).NotTo(HaveOccurred())
+// 				err = kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)
+// 				Expect(err).NotTo(HaveOccurred())
 
-				// Refresh our copy of the PipelineRun for latest results
-				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
-				Expect(err).NotTo(HaveOccurred())
+// 				// Refresh our copy of the PipelineRun for latest results
+// 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
+// 				Expect(err).NotTo(HaveOccurred())
 
-				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
-				Expect(err).NotTo(HaveOccurred())
-				printTaskRunStatus(tr, namespace, *fwk.CommonController)
-				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s failed\n", tr.PipelineTaskName, pr.Name)
-				Expect(tekton.DidTaskSucceed(tr)).To(BeFalse())
-				// Because the task fails, no results are created
-			})
+// 				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
+// 				Expect(err).NotTo(HaveOccurred())
+// 				printTaskRunStatus(tr, namespace, *fwk.CommonController)
+// 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s failed\n", tr.PipelineTaskName, pr.Name)
+// 				Expect(tekton.DidTaskSucceed(tr)).To(BeFalse())
+// 				// Because the task fails, no results are created
+// 			})
 
-			It("fails when unexpected signature is used", func() {
-				secretName := fmt.Sprintf("dummy-public-key-%s", util.GenerateRandomString(10))
-				publicKey := []byte("-----BEGIN PUBLIC KEY-----\n" +
-					"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENZxkE/d0fKvJ51dXHQmxXaRMTtVz\n" +
-					"BQWcmJD/7pcMDEmBcmk8O1yUPIiFj5TMZqabjS9CQQN+jKHG+Bfi0BYlHg==\n" +
-					"-----END PUBLIC KEY-----")
-				GinkgoWriter.Println("Create an unexpected public signing key")
-				Expect(kubeController.CreateOrUpdateSigningSecret(publicKey, secretName, namespace)).To(Succeed())
-				generator.PublicSecret = fmt.Sprintf("k8s://%s/%s", namespace, secretName)
+// 			It("fails when unexpected signature is used", func() {
+// 				secretName := fmt.Sprintf("dummy-public-key-%s", util.GenerateRandomString(10))
+// 				publicKey := []byte("-----BEGIN PUBLIC KEY-----\n" +
+// 					"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENZxkE/d0fKvJ51dXHQmxXaRMTtVz\n" +
+// 					"BQWcmJD/7pcMDEmBcmk8O1yUPIiFj5TMZqabjS9CQQN+jKHG+Bfi0BYlHg==\n" +
+// 					"-----END PUBLIC KEY-----")
+// 				GinkgoWriter.Println("Create an unexpected public signing key")
+// 				Expect(kubeController.CreateOrUpdateSigningSecret(publicKey, secretName, namespace)).To(Succeed())
+// 				generator.PublicSecret = fmt.Sprintf("k8s://%s/%s", namespace, secretName)
 
-				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
-				Expect(err).NotTo(HaveOccurred())
-				err = kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)
-				Expect(err).NotTo(HaveOccurred())
+// 				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
+// 				Expect(err).NotTo(HaveOccurred())
+// 				err = kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)
+// 				Expect(err).NotTo(HaveOccurred())
 
-				// Refresh our copy of the PipelineRun for latest results
-				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
-				Expect(err).NotTo(HaveOccurred())
+// 				// Refresh our copy of the PipelineRun for latest results
+// 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
+// 				Expect(err).NotTo(HaveOccurred())
 
-				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
-				Expect(err).NotTo(HaveOccurred())
-				printTaskRunStatus(tr, namespace, *fwk.CommonController)
-				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s failed\n", tr.PipelineTaskName, pr.Name)
-				Expect(tekton.DidTaskSucceed(tr)).To(BeFalse())
-				// Because the task fails, no results are created
-			})
-		})
-	})
-})
+// 				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
+// 				Expect(err).NotTo(HaveOccurred())
+// 				printTaskRunStatus(tr, namespace, *fwk.CommonController)
+// 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s failed\n", tr.PipelineTaskName, pr.Name)
+// 				Expect(tekton.DidTaskSucceed(tr)).To(BeFalse())
+// 				// Because the task fails, no results are created
+// 			})
+// 		})
+// 	})
+// })
 
-func printPolicyConfiguration(policy ecp.EnterpriseContractPolicySpec) {
-	sources := ""
-	for i, s := range policy.Sources {
-		if i != 0 {
-			sources += "\n"
-		}
-		if s.GitRepository != nil {
-			if s.GitRepository.Revision != nil {
-				sources += fmt.Sprintf("[%d] repository: '%s', revision: '%s'", i, s.GitRepository.Repository, *s.GitRepository.Revision)
-			} else {
-				sources += fmt.Sprintf("[%d] repository: '%s'", i, s.GitRepository.Repository)
-			}
-		}
-	}
-	exceptions := "[]"
-	if policy.Exceptions != nil {
-		exceptions = fmt.Sprintf("%v", policy.Exceptions.NonBlocking)
-	}
-	GinkgoWriter.Printf("Configured sources: %s\nand non-blocking policies: %v\n", sources, exceptions)
-}
+// func printPolicyConfiguration(policy ecp.EnterpriseContractPolicySpec) {
+// 	sources := ""
+// 	for i, s := range policy.Sources {
+// 		if i != 0 {
+// 			sources += "\n"
+// 		}
+// 		if s.GitRepository != nil {
+// 			if s.GitRepository.Revision != nil {
+// 				sources += fmt.Sprintf("[%d] repository: '%s', revision: '%s'", i, s.GitRepository.Repository, *s.GitRepository.Revision)
+// 			} else {
+// 				sources += fmt.Sprintf("[%d] repository: '%s'", i, s.GitRepository.Repository)
+// 			}
+// 		}
+// 	}
+// 	exceptions := "[]"
+// 	if policy.Exceptions != nil {
+// 		exceptions = fmt.Sprintf("%v", policy.Exceptions.NonBlocking)
+// 	}
+// 	GinkgoWriter.Printf("Configured sources: %s\nand non-blocking policies: %v\n", sources, exceptions)
+// }
 
-func printTaskRunStatus(tr *v1beta1.PipelineRunTaskRunStatus, namespace string, sc common.SuiteController) {
-	if tr.Status == nil {
-		GinkgoWriter.Printf("*** TaskRun status: nil")
-		return
-	}
+// func printTaskRunStatus(tr *v1beta1.PipelineRunTaskRunStatus, namespace string, sc common.SuiteController) {
+// 	if tr.Status == nil {
+// 		GinkgoWriter.Printf("*** TaskRun status: nil")
+// 		return
+// 	}
 
-	if y, err := yaml.Marshal(tr.Status); err == nil {
-		GinkgoWriter.Printf("*** TaskRun status:\n%s\n", string(y))
-	} else {
-		GinkgoWriter.Printf("*** Unable to serialize TaskRunStatus to YAML: %#v; error: %s", tr.Status, err)
-	}
+// 	if y, err := yaml.Marshal(tr.Status); err == nil {
+// 		GinkgoWriter.Printf("*** TaskRun status:\n%s\n", string(y))
+// 	} else {
+// 		GinkgoWriter.Printf("*** Unable to serialize TaskRunStatus to YAML: %#v; error: %s", tr.Status, err)
+// 	}
 
-	for _, s := range tr.Status.TaskRunStatusFields.Steps {
-		if logs, err := sc.GetContainerLogs(tr.Status.PodName, s.ContainerName, namespace); err == nil {
-			GinkgoWriter.Printf("*** Logs from pod '%s', container '%s':\n----- START -----%s----- END -----\n", tr.Status.PodName, s.ContainerName, logs)
-		} else {
-			GinkgoWriter.Printf("*** Can't fetch logs from pod '%s', container '%s': %s", tr.Status.PodName, s.ContainerName, err)
-		}
-	}
-}
+// 	for _, s := range tr.Status.TaskRunStatusFields.Steps {
+// 		if logs, err := sc.GetContainerLogs(tr.Status.PodName, s.ContainerName, namespace); err == nil {
+// 			GinkgoWriter.Printf("*** Logs from pod '%s', container '%s':\n----- START -----%s----- END -----\n", tr.Status.PodName, s.ContainerName, logs)
+// 		} else {
+// 			GinkgoWriter.Printf("*** Can't fetch logs from pod '%s', container '%s': %s", tr.Status.PodName, s.ContainerName, err)
+// 		}
+// 	}
+// }

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -1,354 +1,354 @@
 package build
 
-// import (
-// 	"context"
-// 	"fmt"
-// 	"time"
+import (
+	"context"
+	"fmt"
+	"time"
 
-// 	"github.com/devfile/library/pkg/util"
-// 	ecp "github.com/hacbs-contract/enterprise-contract-controller/api/v1alpha1"
-// 	. "github.com/onsi/ginkgo/v2"
-// 	. "github.com/onsi/gomega"
-// 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-// 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-// 	"sigs.k8s.io/yaml"
+	"github.com/devfile/library/pkg/util"
+	ecp "github.com/hacbs-contract/enterprise-contract-controller/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
-// 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
-// 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
-// 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/common"
-// 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
-// )
+	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
+	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils/common"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
+)
 
-// var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HACBS"), func() {
-// 	defer GinkgoRecover()
+var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HACBS"), func() {
+	defer GinkgoRecover()
 
-// 	var fwk *framework.Framework
+	var fwk *framework.Framework
 
-// 	BeforeAll(func() {
-// 		// Initialize the tests controllers
-// 		var err error
-// 		fwk, err = framework.NewFramework()
-// 		Expect(err).NotTo(HaveOccurred())
-// 	})
+	BeforeAll(func() {
+		// Initialize the tests controllers
+		var err error
+		fwk, err = framework.NewFramework()
+		Expect(err).NotTo(HaveOccurred())
+	})
 
-// 	Context("infrastructure is running", func() {
-// 		It("verify the chains controller is running", func() {
-// 			err := fwk.CommonController.WaitForPodSelector(fwk.CommonController.IsPodRunning, constants.TEKTON_CHAINS_NS, "app", "tekton-chains-controller", 60, 100)
-// 			Expect(err).NotTo(HaveOccurred())
-// 		})
-// 		It("verify the correct secrets have been created", func() {
-// 			_, err := fwk.CommonController.GetSecret(constants.TEKTON_CHAINS_NS, "chains-ca-cert")
-// 			Expect(err).NotTo(HaveOccurred())
-// 		})
-// 		It("verify the correct roles are created", func() {
-// 			_, csaErr := fwk.CommonController.GetRole("chains-secret-admin", constants.TEKTON_CHAINS_NS)
-// 			Expect(csaErr).NotTo(HaveOccurred())
-// 			_, srErr := fwk.CommonController.GetRole("secret-reader", "openshift-ingress-operator")
-// 			Expect(srErr).NotTo(HaveOccurred())
-// 		})
-// 		It("verify the correct rolebindings are created", func() {
-// 			_, csaErr := fwk.CommonController.GetRoleBinding("chains-secret-admin", constants.TEKTON_CHAINS_NS)
-// 			Expect(csaErr).NotTo(HaveOccurred())
-// 			_, csrErr := fwk.CommonController.GetRoleBinding("chains-secret-reader", "openshift-ingress-operator")
-// 			Expect(csrErr).NotTo(HaveOccurred())
-// 		})
-// 		It("verify the correct service account is created", func() {
-// 			_, err := fwk.CommonController.GetServiceAccount("chains-secrets-admin", constants.TEKTON_CHAINS_NS)
-// 			Expect(err).NotTo(HaveOccurred())
-// 		})
-// 	})
+	Context("infrastructure is running", func() {
+		It("verify the chains controller is running", func() {
+			err := fwk.HacbsUser.CommonController.WaitForPodSelector(fwk.HacbsUser.CommonController.IsPodRunning, constants.TEKTON_CHAINS_NS, "app", "tekton-chains-controller", 60, 100)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("verify the correct secrets have been created", func() {
+			_, err := fwk.HacbsUser.CommonController.GetSecret(constants.TEKTON_CHAINS_NS, "chains-ca-cert")
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("verify the correct roles are created", func() {
+			_, csaErr := fwk.HacbsUser.CommonController.GetRole("chains-secret-admin", constants.TEKTON_CHAINS_NS)
+			Expect(csaErr).NotTo(HaveOccurred())
+			_, srErr := fwk.HacbsUser.CommonController.GetRole("secret-reader", "openshift-ingress-operator")
+			Expect(srErr).NotTo(HaveOccurred())
+		})
+		It("verify the correct rolebindings are created", func() {
+			_, csaErr := fwk.HacbsUser.CommonController.GetRoleBinding("chains-secret-admin", constants.TEKTON_CHAINS_NS)
+			Expect(csaErr).NotTo(HaveOccurred())
+			_, csrErr := fwk.HacbsUser.CommonController.GetRoleBinding("chains-secret-reader", "openshift-ingress-operator")
+			Expect(csrErr).NotTo(HaveOccurred())
+		})
+		It("verify the correct service account is created", func() {
+			_, err := fwk.HacbsUser.CommonController.GetServiceAccount("chains-secrets-admin", constants.TEKTON_CHAINS_NS)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
 
-// 	Context("test creating and signing an image and task", func() {
-// 		// Make the PipelineRun name and namespace predictable. For convenience, the name of the
-// 		// PipelineRun that builds an image, is the same as the repository where the image is
-// 		// pushed to.
-// 		namespace := constants.TEKTON_CHAINS_E2E_NS
-// 		buildPipelineRunName := fmt.Sprintf("buildah-demo-%s", util.GenerateRandomString(10))
-// 		image := fmt.Sprintf("image-registry.openshift-image-registry.svc:5000/%s/%s", namespace, buildPipelineRunName)
-// 		var imageWithDigest string
-// 		serviceAccountName := "pipeline"
+	Context("test creating and signing an image and task", func() {
+		// Make the PipelineRun name and namespace predictable. For convenience, the name of the
+		// PipelineRun that builds an image, is the same as the repository where the image is
+		// pushed to.
+		namespace := constants.TEKTON_CHAINS_E2E_NS
+		buildPipelineRunName := fmt.Sprintf("buildah-demo-%s", util.GenerateRandomString(10))
+		image := fmt.Sprintf("image-registry.openshift-image-registry.svc:5000/%s/%s", namespace, buildPipelineRunName)
+		var imageWithDigest string
+		serviceAccountName := "pipeline"
 
-// 		pipelineRunTimeout := 360
-// 		attestationTimeout := time.Duration(60) * time.Second
+		pipelineRunTimeout := 360
+		attestationTimeout := time.Duration(60) * time.Second
 
-// 		var kubeController tekton.KubeController
+		var kubeController tekton.KubeController
 
-// 		var policySource ecp.GitPolicySource
+		var policySource ecp.GitPolicySource
 
-// 		BeforeAll(func() {
-// 			kubeController = tekton.KubeController{
-// 				Commonctrl: *fwk.CommonController,
-// 				Tektonctrl: *fwk.TektonController,
-// 				Namespace:  namespace,
-// 			}
+		BeforeAll(func() {
+			kubeController = tekton.KubeController{
+				Commonctrl: *fwk.HacbsUser.CommonController,
+				Tektonctrl: *fwk.HacbsUser.TektonController,
+				Namespace:  namespace,
+			}
 
-// 			// Create the e2e test namespace
-// 			_, err := kubeController.Commonctrl.CreateTestNamespace(namespace)
-// 			Expect(err).NotTo(HaveOccurred(), "Error when creating namespace %q: %v", namespace, err)
+			// Create the e2e test namespace
+			_, err := kubeController.Commonctrl.CreateTestNamespace(namespace)
+			Expect(err).NotTo(HaveOccurred(), "Error when creating namespace %q: %v", namespace, err)
 
-// 			// Wait until the "pipeline" SA is created
-// 			GinkgoWriter.Printf("Wait until the %q SA is created in namespace %q\n", serviceAccountName, namespace)
-// 			Eventually(func() bool {
-// 				sa, err := kubeController.Commonctrl.GetServiceAccount(serviceAccountName, namespace)
-// 				return sa != nil && err == nil
-// 			}).WithTimeout(1*time.Minute).WithPolling(100*time.Millisecond).Should(
-// 				BeTrue(), "timed out when waiting for the %q SA to be created", serviceAccountName)
+			// Wait until the "pipeline" SA is created
+			GinkgoWriter.Printf("Wait until the %q SA is created in namespace %q\n", serviceAccountName, namespace)
+			Eventually(func() bool {
+				sa, err := kubeController.Commonctrl.GetServiceAccount(serviceAccountName, namespace)
+				return sa != nil && err == nil
+			}).WithTimeout(1*time.Minute).WithPolling(100*time.Millisecond).Should(
+				BeTrue(), "timed out when waiting for the %q SA to be created", serviceAccountName)
 
-// 			// the default policy source
-// 			rev := "main"
-// 			policySource = ecp.GitPolicySource{
-// 				Repository: "https://github.com/hacbs-contract/ec-policies/policy",
-// 				Revision:   &rev,
-// 			}
+			// the default policy source
+			rev := "main"
+			policySource = ecp.GitPolicySource{
+				Repository: "https://github.com/hacbs-contract/ec-policies/policy",
+				Revision:   &rev,
+			}
 
-// 			// if there is a ConfigMap e2e-tests/ec-config with keys `revision` and
-// 			// `repository` values from those will replace the default policy source
-// 			// this gives us a way to set the tests to use a different policy if we
-// 			// break the tests in the default policy source
-// 			if config, err := fwk.CommonController.K8sClient.KubeInterface().CoreV1().ConfigMaps("e2e-tests").Get(context.TODO(), "ec-config", v1.GetOptions{}); err != nil {
-// 				if v, ok := config.Data["revision"]; ok {
-// 					policySource.Revision = &v
-// 				}
-// 				if v, ok := config.Data["repository"]; ok {
-// 					policySource.Repository = v
-// 				}
-// 			}
+			// if there is a ConfigMap e2e-tests/ec-config with keys `revision` and
+			// `repository` values from those will replace the default policy source
+			// this gives us a way to set the tests to use a different policy if we
+			// break the tests in the default policy source
+			if config, err := fwk.HacbsUser.CommonController.KubeInterface().CoreV1().ConfigMaps("e2e-tests").Get(context.TODO(), "ec-config", v1.GetOptions{}); err != nil {
+				if v, ok := config.Data["revision"]; ok {
+					policySource.Revision = &v
+				}
+				if v, ok := config.Data["repository"]; ok {
+					policySource.Repository = v
+				}
+			}
 
-// 			// At a bare minimum, each spec within this context relies on the existence of
-// 			// an image that has been signed by Tekton Chains. Trigger a demo task to fulfill
-// 			// this purpose.
-// 			pr, err := kubeController.RunPipeline(tekton.BuildahDemo{Image: image, Bundle: fwk.TektonController.Bundles.BuildTemplatesBundle}, pipelineRunTimeout)
-// 			Expect(err).NotTo(HaveOccurred())
-// 			// Verify that the build task was created as expected.
-// 			Expect(pr.ObjectMeta.Name).To(Equal(buildPipelineRunName))
-// 			Expect(pr.ObjectMeta.Namespace).To(Equal(namespace))
-// 			Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
-// 			GinkgoWriter.Printf("The pipeline named %q in namespace %q suceeded\n", pr.ObjectMeta.Name, pr.ObjectMeta.Namespace)
+			// At a bare minimum, each spec within this context relies on the existence of
+			// an image that has been signed by Tekton Chains. Trigger a demo task to fulfill
+			// this purpose.
+			pr, err := kubeController.RunPipeline(tekton.BuildahDemo{Image: image, Bundle: fwk.HacbsUser.TektonController.Bundles.BuildTemplatesBundle}, pipelineRunTimeout)
+			Expect(err).NotTo(HaveOccurred())
+			// Verify that the build task was created as expected.
+			Expect(pr.ObjectMeta.Name).To(Equal(buildPipelineRunName))
+			Expect(pr.ObjectMeta.Namespace).To(Equal(namespace))
+			Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
+			GinkgoWriter.Printf("The pipeline named %q in namespace %q suceeded\n", pr.ObjectMeta.Name, pr.ObjectMeta.Namespace)
 
-// 			// The TaskRun resource has been updated, refresh our reference.
-// 			pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.ObjectMeta.Name, pr.ObjectMeta.Namespace)
-// 			Expect(err).NotTo(HaveOccurred())
+			// The TaskRun resource has been updated, refresh our reference.
+			pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.ObjectMeta.Name, pr.ObjectMeta.Namespace)
+			Expect(err).NotTo(HaveOccurred())
 
-// 			// Verify TaskRun has the type hinting required by Tekton Chains
-// 			digest, err := kubeController.GetTaskRunResult(pr, "build-container", "IMAGE_DIGEST")
-// 			Expect(err).NotTo(HaveOccurred())
-// 			i, err := kubeController.GetTaskRunResult(pr, "build-container", "IMAGE_URL")
-// 			Expect(err).NotTo(HaveOccurred())
-// 			Expect(i).To(Equal(image))
+			// Verify TaskRun has the type hinting required by Tekton Chains
+			digest, err := kubeController.GetTaskRunResult(pr, "build-container", "IMAGE_DIGEST")
+			Expect(err).NotTo(HaveOccurred())
+			i, err := kubeController.GetTaskRunResult(pr, "build-container", "IMAGE_URL")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(i).To(Equal(image))
 
-// 			// Specs now have a deterministic image reference for validation \o/
-// 			imageWithDigest = fmt.Sprintf("%s@%s", image, digest)
+			// Specs now have a deterministic image reference for validation \o/
+			imageWithDigest = fmt.Sprintf("%s@%s", image, digest)
 
-// 			GinkgoWriter.Printf("The image signed by Tekton Chains is %s\n", imageWithDigest)
-// 		})
+			GinkgoWriter.Printf("The image signed by Tekton Chains is %s\n", imageWithDigest)
+		})
 
-// 		It("creates signature and attestation", func() {
-// 			err := kubeController.AwaitAttestationAndSignature(imageWithDigest, attestationTimeout)
-// 			Expect(err).NotTo(
-// 				HaveOccurred(),
-// 				"Could not find .att or .sig ImageStreamTags within the %s timeout. "+
-// 					"Most likely the chains-controller did not create those in time. "+
-// 					"Look at the chains-controller logs.",
-// 				attestationTimeout.String(),
-// 			)
-// 			GinkgoWriter.Printf("Cosign verify pass with .att and .sig ImageStreamTags found for %s\n", imageWithDigest)
-// 		})
+		It("creates signature and attestation", func() {
+			err := kubeController.AwaitAttestationAndSignature(imageWithDigest, attestationTimeout)
+			Expect(err).NotTo(
+				HaveOccurred(),
+				"Could not find .att or .sig ImageStreamTags within the %s timeout. "+
+					"Most likely the chains-controller did not create those in time. "+
+					"Look at the chains-controller logs.",
+				attestationTimeout.String(),
+			)
+			GinkgoWriter.Printf("Cosign verify pass with .att and .sig ImageStreamTags found for %s\n", imageWithDigest)
+		})
 
-// 		Context("verify-enterprise-contract task", func() {
-// 			var generator tekton.VerifyEnterpriseContract
-// 			var rekorHost string
-// 			publicSecretName := "cosign-public-key"
+		Context("verify-enterprise-contract task", func() {
+			var generator tekton.VerifyEnterpriseContract
+			var rekorHost string
+			publicSecretName := "cosign-public-key"
 
-// 			BeforeAll(func() {
-// 				// Copy the public key from tekton-chains/signing-secrets to a new
-// 				// secret that contains just the public key to ensure that access
-// 				// to password and private key are not needed.
-// 				publicKey, err := kubeController.GetPublicKey("signing-secrets", constants.TEKTON_CHAINS_NS)
-// 				Expect(err).ToNot(HaveOccurred())
-// 				GinkgoWriter.Printf("Copy public key from %s/signing-secrets to a new secret\n", constants.TEKTON_CHAINS_NS)
-// 				Expect(kubeController.CreateOrUpdateSigningSecret(
-// 					publicKey, publicSecretName, namespace)).To(Succeed())
+			BeforeAll(func() {
+				// Copy the public key from tekton-chains/signing-secrets to a new
+				// secret that contains just the public key to ensure that access
+				// to password and private key are not needed.
+				publicKey, err := kubeController.GetPublicKey("signing-secrets", constants.TEKTON_CHAINS_NS)
+				Expect(err).ToNot(HaveOccurred())
+				GinkgoWriter.Printf("Copy public key from %s/signing-secrets to a new secret\n", constants.TEKTON_CHAINS_NS)
+				Expect(kubeController.CreateOrUpdateSigningSecret(
+					publicKey, publicSecretName, namespace)).To(Succeed())
 
-// 				rekorHost, err = kubeController.GetRekorHost()
-// 				Expect(err).ToNot(HaveOccurred())
-// 				GinkgoWriter.Printf("Configured Rekor host: %s\n", rekorHost)
-// 			})
+				rekorHost, err = kubeController.GetRekorHost()
+				Expect(err).ToNot(HaveOccurred())
+				GinkgoWriter.Printf("Configured Rekor host: %s\n", rekorHost)
+			})
 
-// 			BeforeEach(func() {
-// 				generator = tekton.VerifyEnterpriseContract{
-// 					PipelineRunName: "verify-enterprise-contract",
-// 					ImageRef:        imageWithDigest,
-// 					PublicSecret:    fmt.Sprintf("k8s://%s/%s", namespace, publicSecretName),
-// 					PipelineName:    "pipeline-run-that-does-not-exist",
-// 					RekorHost:       rekorHost,
-// 					SslCertDir:      "/var/run/secrets/kubernetes.io/serviceaccount",
-// 					StrictPolicy:    true,
-// 					Bundle:          fwk.TektonController.Bundles.HACBSTemplatesBundle,
-// 				}
+			BeforeEach(func() {
+				generator = tekton.VerifyEnterpriseContract{
+					PipelineRunName: "verify-enterprise-contract",
+					ImageRef:        imageWithDigest,
+					PublicSecret:    fmt.Sprintf("k8s://%s/%s", namespace, publicSecretName),
+					PipelineName:    "pipeline-run-that-does-not-exist",
+					RekorHost:       rekorHost,
+					SslCertDir:      "/var/run/secrets/kubernetes.io/serviceaccount",
+					StrictPolicy:    true,
+					Bundle:          fwk.HacbsUser.TektonController.Bundles.HACBSTemplatesBundle,
+				}
 
-// 				// Since specs could update the config policy, make sure it has a consistent
-// 				// baseline at the start of each spec.
-// 				baselinePolicies := ecp.EnterpriseContractPolicySpec{
-// 					Sources: []ecp.PolicySource{
-// 						{
-// 							GitRepository: &policySource,
-// 						},
-// 					},
-// 				}
-// 				Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, baselinePolicies)).To(Succeed())
-// 				printPolicyConfiguration(baselinePolicies)
-// 			})
+				// Since specs could update the config policy, make sure it has a consistent
+				// baseline at the start of each spec.
+				baselinePolicies := ecp.EnterpriseContractPolicySpec{
+					Sources: []ecp.PolicySource{
+						{
+							GitRepository: &policySource,
+						},
+					},
+				}
+				Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, baselinePolicies)).To(Succeed())
+				printPolicyConfiguration(baselinePolicies)
+			})
 
-// 			It("succeeds when policy is met", func() {
-// 				// Setup a policy config to ignore the policy check for tests
-// 				policy := ecp.EnterpriseContractPolicySpec{
-// 					Sources: []ecp.PolicySource{
-// 						{
-// 							GitRepository: &policySource,
-// 						},
-// 					},
-// 					Exceptions: &ecp.EnterpriseContractPolicyExceptions{
-// 						NonBlocking: []string{"not_useful", "test", "tasks", "attestation_task_bundle"}, // add more exceptions here as needed
-// 					},
-// 				}
-// 				Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
-// 				printPolicyConfiguration(policy)
-// 				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
-// 				Expect(err).NotTo(HaveOccurred())
-// 				Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
+			It("succeeds when policy is met", func() {
+				// Setup a policy config to ignore the policy check for tests
+				policy := ecp.EnterpriseContractPolicySpec{
+					Sources: []ecp.PolicySource{
+						{
+							GitRepository: &policySource,
+						},
+					},
+					Exceptions: &ecp.EnterpriseContractPolicyExceptions{
+						NonBlocking: []string{"not_useful", "test", "tasks", "attestation_task_bundle"}, // add more exceptions here as needed
+					},
+				}
+				Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
+				printPolicyConfiguration(policy)
+				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
 
-// 				// Refresh our copy of the PipelineRun for latest results
-// 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
-// 				Expect(err).NotTo(HaveOccurred())
+				// Refresh our copy of the PipelineRun for latest results
+				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
+				Expect(err).NotTo(HaveOccurred())
 
-// 				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
-// 				Expect(err).NotTo(HaveOccurred())
-// 				printTaskRunStatus(tr, namespace, *fwk.CommonController)
-// 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s suceeded\n", tr.PipelineTaskName, pr.Name)
-// 				Expect(tekton.DidTaskSucceed(tr)).To(BeTrue())
-// 				GinkgoWriter.Printf("Make sure EC-v2 results for PipelineRun %s are succeeding\n", pr.Name)
-// 				Expect(tr.Status.TaskRunResults).Should(ContainElements(
-// 					tekton.MatchTaskRunResultWithJSONPathValue("REPORT", "{$.success}", "[true]"),
-// 				))
-// 			})
+				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
+				Expect(err).NotTo(HaveOccurred())
+				printTaskRunStatus(tr, namespace, *fwk.HacbsUser.CommonController)
+				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s suceeded\n", tr.PipelineTaskName, pr.Name)
+				Expect(tekton.DidTaskSucceed(tr)).To(BeTrue())
+				GinkgoWriter.Printf("Make sure EC-v2 results for PipelineRun %s are succeeding\n", pr.Name)
+				Expect(tr.Status.TaskRunResults).Should(ContainElements(
+					tekton.MatchTaskRunResultWithJSONPathValue("REPORT", "{$.success}", "[true]"),
+				))
+			})
 
-// 			It("does not pass when tests are not satisfied on non-strict mode", func() {
-// 				// Setup a policy config to minimize the amount of policy violations. Otherwise,
-// 				// the report may exceed the 4k max and Tekton does not create the task result.
-// 				policy := ecp.EnterpriseContractPolicySpec{
-// 					Sources: []ecp.PolicySource{{GitRepository: &policySource}},
-// 					Exceptions: &ecp.EnterpriseContractPolicyExceptions{
-// 						NonBlocking: []string{"tasks", "attestation_task_bundle"},
-// 					},
-// 				}
-// 				Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
-// 				printPolicyConfiguration(policy)
-// 				generator.StrictPolicy = false
-// 				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
-// 				Expect(err).NotTo(HaveOccurred())
-// 				Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
+			It("does not pass when tests are not satisfied on non-strict mode", func() {
+				// Setup a policy config to minimize the amount of policy violations. Otherwise,
+				// the report may exceed the 4k max and Tekton does not create the task result.
+				policy := ecp.EnterpriseContractPolicySpec{
+					Sources: []ecp.PolicySource{{GitRepository: &policySource}},
+					Exceptions: &ecp.EnterpriseContractPolicyExceptions{
+						NonBlocking: []string{"tasks", "attestation_task_bundle"},
+					},
+				}
+				Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
+				printPolicyConfiguration(policy)
+				generator.StrictPolicy = false
+				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
 
-// 				// Refresh our copy of the PipelineRun for latest results
-// 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
-// 				Expect(err).NotTo(HaveOccurred())
+				// Refresh our copy of the PipelineRun for latest results
+				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
+				Expect(err).NotTo(HaveOccurred())
 
-// 				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
-// 				Expect(err).NotTo(HaveOccurred())
-// 				printTaskRunStatus(tr, namespace, *fwk.CommonController)
-// 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s suceeded\n", tr.PipelineTaskName, pr.Name)
-// 				Expect(tekton.DidTaskSucceed(tr)).To(BeTrue())
-// 				GinkgoWriter.Printf("Make sure EC-v2 results for PipelineRun %s are failing\n", pr.Name)
-// 				Expect(tr.Status.TaskRunResults).Should(ContainElements(
-// 					tekton.MatchTaskRunResultWithJSONPathValue("REPORT", "{$.success}", "[false]"),
-// 				))
-// 			})
+				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
+				Expect(err).NotTo(HaveOccurred())
+				printTaskRunStatus(tr, namespace, *fwk.HacbsUser.CommonController)
+				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s suceeded\n", tr.PipelineTaskName, pr.Name)
+				Expect(tekton.DidTaskSucceed(tr)).To(BeTrue())
+				GinkgoWriter.Printf("Make sure EC-v2 results for PipelineRun %s are failing\n", pr.Name)
+				Expect(tr.Status.TaskRunResults).Should(ContainElements(
+					tekton.MatchTaskRunResultWithJSONPathValue("REPORT", "{$.success}", "[false]"),
+				))
+			})
 
-// 			It("fails when tests are not satisfied on strict mode", func() {
-// 				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
-// 				Expect(err).NotTo(HaveOccurred())
-// 				err = kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)
-// 				Expect(err).NotTo(HaveOccurred())
+			It("fails when tests are not satisfied on strict mode", func() {
+				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
+				Expect(err).NotTo(HaveOccurred())
+				err = kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)
+				Expect(err).NotTo(HaveOccurred())
 
-// 				// Refresh our copy of the PipelineRun for latest results
-// 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
-// 				Expect(err).NotTo(HaveOccurred())
+				// Refresh our copy of the PipelineRun for latest results
+				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
+				Expect(err).NotTo(HaveOccurred())
 
-// 				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
-// 				Expect(err).NotTo(HaveOccurred())
-// 				printTaskRunStatus(tr, namespace, *fwk.CommonController)
-// 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s failed\n", tr.PipelineTaskName, pr.Name)
-// 				Expect(tekton.DidTaskSucceed(tr)).To(BeFalse())
-// 				// Because the task fails, no results are created
-// 			})
+				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
+				Expect(err).NotTo(HaveOccurred())
+				printTaskRunStatus(tr, namespace, *fwk.HacbsUser.CommonController)
+				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s failed\n", tr.PipelineTaskName, pr.Name)
+				Expect(tekton.DidTaskSucceed(tr)).To(BeFalse())
+				// Because the task fails, no results are created
+			})
 
-// 			It("fails when unexpected signature is used", func() {
-// 				secretName := fmt.Sprintf("dummy-public-key-%s", util.GenerateRandomString(10))
-// 				publicKey := []byte("-----BEGIN PUBLIC KEY-----\n" +
-// 					"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENZxkE/d0fKvJ51dXHQmxXaRMTtVz\n" +
-// 					"BQWcmJD/7pcMDEmBcmk8O1yUPIiFj5TMZqabjS9CQQN+jKHG+Bfi0BYlHg==\n" +
-// 					"-----END PUBLIC KEY-----")
-// 				GinkgoWriter.Println("Create an unexpected public signing key")
-// 				Expect(kubeController.CreateOrUpdateSigningSecret(publicKey, secretName, namespace)).To(Succeed())
-// 				generator.PublicSecret = fmt.Sprintf("k8s://%s/%s", namespace, secretName)
+			It("fails when unexpected signature is used", func() {
+				secretName := fmt.Sprintf("dummy-public-key-%s", util.GenerateRandomString(10))
+				publicKey := []byte("-----BEGIN PUBLIC KEY-----\n" +
+					"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENZxkE/d0fKvJ51dXHQmxXaRMTtVz\n" +
+					"BQWcmJD/7pcMDEmBcmk8O1yUPIiFj5TMZqabjS9CQQN+jKHG+Bfi0BYlHg==\n" +
+					"-----END PUBLIC KEY-----")
+				GinkgoWriter.Println("Create an unexpected public signing key")
+				Expect(kubeController.CreateOrUpdateSigningSecret(publicKey, secretName, namespace)).To(Succeed())
+				generator.PublicSecret = fmt.Sprintf("k8s://%s/%s", namespace, secretName)
 
-// 				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
-// 				Expect(err).NotTo(HaveOccurred())
-// 				err = kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)
-// 				Expect(err).NotTo(HaveOccurred())
+				pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
+				Expect(err).NotTo(HaveOccurred())
+				err = kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)
+				Expect(err).NotTo(HaveOccurred())
 
-// 				// Refresh our copy of the PipelineRun for latest results
-// 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
-// 				Expect(err).NotTo(HaveOccurred())
+				// Refresh our copy of the PipelineRun for latest results
+				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
+				Expect(err).NotTo(HaveOccurred())
 
-// 				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
-// 				Expect(err).NotTo(HaveOccurred())
-// 				printTaskRunStatus(tr, namespace, *fwk.CommonController)
-// 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s failed\n", tr.PipelineTaskName, pr.Name)
-// 				Expect(tekton.DidTaskSucceed(tr)).To(BeFalse())
-// 				// Because the task fails, no results are created
-// 			})
-// 		})
-// 	})
-// })
+				tr, err := kubeController.GetTaskRunStatus(pr, "verify-enterprise-contract-v2")
+				Expect(err).NotTo(HaveOccurred())
+				printTaskRunStatus(tr, namespace, *fwk.HacbsUser.CommonController)
+				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s failed\n", tr.PipelineTaskName, pr.Name)
+				Expect(tekton.DidTaskSucceed(tr)).To(BeFalse())
+				// Because the task fails, no results are created
+			})
+		})
+	})
+})
 
-// func printPolicyConfiguration(policy ecp.EnterpriseContractPolicySpec) {
-// 	sources := ""
-// 	for i, s := range policy.Sources {
-// 		if i != 0 {
-// 			sources += "\n"
-// 		}
-// 		if s.GitRepository != nil {
-// 			if s.GitRepository.Revision != nil {
-// 				sources += fmt.Sprintf("[%d] repository: '%s', revision: '%s'", i, s.GitRepository.Repository, *s.GitRepository.Revision)
-// 			} else {
-// 				sources += fmt.Sprintf("[%d] repository: '%s'", i, s.GitRepository.Repository)
-// 			}
-// 		}
-// 	}
-// 	exceptions := "[]"
-// 	if policy.Exceptions != nil {
-// 		exceptions = fmt.Sprintf("%v", policy.Exceptions.NonBlocking)
-// 	}
-// 	GinkgoWriter.Printf("Configured sources: %s\nand non-blocking policies: %v\n", sources, exceptions)
-// }
+func printPolicyConfiguration(policy ecp.EnterpriseContractPolicySpec) {
+	sources := ""
+	for i, s := range policy.Sources {
+		if i != 0 {
+			sources += "\n"
+		}
+		if s.GitRepository != nil {
+			if s.GitRepository.Revision != nil {
+				sources += fmt.Sprintf("[%d] repository: '%s', revision: '%s'", i, s.GitRepository.Repository, *s.GitRepository.Revision)
+			} else {
+				sources += fmt.Sprintf("[%d] repository: '%s'", i, s.GitRepository.Repository)
+			}
+		}
+	}
+	exceptions := "[]"
+	if policy.Exceptions != nil {
+		exceptions = fmt.Sprintf("%v", policy.Exceptions.NonBlocking)
+	}
+	GinkgoWriter.Printf("Configured sources: %s\nand non-blocking policies: %v\n", sources, exceptions)
+}
 
-// func printTaskRunStatus(tr *v1beta1.PipelineRunTaskRunStatus, namespace string, sc common.SuiteController) {
-// 	if tr.Status == nil {
-// 		GinkgoWriter.Printf("*** TaskRun status: nil")
-// 		return
-// 	}
+func printTaskRunStatus(tr *v1beta1.PipelineRunTaskRunStatus, namespace string, sc common.SuiteController) {
+	if tr.Status == nil {
+		GinkgoWriter.Printf("*** TaskRun status: nil")
+		return
+	}
 
-// 	if y, err := yaml.Marshal(tr.Status); err == nil {
-// 		GinkgoWriter.Printf("*** TaskRun status:\n%s\n", string(y))
-// 	} else {
-// 		GinkgoWriter.Printf("*** Unable to serialize TaskRunStatus to YAML: %#v; error: %s", tr.Status, err)
-// 	}
+	if y, err := yaml.Marshal(tr.Status); err == nil {
+		GinkgoWriter.Printf("*** TaskRun status:\n%s\n", string(y))
+	} else {
+		GinkgoWriter.Printf("*** Unable to serialize TaskRunStatus to YAML: %#v; error: %s", tr.Status, err)
+	}
 
-// 	for _, s := range tr.Status.TaskRunStatusFields.Steps {
-// 		if logs, err := sc.GetContainerLogs(tr.Status.PodName, s.ContainerName, namespace); err == nil {
-// 			GinkgoWriter.Printf("*** Logs from pod '%s', container '%s':\n----- START -----%s----- END -----\n", tr.Status.PodName, s.ContainerName, logs)
-// 		} else {
-// 			GinkgoWriter.Printf("*** Can't fetch logs from pod '%s', container '%s': %s", tr.Status.PodName, s.ContainerName, err)
-// 		}
-// 	}
-// }
+	for _, s := range tr.Status.TaskRunStatusFields.Steps {
+		if logs, err := sc.GetContainerLogs(tr.Status.PodName, s.ContainerName, namespace); err == nil {
+			GinkgoWriter.Printf("*** Logs from pod '%s', container '%s':\n----- START -----%s----- END -----\n", tr.Status.PodName, s.ContainerName, logs)
+		} else {
+			GinkgoWriter.Printf("*** Can't fetch logs from pod '%s', container '%s': %s", tr.Status.PodName, s.ContainerName, err)
+		}
+	}
+}

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -1,424 +1,424 @@
 package build
 
-// import (
-// 	"context"
-// 	"encoding/json"
-// 	"fmt"
-// 	"os"
-// 	"strings"
-// 	"time"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
 
-// 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-// 	"k8s.io/apimachinery/pkg/util/wait"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
-// 	"github.com/devfile/library/pkg/util"
-// 	"github.com/google/uuid"
-// 	. "github.com/onsi/ginkgo/v2"
-// 	. "github.com/onsi/gomega"
-// 	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
+	"github.com/devfile/library/pkg/util"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
 
-// 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
-// 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
-// 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
+	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
+	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 
-// 	corev1 "k8s.io/api/core/v1"
-// 	v1 "k8s.io/api/core/v1"
-// 	"k8s.io/apimachinery/pkg/api/errors"
-// 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-// 	"k8s.io/klog/v2"
-// 	"knative.dev/pkg/apis"
-// )
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"knative.dev/pkg/apis"
+)
 
-// var (
-// 	testProjectGitUrl   = utils.GetEnv("JVM_BUILD_SERVICE_TEST_REPO_URL", "https://github.com/stuartwdouglas/hacbs-test-project")
-// 	testProjectRevision = utils.GetEnv("JVM_BUILD_SERVICE_TEST_REPO_REVISION", "main")
-// )
+var (
+	testProjectGitUrl   = utils.GetEnv("JVM_BUILD_SERVICE_TEST_REPO_URL", "https://github.com/stuartwdouglas/hacbs-test-project")
+	testProjectRevision = utils.GetEnv("JVM_BUILD_SERVICE_TEST_REPO_REVISION", "main")
+)
 
-// var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jvm-build", "HACBS"), Pending, func() {
-// 	defer GinkgoRecover()
+var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jvm-build", "HACBS"), Pending, func() {
+	defer GinkgoRecover()
 
-// 	var testNamespace, applicationName, componentName, outputContainerImage string
-// 	var componentPipelineRun *v1beta1.PipelineRun
-// 	var timeout, interval time.Duration
-// 	var doCollectLogs bool
+	var testNamespace, applicationName, componentName, outputContainerImage string
+	var componentPipelineRun *v1beta1.PipelineRun
+	var timeout, interval time.Duration
+	var doCollectLogs bool
 
-// 	f, err := framework.NewFramework()
-// 	Expect(err).NotTo(HaveOccurred())
+	f, err := framework.NewFramework()
+	Expect(err).NotTo(HaveOccurred())
 
-// 	AfterAll(func() {
-// 		abList, err := f.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
-// 		if err != nil {
-// 			klog.Infof("got error fetching artifactbuilds: %s", err.Error())
-// 		}
+	AfterAll(func() {
+		abList, err := f.HacbsUser.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
+		if err != nil {
+			klog.Infof("got error fetching artifactbuilds: %s", err.Error())
+		}
 
-// 		dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
-// 		if err != nil {
-// 			klog.Infof("got error fetching dependencybuilds: %s", err.Error())
-// 		}
+		dbList, err := f.HacbsUser.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
+		if err != nil {
+			klog.Infof("got error fetching dependencybuilds: %s", err.Error())
+		}
 
-// 		if CurrentSpecReport().Failed() || doCollectLogs {
-// 			var testLogsDir string
-// 			artifactDir := os.Getenv("ARTIFACT_DIR")
-// 			var storeLogsInFiles bool
+		if CurrentSpecReport().Failed() || doCollectLogs {
+			var testLogsDir string
+			artifactDir := os.Getenv("ARTIFACT_DIR")
+			var storeLogsInFiles bool
 
-// 			if artifactDir != "" {
-// 				testLogsDir = fmt.Sprintf("%s/jvm-build-service-test", artifactDir)
-// 				err := os.MkdirAll(testLogsDir, 0755)
-// 				if err != nil && !os.IsExist(err) {
-// 					klog.Infof("cannot create a folder %s for storing test logs/resources: %+v", testLogsDir, err)
-// 				} else {
-// 					storeLogsInFiles = true
-// 				}
-// 			}
-// 			// get jvm-build-service logs
-// 			toDebug := map[string]string{}
+			if artifactDir != "" {
+				testLogsDir = fmt.Sprintf("%s/jvm-build-service-test", artifactDir)
+				err := os.MkdirAll(testLogsDir, 0755)
+				if err != nil && !os.IsExist(err) {
+					klog.Infof("cannot create a folder %s for storing test logs/resources: %+v", testLogsDir, err)
+				} else {
+					storeLogsInFiles = true
+				}
+			}
+			// get jvm-build-service logs
+			toDebug := map[string]string{}
 
-// 			jvmPodList, jerr := f.CommonController.K8sClient.KubeInterface().CoreV1().Pods("jvm-build-service").List(context.TODO(), metav1.ListOptions{})
-// 			if jerr != nil {
-// 				klog.Infof("error listing jvm-build-service pods: %s", jerr.Error())
-// 			}
-// 			klog.Infof("found %d pods in jvm-build-service namespace", len(jvmPodList.Items))
-// 			for _, pod := range jvmPodList.Items {
-// 				var containers []corev1.Container
-// 				containers = append(containers, pod.Spec.InitContainers...)
-// 				containers = append(containers, pod.Spec.Containers...)
-// 				for _, c := range containers {
-// 					cLog, cerr := f.CommonController.GetContainerLogs(pod.Name, c.Name, pod.Namespace)
-// 					if cerr != nil {
-// 						klog.Infof("error getting logs for pod/container %s/%s: %s", pod.Name, c.Name, cerr.Error())
-// 						continue
-// 					}
-// 					filename := fmt.Sprintf("%s-pod-%s-%s.log", pod.Namespace, pod.Name, c.Name)
-// 					toDebug[filename] = cLog
-// 				}
-// 			}
-// 			// let's make sure and print the pr that starts the analysis first
+			jvmPodList, jerr := f.HacbsUser.CommonController.KubeInterface().CoreV1().Pods("jvm-build-service").List(context.TODO(), metav1.ListOptions{})
+			if jerr != nil {
+				klog.Infof("error listing jvm-build-service pods: %s", jerr.Error())
+			}
+			klog.Infof("found %d pods in jvm-build-service namespace", len(jvmPodList.Items))
+			for _, pod := range jvmPodList.Items {
+				var containers []corev1.Container
+				containers = append(containers, pod.Spec.InitContainers...)
+				containers = append(containers, pod.Spec.Containers...)
+				for _, c := range containers {
+					cLog, cerr := f.HacbsUser.CommonController.GetContainerLogs(pod.Name, c.Name, pod.Namespace)
+					if cerr != nil {
+						klog.Infof("error getting logs for pod/container %s/%s: %s", pod.Name, c.Name, cerr.Error())
+						continue
+					}
+					filename := fmt.Sprintf("%s-pod-%s-%s.log", pod.Namespace, pod.Name, c.Name)
+					toDebug[filename] = cLog
+				}
+			}
+			// let's make sure and print the pr that starts the analysis first
 
-// 			logs, err := f.TektonController.GetPipelineRunLogs(componentPipelineRun.Name, testNamespace)
-// 			if err != nil {
-// 				klog.Infof("got error fetching PR logs: %s", err.Error())
-// 			}
-// 			filename := fmt.Sprintf("%s-pr-%s.log", testNamespace, componentPipelineRun.Name)
-// 			toDebug[filename] = logs
+			logs, err := f.HacbsUser.TektonController.GetPipelineRunLogs(componentPipelineRun.Name, testNamespace)
+			if err != nil {
+				klog.Infof("got error fetching PR logs: %s", err.Error())
+			}
+			filename := fmt.Sprintf("%s-pr-%s.log", testNamespace, componentPipelineRun.Name)
+			toDebug[filename] = logs
 
-// 			prList, err := f.TektonController.ListAllPipelineRuns(testNamespace)
-// 			if err != nil {
-// 				klog.Infof("got error fetching PR list: %s", err.Error())
-// 			}
-// 			klog.Infof("total number of pipeline runs not pruned: %d", len(prList.Items))
-// 			for _, pr := range prList.Items {
-// 				if pr.Name == componentPipelineRun.Name {
-// 					continue
-// 				}
-// 				prLog, err := f.TektonController.GetPipelineRunLogs(pr.Name, pr.Namespace)
-// 				if err != nil {
-// 					klog.Infof("got error fetching PR logs for %s: %s", pr.Name, err.Error())
-// 				}
-// 				filename := fmt.Sprintf("%s-pr-%s.log", pr.Namespace, pr.Name)
-// 				toDebug[filename] = prLog
-// 			}
+			prList, err := f.HacbsUser.TektonController.ListAllPipelineRuns(testNamespace)
+			if err != nil {
+				klog.Infof("got error fetching PR list: %s", err.Error())
+			}
+			klog.Infof("total number of pipeline runs not pruned: %d", len(prList.Items))
+			for _, pr := range prList.Items {
+				if pr.Name == componentPipelineRun.Name {
+					continue
+				}
+				prLog, err := f.HacbsUser.TektonController.GetPipelineRunLogs(pr.Name, pr.Namespace)
+				if err != nil {
+					klog.Infof("got error fetching PR logs for %s: %s", pr.Name, err.Error())
+				}
+				filename := fmt.Sprintf("%s-pr-%s.log", pr.Namespace, pr.Name)
+				toDebug[filename] = prLog
+			}
 
-// 			for _, ab := range abList.Items {
-// 				v, err := json.MarshalIndent(ab, "", "  ")
-// 				if err != nil {
-// 					klog.Infof("error when marshalling content of %s from %s namespace: %+v", ab.Name, ab.Namespace, err)
-// 				} else {
-// 					filename := fmt.Sprintf("%s-ab-%s.json", ab.Namespace, ab.Name)
-// 					toDebug[filename] = string(v)
-// 				}
-// 			}
-// 			for _, db := range dbList.Items {
-// 				v, err := json.MarshalIndent(db, "", "  ")
-// 				if err != nil {
-// 					klog.Infof("error when marshalling content of %s from %s namespace: %+v", db.Name, db.Namespace, err)
-// 				} else {
-// 					filename := fmt.Sprintf("%s-db-%s.json", db.Namespace, db.Name)
-// 					toDebug[filename] = string(v)
-// 				}
-// 			}
+			for _, ab := range abList.Items {
+				v, err := json.MarshalIndent(ab, "", "  ")
+				if err != nil {
+					klog.Infof("error when marshalling content of %s from %s namespace: %+v", ab.Name, ab.Namespace, err)
+				} else {
+					filename := fmt.Sprintf("%s-ab-%s.json", ab.Namespace, ab.Name)
+					toDebug[filename] = string(v)
+				}
+			}
+			for _, db := range dbList.Items {
+				v, err := json.MarshalIndent(db, "", "  ")
+				if err != nil {
+					klog.Infof("error when marshalling content of %s from %s namespace: %+v", db.Name, db.Namespace, err)
+				} else {
+					filename := fmt.Sprintf("%s-db-%s.json", db.Namespace, db.Name)
+					toDebug[filename] = string(v)
+				}
+			}
 
-// 			for file, content := range toDebug {
-// 				if storeLogsInFiles {
-// 					filename := fmt.Sprintf("%s/%s", testLogsDir, file)
-// 					if err := os.WriteFile(filename, []byte(content), 0644); err != nil {
-// 						klog.Infof("cannot write to %s: %+v", filename, err)
-// 					} else {
-// 						continue
-// 					}
-// 				} else {
-// 					klog.Infof("%s\n%s", file, content)
-// 				}
-// 			}
-// 		}
-// 		// Cleanup
-// 		for _, ab := range abList.Items {
-// 			err := f.JvmbuildserviceController.DeleteArtifactBuild(ab.Name, ab.Namespace)
-// 			if err != nil {
-// 				klog.Infof("got error deleting AB %s: %s", ab.Name, err.Error())
-// 			}
-// 		}
-// 		for _, db := range dbList.Items {
-// 			err := f.JvmbuildserviceController.DeleteDependencyBuild(db.Name, db.Namespace)
-// 			if err != nil {
-// 				klog.Infof("got error deleting DB %s: %s", db.Name, err.Error())
-// 			}
-// 		}
-// 		Expect(f.HasController.DeleteHasComponent(componentName, testNamespace, false)).To(Succeed())
-// 		Expect(f.HasController.DeleteHasApplication(applicationName, testNamespace, false)).To(Succeed())
-// 		Expect(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(Succeed())
-// 	})
+			for file, content := range toDebug {
+				if storeLogsInFiles {
+					filename := fmt.Sprintf("%s/%s", testLogsDir, file)
+					if err := os.WriteFile(filename, []byte(content), 0644); err != nil {
+						klog.Infof("cannot write to %s: %+v", filename, err)
+					} else {
+						continue
+					}
+				} else {
+					klog.Infof("%s\n%s", file, content)
+				}
+			}
+		}
+		// Cleanup
+		for _, ab := range abList.Items {
+			err := f.HacbsUser.JvmbuildserviceController.DeleteArtifactBuild(ab.Name, ab.Namespace)
+			if err != nil {
+				klog.Infof("got error deleting AB %s: %s", ab.Name, err.Error())
+			}
+		}
+		for _, db := range dbList.Items {
+			err := f.HacbsUser.JvmbuildserviceController.DeleteDependencyBuild(db.Name, db.Namespace)
+			if err != nil {
+				klog.Infof("got error deleting DB %s: %s", db.Name, err.Error())
+			}
+		}
+		Expect(f.HacbsUser.HasController.DeleteHasComponent(componentName, testNamespace, false)).To(Succeed())
+		Expect(f.HacbsUser.HasController.DeleteHasApplication(applicationName, testNamespace, false)).To(Succeed())
+		Expect(f.HacbsUser.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(Succeed())
+	})
 
-// 	BeforeAll(func() {
-// 		testNamespace = utils.GetGeneratedNamespace("jvm-build")
+	BeforeAll(func() {
+		testNamespace = utils.GetGeneratedNamespace("jvm-build")
 
-// 		klog.Infof("Test namespace: %s", testNamespace)
+		klog.Infof("Test namespace: %s", testNamespace)
 
-// 		_, err := f.CommonController.CreateTestNamespace(testNamespace)
-// 		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+		_, err := f.HacbsUser.CommonController.CreateTestNamespace(testNamespace)
+		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
 
-// 		customBundleConfigMap, err := f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, testNamespace)
-// 		if err != nil {
-// 			if errors.IsNotFound(err) {
-// 				defaultBundleConfigMap, err := f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
-// 				Expect(err).ToNot(HaveOccurred())
+		customBundleConfigMap, err := f.HacbsUser.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, testNamespace)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				defaultBundleConfigMap, err := f.HacbsUser.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
+				Expect(err).ToNot(HaveOccurred())
 
-// 				bundlePullSpec := defaultBundleConfigMap.Data["default_build_bundle"]
-// 				hacbsBundleConfigMap := &v1.ConfigMap{
-// 					ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
-// 					Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
-// 				}
-// 				_, err = f.CommonController.CreateConfigMap(hacbsBundleConfigMap, testNamespace)
-// 				Expect(err).ToNot(HaveOccurred())
-// 				DeferCleanup(f.CommonController.DeleteConfigMap, constants.BuildPipelinesConfigMapName, testNamespace, false)
-// 			} else {
-// 				Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, testNamespace, err))
-// 			}
-// 		} else {
-// 			bundlePullSpec := customBundleConfigMap.Data["default_build_bundle"]
-// 			hacbsBundleConfigMap := &v1.ConfigMap{
-// 				ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
-// 				Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
-// 			}
+				bundlePullSpec := defaultBundleConfigMap.Data["default_build_bundle"]
+				hacbsBundleConfigMap := &v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
+					Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
+				}
+				_, err = f.HacbsUser.CommonController.CreateConfigMap(hacbsBundleConfigMap, testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				DeferCleanup(f.HacbsUser.CommonController.DeleteConfigMap, constants.BuildPipelinesConfigMapName, testNamespace, false)
+			} else {
+				Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, testNamespace, err))
+			}
+		} else {
+			bundlePullSpec := customBundleConfigMap.Data["default_build_bundle"]
+			hacbsBundleConfigMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
+				Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
+			}
 
-// 			_, err = f.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
-// 			Expect(err).ToNot(HaveOccurred())
-// 			DeferCleanup(func() error {
-// 				hacbsBundleConfigMap.Data = customBundleConfigMap.Data
-// 				_, err := f.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
-// 				if err != nil {
-// 					return err
-// 				}
-// 				return nil
-// 			})
-// 		}
+			_, err = f.HacbsUser.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() error {
+				hacbsBundleConfigMap.Data = customBundleConfigMap.Data
+				_, err := f.HacbsUser.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
+				if err != nil {
+					return err
+				}
+				return nil
+			})
+		}
 
-// 		//enable artifact rebuilds
-// 		jvmConfigMap := &v1.ConfigMap{
-// 			ObjectMeta: metav1.ObjectMeta{Name: constants.JVMUserConfigMapName},
-// 			Data:       map[string]string{constants.JVMEnableRebuilds: "true"},
-// 		}
-// 		existingJvmConfigMap, err := f.CommonController.GetConfigMap(constants.JVMUserConfigMapName, testNamespace)
-// 		if err != nil {
-// 			if errors.IsNotFound(err) {
-// 				_, err = f.CommonController.CreateConfigMap(jvmConfigMap, testNamespace)
-// 				Expect(err).ToNot(HaveOccurred())
-// 				DeferCleanup(f.CommonController.DeleteConfigMap, constants.JVMUserConfigMapName, testNamespace, false)
-// 			} else {
-// 				Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.JVMUserConfigMapName, testNamespace, err))
-// 			}
-// 		} else {
-// 			_, err = f.CommonController.UpdateConfigMap(jvmConfigMap, testNamespace)
-// 			Expect(err).ToNot(HaveOccurred())
-// 			DeferCleanup(func() error {
-// 				_, err := f.CommonController.UpdateConfigMap(existingJvmConfigMap, testNamespace)
-// 				if err != nil {
-// 					return err
-// 				}
-// 				return nil
-// 			})
-// 		}
-// 		timeout = time.Minute * 20
-// 		interval = time.Second * 10
+		//enable artifact rebuilds
+		jvmConfigMap := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: constants.JVMUserConfigMapName},
+			Data:       map[string]string{constants.JVMEnableRebuilds: "true"},
+		}
+		existingJvmConfigMap, err := f.HacbsUser.CommonController.GetConfigMap(constants.JVMUserConfigMapName, testNamespace)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				_, err = f.HacbsUser.CommonController.CreateConfigMap(jvmConfigMap, testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				DeferCleanup(f.HacbsUser.CommonController.DeleteConfigMap, constants.JVMUserConfigMapName, testNamespace, false)
+			} else {
+				Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.JVMUserConfigMapName, testNamespace, err))
+			}
+		} else {
+			_, err = f.HacbsUser.CommonController.UpdateConfigMap(jvmConfigMap, testNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() error {
+				_, err := f.HacbsUser.CommonController.UpdateConfigMap(existingJvmConfigMap, testNamespace)
+				if err != nil {
+					return err
+				}
+				return nil
+			})
+		}
+		timeout = time.Minute * 20
+		interval = time.Second * 10
 
-// 		applicationName = fmt.Sprintf("jvm-build-suite-application-%s", util.GenerateRandomString(4))
-// 		app, err := f.HasController.CreateHasApplication(applicationName, testNamespace)
-// 		Expect(err).NotTo(HaveOccurred())
-// 		Expect(utils.WaitUntil(f.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
-// 			Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
-// 		)
+		applicationName = fmt.Sprintf("jvm-build-suite-application-%s", util.GenerateRandomString(4))
+		app, err := f.HacbsUser.HasController.CreateHasApplication(applicationName, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(utils.WaitUntil(f.HacbsUser.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+			Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
+		)
 
-// 		componentName = fmt.Sprintf("jvm-build-suite-component-%s", util.GenerateRandomString(4))
-// 		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+		componentName = fmt.Sprintf("jvm-build-suite-component-%s", util.GenerateRandomString(4))
+		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
 
-// 		// Create a component with Git Source URL being defined
-// 		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, testProjectGitUrl, testProjectRevision, "", outputContainerImage, "")
-// 		Expect(err).ShouldNot(HaveOccurred())
-// 	})
+		// Create a component with Git Source URL being defined
+		_, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, testNamespace, testProjectGitUrl, testProjectRevision, "", outputContainerImage, "")
+		Expect(err).ShouldNot(HaveOccurred())
+	})
 
-// 	When("the Component with s2i-java component is created", func() {
-// 		It("a PipelineRun is triggered", func() {
-// 			Eventually(func() bool {
-// 				componentPipelineRun, err = f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
-// 				if err != nil {
-// 					klog.Infoln("PipelineRun has not been created yet")
-// 					return false
-// 				}
-// 				return componentPipelineRun.HasStarted()
-// 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
-// 		})
+	When("the Component with s2i-java component is created", func() {
+		It("a PipelineRun is triggered", func() {
+			Eventually(func() bool {
+				componentPipelineRun, err = f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+				if err != nil {
+					klog.Infoln("PipelineRun has not been created yet")
+					return false
+				}
+				return componentPipelineRun.HasStarted()
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
+		})
 
-// 		It("the build-container task from component PipelineRun references a correct sidecar image", func() {
-// 			ciSidecarImage := os.Getenv("JVM_BUILD_SERVICE_SIDECAR_IMAGE")
-// 			if ciSidecarImage == "" {
-// 				Skip("JVM_BUILD_SERVICE_SIDECAR_IMAGE env var is not exported, skipping the test...")
-// 			}
+		It("the build-container task from component PipelineRun references a correct sidecar image", func() {
+			ciSidecarImage := os.Getenv("JVM_BUILD_SERVICE_SIDECAR_IMAGE")
+			if ciSidecarImage == "" {
+				Skip("JVM_BUILD_SERVICE_SIDECAR_IMAGE env var is not exported, skipping the test...")
+			}
 
-// 			err = wait.PollImmediate(interval, timeout, func() (done bool, err error) {
-// 				pr, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
-// 				if err != nil {
-// 					klog.Infof("get pr for component %s produced err: %s", componentName, err.Error())
-// 					return false, nil
-// 				}
+			err = wait.PollImmediate(interval, timeout, func() (done bool, err error) {
+				pr, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+				if err != nil {
+					klog.Infof("get pr for component %s produced err: %s", componentName, err.Error())
+					return false, nil
+				}
 
-// 				for _, tr := range pr.Status.TaskRuns {
-// 					if tr.PipelineTaskName == "build-container" && tr.Status != nil && tr.Status.TaskSpec != nil && tr.Status.TaskSpec.Sidecars != nil {
-// 						for _, sc := range tr.Status.TaskSpec.Sidecars {
-// 							if sc.Name == "proxy" {
-// 								if sc.Image != ciSidecarImage {
-// 									Fail(fmt.Sprintf("the build-container task from component pipelinerun doesn't contain correct sidecar image. expected: %v, actual: %v", ciSidecarImage, sc.Image))
-// 								} else {
-// 									return true, nil
-// 								}
-// 							}
-// 						}
-// 					}
-// 				}
-// 				return false, nil
-// 			})
-// 			if err != nil {
-// 				Fail(fmt.Sprintf("failure occured when verifying the sidecar image reference in pipelinerun: %v", err))
-// 			}
-// 		})
+				for _, tr := range pr.Status.TaskRuns {
+					if tr.PipelineTaskName == "build-container" && tr.Status != nil && tr.Status.TaskSpec != nil && tr.Status.TaskSpec.Sidecars != nil {
+						for _, sc := range tr.Status.TaskSpec.Sidecars {
+							if sc.Name == "proxy" {
+								if sc.Image != ciSidecarImage {
+									Fail(fmt.Sprintf("the build-container task from component pipelinerun doesn't contain correct sidecar image. expected: %v, actual: %v", ciSidecarImage, sc.Image))
+								} else {
+									return true, nil
+								}
+							}
+						}
+					}
+				}
+				return false, nil
+			})
+			if err != nil {
+				Fail(fmt.Sprintf("failure occured when verifying the sidecar image reference in pipelinerun: %v", err))
+			}
+		})
 
-// 		It("the build-container task from component pipelinerun references a correct analyzer image", func() {
-// 			ciAnalyzerImage := os.Getenv("JVM_BUILD_SERVICE_ANALYZER_IMAGE")
+		It("the build-container task from component pipelinerun references a correct analyzer image", func() {
+			ciAnalyzerImage := os.Getenv("JVM_BUILD_SERVICE_ANALYZER_IMAGE")
 
-// 			if ciAnalyzerImage == "" {
-// 				Skip("JVM_BUILD_SERVICE_ANALYZER_IMAGE env var is not exported, skipping the test...")
-// 			}
+			if ciAnalyzerImage == "" {
+				Skip("JVM_BUILD_SERVICE_ANALYZER_IMAGE env var is not exported, skipping the test...")
+			}
 
-// 			err = wait.PollImmediate(interval, timeout, func() (done bool, err error) {
-// 				pr, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
-// 				if err != nil {
-// 					klog.Infof("get pr for the component %s produced err: %s", componentName, err.Error())
-// 					return false, nil
-// 				}
+			err = wait.PollImmediate(interval, timeout, func() (done bool, err error) {
+				pr, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+				if err != nil {
+					klog.Infof("get pr for the component %s produced err: %s", componentName, err.Error())
+					return false, nil
+				}
 
-// 				for _, tr := range pr.Status.TaskRuns {
-// 					if tr.PipelineTaskName == "build-container" && tr.Status != nil && tr.Status.TaskSpec != nil && tr.Status.TaskSpec.Steps != nil {
-// 						for _, step := range tr.Status.TaskSpec.Steps {
-// 							if step.Name == "analyse-dependencies-java-sbom" {
-// 								if step.Image != ciAnalyzerImage {
-// 									Fail(fmt.Sprintf("the build-container task from component pipelinerun doesn't reference the correct analyzer image. expected: %v, actual: %v", ciAnalyzerImage, step.Image))
-// 								} else {
-// 									return true, nil
-// 								}
-// 							}
-// 						}
-// 					}
-// 				}
-// 				return false, nil
-// 			})
-// 			if err != nil {
-// 				Fail(fmt.Sprintf("failure occured when verifying the analyzer image reference in pipelinerun: %v", err))
-// 			}
-// 		})
+				for _, tr := range pr.Status.TaskRuns {
+					if tr.PipelineTaskName == "build-container" && tr.Status != nil && tr.Status.TaskSpec != nil && tr.Status.TaskSpec.Steps != nil {
+						for _, step := range tr.Status.TaskSpec.Steps {
+							if step.Name == "analyse-dependencies-java-sbom" {
+								if step.Image != ciAnalyzerImage {
+									Fail(fmt.Sprintf("the build-container task from component pipelinerun doesn't reference the correct analyzer image. expected: %v, actual: %v", ciAnalyzerImage, step.Image))
+								} else {
+									return true, nil
+								}
+							}
+						}
+					}
+				}
+				return false, nil
+			})
+			if err != nil {
+				Fail(fmt.Sprintf("failure occured when verifying the analyzer image reference in pipelinerun: %v", err))
+			}
+		})
 
-// 		It("that PipelineRun completes successfully", func() {
-// 			Eventually(func() bool {
-// 				pr, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
-// 				if err != nil {
-// 					klog.Infof("get of pr %s returned error: %s", pr.Name, err.Error())
-// 					return false
-// 				}
-// 				if !pr.IsDone() {
-// 					klog.Infof("pipeline run %s not done", pr.Name)
-// 					return false
-// 				}
-// 				if !pr.GetStatusCondition().GetCondition(apis.ConditionSucceeded).IsTrue() {
-// 					Fail("component pipeline run did not succeed")
-// 				}
-// 				return true
-// 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the pipeline run to complete")
-// 		})
-// 		It("artifactbuilds and dependencybuilds are generated", func() {
-// 			Eventually(func() bool {
-// 				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
-// 				if err != nil {
-// 					klog.Infof("error listing artifactbuilds: %s", err.Error())
-// 					return false
-// 				}
-// 				gotABs := false
-// 				if len(abList.Items) > 0 {
-// 					gotABs = true
-// 				}
-// 				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
-// 				if err != nil {
-// 					klog.Infof("error listing dependencybuilds: %s", err.Error())
-// 					return false
-// 				}
-// 				gotDBs := false
-// 				if len(dbList.Items) > 0 {
-// 					gotDBs = true
-// 				}
-// 				if gotABs && gotDBs {
-// 					return true
-// 				}
-// 				return false
-// 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the generation of artifactbuilds and dependencybuilds")
-// 		})
+		It("that PipelineRun completes successfully", func() {
+			Eventually(func() bool {
+				pr, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+				if err != nil {
+					klog.Infof("get of pr %s returned error: %s", pr.Name, err.Error())
+					return false
+				}
+				if !pr.IsDone() {
+					klog.Infof("pipeline run %s not done", pr.Name)
+					return false
+				}
+				if !pr.GetStatusCondition().GetCondition(apis.ConditionSucceeded).IsTrue() {
+					Fail("component pipeline run did not succeed")
+				}
+				return true
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the pipeline run to complete")
+		})
+		It("artifactbuilds and dependencybuilds are generated", func() {
+			Eventually(func() bool {
+				abList, err := f.HacbsUser.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
+				if err != nil {
+					klog.Infof("error listing artifactbuilds: %s", err.Error())
+					return false
+				}
+				gotABs := false
+				if len(abList.Items) > 0 {
+					gotABs = true
+				}
+				dbList, err := f.HacbsUser.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
+				if err != nil {
+					klog.Infof("error listing dependencybuilds: %s", err.Error())
+					return false
+				}
+				gotDBs := false
+				if len(dbList.Items) > 0 {
+					gotDBs = true
+				}
+				if gotABs && gotDBs {
+					return true
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the generation of artifactbuilds and dependencybuilds")
+		})
 
-// 		It("some artifactbuilds and dependencybuilds complete", func() {
-// 			err = wait.PollImmediate(interval, timeout, func() (done bool, err error) {
-// 				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
-// 				if err != nil {
-// 					klog.Infof("error listing artifactbuilds: %s", err.Error())
-// 					return false, nil
-// 				}
-// 				abComplete := false
-// 				for _, ab := range abList.Items {
-// 					if ab.Status.State == v1alpha1.ArtifactBuildStateComplete {
-// 						abComplete = true
-// 						break
-// 					}
-// 				}
-// 				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
-// 				if err != nil {
-// 					klog.Infof("error listing dependencybuilds: %s", err.Error())
-// 					return false, nil
-// 				}
-// 				dbComplete := false
-// 				for _, db := range dbList.Items {
-// 					if db.Status.State == v1alpha1.DependencyBuildStateComplete {
-// 						dbComplete = true
-// 						break
-// 					}
-// 				}
-// 				if abComplete && dbComplete {
-// 					return true, nil
-// 				}
-// 				return false, nil
-// 			})
-// 			if err != nil {
-// 				ciRepoName := os.Getenv("REPO_NAME")
-// 				// Fail only in case the test was run from jvm-build-service repo or locally
-// 				if ciRepoName == "jvm-build-service" || ciRepoName == "" {
-// 					Fail("timed out waiting for some artifactbuilds/dependencybuilds to complete")
-// 				} else {
-// 					doCollectLogs = true
-// 					Skip("SKIPPING: unstable feature: timed-out when waiting for some artifactbuilds and dependencybuilds complete")
-// 				}
-// 			}
-// 		})
-// 	})
-// })
+		It("some artifactbuilds and dependencybuilds complete", func() {
+			err = wait.PollImmediate(interval, timeout, func() (done bool, err error) {
+				abList, err := f.HacbsUser.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
+				if err != nil {
+					klog.Infof("error listing artifactbuilds: %s", err.Error())
+					return false, nil
+				}
+				abComplete := false
+				for _, ab := range abList.Items {
+					if ab.Status.State == v1alpha1.ArtifactBuildStateComplete {
+						abComplete = true
+						break
+					}
+				}
+				dbList, err := f.HacbsUser.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
+				if err != nil {
+					klog.Infof("error listing dependencybuilds: %s", err.Error())
+					return false, nil
+				}
+				dbComplete := false
+				for _, db := range dbList.Items {
+					if db.Status.State == v1alpha1.DependencyBuildStateComplete {
+						dbComplete = true
+						break
+					}
+				}
+				if abComplete && dbComplete {
+					return true, nil
+				}
+				return false, nil
+			})
+			if err != nil {
+				ciRepoName := os.Getenv("REPO_NAME")
+				// Fail only in case the test was run from jvm-build-service repo or locally
+				if ciRepoName == "jvm-build-service" || ciRepoName == "" {
+					Fail("timed out waiting for some artifactbuilds/dependencybuilds to complete")
+				} else {
+					doCollectLogs = true
+					Skip("SKIPPING: unstable feature: timed-out when waiting for some artifactbuilds and dependencybuilds complete")
+				}
+			}
+		})
+	})
+})

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -1,424 +1,424 @@
 package build
 
-import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"os"
-	"strings"
-	"time"
+// import (
+// 	"context"
+// 	"encoding/json"
+// 	"fmt"
+// 	"os"
+// 	"strings"
+// 	"time"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"k8s.io/apimachinery/pkg/util/wait"
+// 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+// 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/devfile/library/pkg/util"
-	"github.com/google/uuid"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
+// 	"github.com/devfile/library/pkg/util"
+// 	"github.com/google/uuid"
+// 	. "github.com/onsi/ginkgo/v2"
+// 	. "github.com/onsi/gomega"
+// 	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
 
-	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
-	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
-	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
+// 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
+// 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
+// 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
-	"knative.dev/pkg/apis"
-)
+// 	corev1 "k8s.io/api/core/v1"
+// 	v1 "k8s.io/api/core/v1"
+// 	"k8s.io/apimachinery/pkg/api/errors"
+// 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+// 	"k8s.io/klog/v2"
+// 	"knative.dev/pkg/apis"
+// )
 
-var (
-	testProjectGitUrl   = utils.GetEnv("JVM_BUILD_SERVICE_TEST_REPO_URL", "https://github.com/stuartwdouglas/hacbs-test-project")
-	testProjectRevision = utils.GetEnv("JVM_BUILD_SERVICE_TEST_REPO_REVISION", "main")
-)
+// var (
+// 	testProjectGitUrl   = utils.GetEnv("JVM_BUILD_SERVICE_TEST_REPO_URL", "https://github.com/stuartwdouglas/hacbs-test-project")
+// 	testProjectRevision = utils.GetEnv("JVM_BUILD_SERVICE_TEST_REPO_REVISION", "main")
+// )
 
-var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jvm-build", "HACBS"), Pending, func() {
-	defer GinkgoRecover()
+// var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jvm-build", "HACBS"), Pending, func() {
+// 	defer GinkgoRecover()
 
-	var testNamespace, applicationName, componentName, outputContainerImage string
-	var componentPipelineRun *v1beta1.PipelineRun
-	var timeout, interval time.Duration
-	var doCollectLogs bool
+// 	var testNamespace, applicationName, componentName, outputContainerImage string
+// 	var componentPipelineRun *v1beta1.PipelineRun
+// 	var timeout, interval time.Duration
+// 	var doCollectLogs bool
 
-	f, err := framework.NewFramework()
-	Expect(err).NotTo(HaveOccurred())
+// 	f, err := framework.NewFramework()
+// 	Expect(err).NotTo(HaveOccurred())
 
-	AfterAll(func() {
-		abList, err := f.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
-		if err != nil {
-			klog.Infof("got error fetching artifactbuilds: %s", err.Error())
-		}
+// 	AfterAll(func() {
+// 		abList, err := f.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
+// 		if err != nil {
+// 			klog.Infof("got error fetching artifactbuilds: %s", err.Error())
+// 		}
 
-		dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
-		if err != nil {
-			klog.Infof("got error fetching dependencybuilds: %s", err.Error())
-		}
+// 		dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
+// 		if err != nil {
+// 			klog.Infof("got error fetching dependencybuilds: %s", err.Error())
+// 		}
 
-		if CurrentSpecReport().Failed() || doCollectLogs {
-			var testLogsDir string
-			artifactDir := os.Getenv("ARTIFACT_DIR")
-			var storeLogsInFiles bool
+// 		if CurrentSpecReport().Failed() || doCollectLogs {
+// 			var testLogsDir string
+// 			artifactDir := os.Getenv("ARTIFACT_DIR")
+// 			var storeLogsInFiles bool
 
-			if artifactDir != "" {
-				testLogsDir = fmt.Sprintf("%s/jvm-build-service-test", artifactDir)
-				err := os.MkdirAll(testLogsDir, 0755)
-				if err != nil && !os.IsExist(err) {
-					klog.Infof("cannot create a folder %s for storing test logs/resources: %+v", testLogsDir, err)
-				} else {
-					storeLogsInFiles = true
-				}
-			}
-			// get jvm-build-service logs
-			toDebug := map[string]string{}
+// 			if artifactDir != "" {
+// 				testLogsDir = fmt.Sprintf("%s/jvm-build-service-test", artifactDir)
+// 				err := os.MkdirAll(testLogsDir, 0755)
+// 				if err != nil && !os.IsExist(err) {
+// 					klog.Infof("cannot create a folder %s for storing test logs/resources: %+v", testLogsDir, err)
+// 				} else {
+// 					storeLogsInFiles = true
+// 				}
+// 			}
+// 			// get jvm-build-service logs
+// 			toDebug := map[string]string{}
 
-			jvmPodList, jerr := f.CommonController.K8sClient.KubeInterface().CoreV1().Pods("jvm-build-service").List(context.TODO(), metav1.ListOptions{})
-			if jerr != nil {
-				klog.Infof("error listing jvm-build-service pods: %s", jerr.Error())
-			}
-			klog.Infof("found %d pods in jvm-build-service namespace", len(jvmPodList.Items))
-			for _, pod := range jvmPodList.Items {
-				var containers []corev1.Container
-				containers = append(containers, pod.Spec.InitContainers...)
-				containers = append(containers, pod.Spec.Containers...)
-				for _, c := range containers {
-					cLog, cerr := f.CommonController.GetContainerLogs(pod.Name, c.Name, pod.Namespace)
-					if cerr != nil {
-						klog.Infof("error getting logs for pod/container %s/%s: %s", pod.Name, c.Name, cerr.Error())
-						continue
-					}
-					filename := fmt.Sprintf("%s-pod-%s-%s.log", pod.Namespace, pod.Name, c.Name)
-					toDebug[filename] = cLog
-				}
-			}
-			// let's make sure and print the pr that starts the analysis first
+// 			jvmPodList, jerr := f.CommonController.K8sClient.KubeInterface().CoreV1().Pods("jvm-build-service").List(context.TODO(), metav1.ListOptions{})
+// 			if jerr != nil {
+// 				klog.Infof("error listing jvm-build-service pods: %s", jerr.Error())
+// 			}
+// 			klog.Infof("found %d pods in jvm-build-service namespace", len(jvmPodList.Items))
+// 			for _, pod := range jvmPodList.Items {
+// 				var containers []corev1.Container
+// 				containers = append(containers, pod.Spec.InitContainers...)
+// 				containers = append(containers, pod.Spec.Containers...)
+// 				for _, c := range containers {
+// 					cLog, cerr := f.CommonController.GetContainerLogs(pod.Name, c.Name, pod.Namespace)
+// 					if cerr != nil {
+// 						klog.Infof("error getting logs for pod/container %s/%s: %s", pod.Name, c.Name, cerr.Error())
+// 						continue
+// 					}
+// 					filename := fmt.Sprintf("%s-pod-%s-%s.log", pod.Namespace, pod.Name, c.Name)
+// 					toDebug[filename] = cLog
+// 				}
+// 			}
+// 			// let's make sure and print the pr that starts the analysis first
 
-			logs, err := f.TektonController.GetPipelineRunLogs(componentPipelineRun.Name, testNamespace)
-			if err != nil {
-				klog.Infof("got error fetching PR logs: %s", err.Error())
-			}
-			filename := fmt.Sprintf("%s-pr-%s.log", testNamespace, componentPipelineRun.Name)
-			toDebug[filename] = logs
+// 			logs, err := f.TektonController.GetPipelineRunLogs(componentPipelineRun.Name, testNamespace)
+// 			if err != nil {
+// 				klog.Infof("got error fetching PR logs: %s", err.Error())
+// 			}
+// 			filename := fmt.Sprintf("%s-pr-%s.log", testNamespace, componentPipelineRun.Name)
+// 			toDebug[filename] = logs
 
-			prList, err := f.TektonController.ListAllPipelineRuns(testNamespace)
-			if err != nil {
-				klog.Infof("got error fetching PR list: %s", err.Error())
-			}
-			klog.Infof("total number of pipeline runs not pruned: %d", len(prList.Items))
-			for _, pr := range prList.Items {
-				if pr.Name == componentPipelineRun.Name {
-					continue
-				}
-				prLog, err := f.TektonController.GetPipelineRunLogs(pr.Name, pr.Namespace)
-				if err != nil {
-					klog.Infof("got error fetching PR logs for %s: %s", pr.Name, err.Error())
-				}
-				filename := fmt.Sprintf("%s-pr-%s.log", pr.Namespace, pr.Name)
-				toDebug[filename] = prLog
-			}
+// 			prList, err := f.TektonController.ListAllPipelineRuns(testNamespace)
+// 			if err != nil {
+// 				klog.Infof("got error fetching PR list: %s", err.Error())
+// 			}
+// 			klog.Infof("total number of pipeline runs not pruned: %d", len(prList.Items))
+// 			for _, pr := range prList.Items {
+// 				if pr.Name == componentPipelineRun.Name {
+// 					continue
+// 				}
+// 				prLog, err := f.TektonController.GetPipelineRunLogs(pr.Name, pr.Namespace)
+// 				if err != nil {
+// 					klog.Infof("got error fetching PR logs for %s: %s", pr.Name, err.Error())
+// 				}
+// 				filename := fmt.Sprintf("%s-pr-%s.log", pr.Namespace, pr.Name)
+// 				toDebug[filename] = prLog
+// 			}
 
-			for _, ab := range abList.Items {
-				v, err := json.MarshalIndent(ab, "", "  ")
-				if err != nil {
-					klog.Infof("error when marshalling content of %s from %s namespace: %+v", ab.Name, ab.Namespace, err)
-				} else {
-					filename := fmt.Sprintf("%s-ab-%s.json", ab.Namespace, ab.Name)
-					toDebug[filename] = string(v)
-				}
-			}
-			for _, db := range dbList.Items {
-				v, err := json.MarshalIndent(db, "", "  ")
-				if err != nil {
-					klog.Infof("error when marshalling content of %s from %s namespace: %+v", db.Name, db.Namespace, err)
-				} else {
-					filename := fmt.Sprintf("%s-db-%s.json", db.Namespace, db.Name)
-					toDebug[filename] = string(v)
-				}
-			}
+// 			for _, ab := range abList.Items {
+// 				v, err := json.MarshalIndent(ab, "", "  ")
+// 				if err != nil {
+// 					klog.Infof("error when marshalling content of %s from %s namespace: %+v", ab.Name, ab.Namespace, err)
+// 				} else {
+// 					filename := fmt.Sprintf("%s-ab-%s.json", ab.Namespace, ab.Name)
+// 					toDebug[filename] = string(v)
+// 				}
+// 			}
+// 			for _, db := range dbList.Items {
+// 				v, err := json.MarshalIndent(db, "", "  ")
+// 				if err != nil {
+// 					klog.Infof("error when marshalling content of %s from %s namespace: %+v", db.Name, db.Namespace, err)
+// 				} else {
+// 					filename := fmt.Sprintf("%s-db-%s.json", db.Namespace, db.Name)
+// 					toDebug[filename] = string(v)
+// 				}
+// 			}
 
-			for file, content := range toDebug {
-				if storeLogsInFiles {
-					filename := fmt.Sprintf("%s/%s", testLogsDir, file)
-					if err := os.WriteFile(filename, []byte(content), 0644); err != nil {
-						klog.Infof("cannot write to %s: %+v", filename, err)
-					} else {
-						continue
-					}
-				} else {
-					klog.Infof("%s\n%s", file, content)
-				}
-			}
-		}
-		// Cleanup
-		for _, ab := range abList.Items {
-			err := f.JvmbuildserviceController.DeleteArtifactBuild(ab.Name, ab.Namespace)
-			if err != nil {
-				klog.Infof("got error deleting AB %s: %s", ab.Name, err.Error())
-			}
-		}
-		for _, db := range dbList.Items {
-			err := f.JvmbuildserviceController.DeleteDependencyBuild(db.Name, db.Namespace)
-			if err != nil {
-				klog.Infof("got error deleting DB %s: %s", db.Name, err.Error())
-			}
-		}
-		Expect(f.HasController.DeleteHasComponent(componentName, testNamespace, false)).To(Succeed())
-		Expect(f.HasController.DeleteHasApplication(applicationName, testNamespace, false)).To(Succeed())
-		Expect(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(Succeed())
-	})
+// 			for file, content := range toDebug {
+// 				if storeLogsInFiles {
+// 					filename := fmt.Sprintf("%s/%s", testLogsDir, file)
+// 					if err := os.WriteFile(filename, []byte(content), 0644); err != nil {
+// 						klog.Infof("cannot write to %s: %+v", filename, err)
+// 					} else {
+// 						continue
+// 					}
+// 				} else {
+// 					klog.Infof("%s\n%s", file, content)
+// 				}
+// 			}
+// 		}
+// 		// Cleanup
+// 		for _, ab := range abList.Items {
+// 			err := f.JvmbuildserviceController.DeleteArtifactBuild(ab.Name, ab.Namespace)
+// 			if err != nil {
+// 				klog.Infof("got error deleting AB %s: %s", ab.Name, err.Error())
+// 			}
+// 		}
+// 		for _, db := range dbList.Items {
+// 			err := f.JvmbuildserviceController.DeleteDependencyBuild(db.Name, db.Namespace)
+// 			if err != nil {
+// 				klog.Infof("got error deleting DB %s: %s", db.Name, err.Error())
+// 			}
+// 		}
+// 		Expect(f.HasController.DeleteHasComponent(componentName, testNamespace, false)).To(Succeed())
+// 		Expect(f.HasController.DeleteHasApplication(applicationName, testNamespace, false)).To(Succeed())
+// 		Expect(f.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(Succeed())
+// 	})
 
-	BeforeAll(func() {
-		testNamespace = utils.GetGeneratedNamespace("jvm-build")
+// 	BeforeAll(func() {
+// 		testNamespace = utils.GetGeneratedNamespace("jvm-build")
 
-		klog.Infof("Test namespace: %s", testNamespace)
+// 		klog.Infof("Test namespace: %s", testNamespace)
 
-		_, err := f.CommonController.CreateTestNamespace(testNamespace)
-		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+// 		_, err := f.CommonController.CreateTestNamespace(testNamespace)
+// 		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
 
-		customBundleConfigMap, err := f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, testNamespace)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				defaultBundleConfigMap, err := f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
-				Expect(err).ToNot(HaveOccurred())
+// 		customBundleConfigMap, err := f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, testNamespace)
+// 		if err != nil {
+// 			if errors.IsNotFound(err) {
+// 				defaultBundleConfigMap, err := f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
+// 				Expect(err).ToNot(HaveOccurred())
 
-				bundlePullSpec := defaultBundleConfigMap.Data["default_build_bundle"]
-				hacbsBundleConfigMap := &v1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
-					Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
-				}
-				_, err = f.CommonController.CreateConfigMap(hacbsBundleConfigMap, testNamespace)
-				Expect(err).ToNot(HaveOccurred())
-				DeferCleanup(f.CommonController.DeleteConfigMap, constants.BuildPipelinesConfigMapName, testNamespace, false)
-			} else {
-				Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, testNamespace, err))
-			}
-		} else {
-			bundlePullSpec := customBundleConfigMap.Data["default_build_bundle"]
-			hacbsBundleConfigMap := &v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
-				Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
-			}
+// 				bundlePullSpec := defaultBundleConfigMap.Data["default_build_bundle"]
+// 				hacbsBundleConfigMap := &v1.ConfigMap{
+// 					ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
+// 					Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
+// 				}
+// 				_, err = f.CommonController.CreateConfigMap(hacbsBundleConfigMap, testNamespace)
+// 				Expect(err).ToNot(HaveOccurred())
+// 				DeferCleanup(f.CommonController.DeleteConfigMap, constants.BuildPipelinesConfigMapName, testNamespace, false)
+// 			} else {
+// 				Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, testNamespace, err))
+// 			}
+// 		} else {
+// 			bundlePullSpec := customBundleConfigMap.Data["default_build_bundle"]
+// 			hacbsBundleConfigMap := &v1.ConfigMap{
+// 				ObjectMeta: metav1.ObjectMeta{Name: constants.BuildPipelinesConfigMapName},
+// 				Data:       map[string]string{"default_build_bundle": strings.Replace(bundlePullSpec, "build-", "hacbs-", 1)},
+// 			}
 
-			_, err = f.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
-			Expect(err).ToNot(HaveOccurred())
-			DeferCleanup(func() error {
-				hacbsBundleConfigMap.Data = customBundleConfigMap.Data
-				_, err := f.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
-				if err != nil {
-					return err
-				}
-				return nil
-			})
-		}
+// 			_, err = f.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
+// 			Expect(err).ToNot(HaveOccurred())
+// 			DeferCleanup(func() error {
+// 				hacbsBundleConfigMap.Data = customBundleConfigMap.Data
+// 				_, err := f.CommonController.UpdateConfigMap(hacbsBundleConfigMap, testNamespace)
+// 				if err != nil {
+// 					return err
+// 				}
+// 				return nil
+// 			})
+// 		}
 
-		//enable artifact rebuilds
-		jvmConfigMap := &v1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: constants.JVMUserConfigMapName},
-			Data:       map[string]string{constants.JVMEnableRebuilds: "true"},
-		}
-		existingJvmConfigMap, err := f.CommonController.GetConfigMap(constants.JVMUserConfigMapName, testNamespace)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				_, err = f.CommonController.CreateConfigMap(jvmConfigMap, testNamespace)
-				Expect(err).ToNot(HaveOccurred())
-				DeferCleanup(f.CommonController.DeleteConfigMap, constants.JVMUserConfigMapName, testNamespace, false)
-			} else {
-				Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.JVMUserConfigMapName, testNamespace, err))
-			}
-		} else {
-			_, err = f.CommonController.UpdateConfigMap(jvmConfigMap, testNamespace)
-			Expect(err).ToNot(HaveOccurred())
-			DeferCleanup(func() error {
-				_, err := f.CommonController.UpdateConfigMap(existingJvmConfigMap, testNamespace)
-				if err != nil {
-					return err
-				}
-				return nil
-			})
-		}
-		timeout = time.Minute * 20
-		interval = time.Second * 10
+// 		//enable artifact rebuilds
+// 		jvmConfigMap := &v1.ConfigMap{
+// 			ObjectMeta: metav1.ObjectMeta{Name: constants.JVMUserConfigMapName},
+// 			Data:       map[string]string{constants.JVMEnableRebuilds: "true"},
+// 		}
+// 		existingJvmConfigMap, err := f.CommonController.GetConfigMap(constants.JVMUserConfigMapName, testNamespace)
+// 		if err != nil {
+// 			if errors.IsNotFound(err) {
+// 				_, err = f.CommonController.CreateConfigMap(jvmConfigMap, testNamespace)
+// 				Expect(err).ToNot(HaveOccurred())
+// 				DeferCleanup(f.CommonController.DeleteConfigMap, constants.JVMUserConfigMapName, testNamespace, false)
+// 			} else {
+// 				Fail(fmt.Sprintf("error occured when trying to get configmap %s in %s namespace: %v", constants.JVMUserConfigMapName, testNamespace, err))
+// 			}
+// 		} else {
+// 			_, err = f.CommonController.UpdateConfigMap(jvmConfigMap, testNamespace)
+// 			Expect(err).ToNot(HaveOccurred())
+// 			DeferCleanup(func() error {
+// 				_, err := f.CommonController.UpdateConfigMap(existingJvmConfigMap, testNamespace)
+// 				if err != nil {
+// 					return err
+// 				}
+// 				return nil
+// 			})
+// 		}
+// 		timeout = time.Minute * 20
+// 		interval = time.Second * 10
 
-		applicationName = fmt.Sprintf("jvm-build-suite-application-%s", util.GenerateRandomString(4))
-		app, err := f.HasController.CreateHasApplication(applicationName, testNamespace)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(utils.WaitUntil(f.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
-			Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
-		)
+// 		applicationName = fmt.Sprintf("jvm-build-suite-application-%s", util.GenerateRandomString(4))
+// 		app, err := f.HasController.CreateHasApplication(applicationName, testNamespace)
+// 		Expect(err).NotTo(HaveOccurred())
+// 		Expect(utils.WaitUntil(f.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+// 			Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
+// 		)
 
-		componentName = fmt.Sprintf("jvm-build-suite-component-%s", util.GenerateRandomString(4))
-		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+// 		componentName = fmt.Sprintf("jvm-build-suite-component-%s", util.GenerateRandomString(4))
+// 		outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
 
-		// Create a component with Git Source URL being defined
-		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, testProjectGitUrl, testProjectRevision, "", outputContainerImage, "")
-		Expect(err).ShouldNot(HaveOccurred())
-	})
+// 		// Create a component with Git Source URL being defined
+// 		_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, testProjectGitUrl, testProjectRevision, "", outputContainerImage, "")
+// 		Expect(err).ShouldNot(HaveOccurred())
+// 	})
 
-	When("the Component with s2i-java component is created", func() {
-		It("a PipelineRun is triggered", func() {
-			Eventually(func() bool {
-				componentPipelineRun, err = f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
-				if err != nil {
-					klog.Infoln("PipelineRun has not been created yet")
-					return false
-				}
-				return componentPipelineRun.HasStarted()
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
-		})
+// 	When("the Component with s2i-java component is created", func() {
+// 		It("a PipelineRun is triggered", func() {
+// 			Eventually(func() bool {
+// 				componentPipelineRun, err = f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+// 				if err != nil {
+// 					klog.Infoln("PipelineRun has not been created yet")
+// 					return false
+// 				}
+// 				return componentPipelineRun.HasStarted()
+// 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
+// 		})
 
-		It("the build-container task from component PipelineRun references a correct sidecar image", func() {
-			ciSidecarImage := os.Getenv("JVM_BUILD_SERVICE_SIDECAR_IMAGE")
-			if ciSidecarImage == "" {
-				Skip("JVM_BUILD_SERVICE_SIDECAR_IMAGE env var is not exported, skipping the test...")
-			}
+// 		It("the build-container task from component PipelineRun references a correct sidecar image", func() {
+// 			ciSidecarImage := os.Getenv("JVM_BUILD_SERVICE_SIDECAR_IMAGE")
+// 			if ciSidecarImage == "" {
+// 				Skip("JVM_BUILD_SERVICE_SIDECAR_IMAGE env var is not exported, skipping the test...")
+// 			}
 
-			err = wait.PollImmediate(interval, timeout, func() (done bool, err error) {
-				pr, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
-				if err != nil {
-					klog.Infof("get pr for component %s produced err: %s", componentName, err.Error())
-					return false, nil
-				}
+// 			err = wait.PollImmediate(interval, timeout, func() (done bool, err error) {
+// 				pr, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+// 				if err != nil {
+// 					klog.Infof("get pr for component %s produced err: %s", componentName, err.Error())
+// 					return false, nil
+// 				}
 
-				for _, tr := range pr.Status.TaskRuns {
-					if tr.PipelineTaskName == "build-container" && tr.Status != nil && tr.Status.TaskSpec != nil && tr.Status.TaskSpec.Sidecars != nil {
-						for _, sc := range tr.Status.TaskSpec.Sidecars {
-							if sc.Name == "proxy" {
-								if sc.Image != ciSidecarImage {
-									Fail(fmt.Sprintf("the build-container task from component pipelinerun doesn't contain correct sidecar image. expected: %v, actual: %v", ciSidecarImage, sc.Image))
-								} else {
-									return true, nil
-								}
-							}
-						}
-					}
-				}
-				return false, nil
-			})
-			if err != nil {
-				Fail(fmt.Sprintf("failure occured when verifying the sidecar image reference in pipelinerun: %v", err))
-			}
-		})
+// 				for _, tr := range pr.Status.TaskRuns {
+// 					if tr.PipelineTaskName == "build-container" && tr.Status != nil && tr.Status.TaskSpec != nil && tr.Status.TaskSpec.Sidecars != nil {
+// 						for _, sc := range tr.Status.TaskSpec.Sidecars {
+// 							if sc.Name == "proxy" {
+// 								if sc.Image != ciSidecarImage {
+// 									Fail(fmt.Sprintf("the build-container task from component pipelinerun doesn't contain correct sidecar image. expected: %v, actual: %v", ciSidecarImage, sc.Image))
+// 								} else {
+// 									return true, nil
+// 								}
+// 							}
+// 						}
+// 					}
+// 				}
+// 				return false, nil
+// 			})
+// 			if err != nil {
+// 				Fail(fmt.Sprintf("failure occured when verifying the sidecar image reference in pipelinerun: %v", err))
+// 			}
+// 		})
 
-		It("the build-container task from component pipelinerun references a correct analyzer image", func() {
-			ciAnalyzerImage := os.Getenv("JVM_BUILD_SERVICE_ANALYZER_IMAGE")
+// 		It("the build-container task from component pipelinerun references a correct analyzer image", func() {
+// 			ciAnalyzerImage := os.Getenv("JVM_BUILD_SERVICE_ANALYZER_IMAGE")
 
-			if ciAnalyzerImage == "" {
-				Skip("JVM_BUILD_SERVICE_ANALYZER_IMAGE env var is not exported, skipping the test...")
-			}
+// 			if ciAnalyzerImage == "" {
+// 				Skip("JVM_BUILD_SERVICE_ANALYZER_IMAGE env var is not exported, skipping the test...")
+// 			}
 
-			err = wait.PollImmediate(interval, timeout, func() (done bool, err error) {
-				pr, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
-				if err != nil {
-					klog.Infof("get pr for the component %s produced err: %s", componentName, err.Error())
-					return false, nil
-				}
+// 			err = wait.PollImmediate(interval, timeout, func() (done bool, err error) {
+// 				pr, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+// 				if err != nil {
+// 					klog.Infof("get pr for the component %s produced err: %s", componentName, err.Error())
+// 					return false, nil
+// 				}
 
-				for _, tr := range pr.Status.TaskRuns {
-					if tr.PipelineTaskName == "build-container" && tr.Status != nil && tr.Status.TaskSpec != nil && tr.Status.TaskSpec.Steps != nil {
-						for _, step := range tr.Status.TaskSpec.Steps {
-							if step.Name == "analyse-dependencies-java-sbom" {
-								if step.Image != ciAnalyzerImage {
-									Fail(fmt.Sprintf("the build-container task from component pipelinerun doesn't reference the correct analyzer image. expected: %v, actual: %v", ciAnalyzerImage, step.Image))
-								} else {
-									return true, nil
-								}
-							}
-						}
-					}
-				}
-				return false, nil
-			})
-			if err != nil {
-				Fail(fmt.Sprintf("failure occured when verifying the analyzer image reference in pipelinerun: %v", err))
-			}
-		})
+// 				for _, tr := range pr.Status.TaskRuns {
+// 					if tr.PipelineTaskName == "build-container" && tr.Status != nil && tr.Status.TaskSpec != nil && tr.Status.TaskSpec.Steps != nil {
+// 						for _, step := range tr.Status.TaskSpec.Steps {
+// 							if step.Name == "analyse-dependencies-java-sbom" {
+// 								if step.Image != ciAnalyzerImage {
+// 									Fail(fmt.Sprintf("the build-container task from component pipelinerun doesn't reference the correct analyzer image. expected: %v, actual: %v", ciAnalyzerImage, step.Image))
+// 								} else {
+// 									return true, nil
+// 								}
+// 							}
+// 						}
+// 					}
+// 				}
+// 				return false, nil
+// 			})
+// 			if err != nil {
+// 				Fail(fmt.Sprintf("failure occured when verifying the analyzer image reference in pipelinerun: %v", err))
+// 			}
+// 		})
 
-		It("that PipelineRun completes successfully", func() {
-			Eventually(func() bool {
-				pr, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
-				if err != nil {
-					klog.Infof("get of pr %s returned error: %s", pr.Name, err.Error())
-					return false
-				}
-				if !pr.IsDone() {
-					klog.Infof("pipeline run %s not done", pr.Name)
-					return false
-				}
-				if !pr.GetStatusCondition().GetCondition(apis.ConditionSucceeded).IsTrue() {
-					Fail("component pipeline run did not succeed")
-				}
-				return true
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the pipeline run to complete")
-		})
-		It("artifactbuilds and dependencybuilds are generated", func() {
-			Eventually(func() bool {
-				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
-				if err != nil {
-					klog.Infof("error listing artifactbuilds: %s", err.Error())
-					return false
-				}
-				gotABs := false
-				if len(abList.Items) > 0 {
-					gotABs = true
-				}
-				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
-				if err != nil {
-					klog.Infof("error listing dependencybuilds: %s", err.Error())
-					return false
-				}
-				gotDBs := false
-				if len(dbList.Items) > 0 {
-					gotDBs = true
-				}
-				if gotABs && gotDBs {
-					return true
-				}
-				return false
-			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the generation of artifactbuilds and dependencybuilds")
-		})
+// 		It("that PipelineRun completes successfully", func() {
+// 			Eventually(func() bool {
+// 				pr, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+// 				if err != nil {
+// 					klog.Infof("get of pr %s returned error: %s", pr.Name, err.Error())
+// 					return false
+// 				}
+// 				if !pr.IsDone() {
+// 					klog.Infof("pipeline run %s not done", pr.Name)
+// 					return false
+// 				}
+// 				if !pr.GetStatusCondition().GetCondition(apis.ConditionSucceeded).IsTrue() {
+// 					Fail("component pipeline run did not succeed")
+// 				}
+// 				return true
+// 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the pipeline run to complete")
+// 		})
+// 		It("artifactbuilds and dependencybuilds are generated", func() {
+// 			Eventually(func() bool {
+// 				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
+// 				if err != nil {
+// 					klog.Infof("error listing artifactbuilds: %s", err.Error())
+// 					return false
+// 				}
+// 				gotABs := false
+// 				if len(abList.Items) > 0 {
+// 					gotABs = true
+// 				}
+// 				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
+// 				if err != nil {
+// 					klog.Infof("error listing dependencybuilds: %s", err.Error())
+// 					return false
+// 				}
+// 				gotDBs := false
+// 				if len(dbList.Items) > 0 {
+// 					gotDBs = true
+// 				}
+// 				if gotABs && gotDBs {
+// 					return true
+// 				}
+// 				return false
+// 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the generation of artifactbuilds and dependencybuilds")
+// 		})
 
-		It("some artifactbuilds and dependencybuilds complete", func() {
-			err = wait.PollImmediate(interval, timeout, func() (done bool, err error) {
-				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
-				if err != nil {
-					klog.Infof("error listing artifactbuilds: %s", err.Error())
-					return false, nil
-				}
-				abComplete := false
-				for _, ab := range abList.Items {
-					if ab.Status.State == v1alpha1.ArtifactBuildStateComplete {
-						abComplete = true
-						break
-					}
-				}
-				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
-				if err != nil {
-					klog.Infof("error listing dependencybuilds: %s", err.Error())
-					return false, nil
-				}
-				dbComplete := false
-				for _, db := range dbList.Items {
-					if db.Status.State == v1alpha1.DependencyBuildStateComplete {
-						dbComplete = true
-						break
-					}
-				}
-				if abComplete && dbComplete {
-					return true, nil
-				}
-				return false, nil
-			})
-			if err != nil {
-				ciRepoName := os.Getenv("REPO_NAME")
-				// Fail only in case the test was run from jvm-build-service repo or locally
-				if ciRepoName == "jvm-build-service" || ciRepoName == "" {
-					Fail("timed out waiting for some artifactbuilds/dependencybuilds to complete")
-				} else {
-					doCollectLogs = true
-					Skip("SKIPPING: unstable feature: timed-out when waiting for some artifactbuilds and dependencybuilds complete")
-				}
-			}
-		})
-	})
-})
+// 		It("some artifactbuilds and dependencybuilds complete", func() {
+// 			err = wait.PollImmediate(interval, timeout, func() (done bool, err error) {
+// 				abList, err := f.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
+// 				if err != nil {
+// 					klog.Infof("error listing artifactbuilds: %s", err.Error())
+// 					return false, nil
+// 				}
+// 				abComplete := false
+// 				for _, ab := range abList.Items {
+// 					if ab.Status.State == v1alpha1.ArtifactBuildStateComplete {
+// 						abComplete = true
+// 						break
+// 					}
+// 				}
+// 				dbList, err := f.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
+// 				if err != nil {
+// 					klog.Infof("error listing dependencybuilds: %s", err.Error())
+// 					return false, nil
+// 				}
+// 				dbComplete := false
+// 				for _, db := range dbList.Items {
+// 					if db.Status.State == v1alpha1.DependencyBuildStateComplete {
+// 						dbComplete = true
+// 						break
+// 					}
+// 				}
+// 				if abComplete && dbComplete {
+// 					return true, nil
+// 				}
+// 				return false, nil
+// 			})
+// 			if err != nil {
+// 				ciRepoName := os.Getenv("REPO_NAME")
+// 				// Fail only in case the test was run from jvm-build-service repo or locally
+// 				if ciRepoName == "jvm-build-service" || ciRepoName == "" {
+// 					Fail("timed out waiting for some artifactbuilds/dependencybuilds to complete")
+// 				} else {
+// 					doCollectLogs = true
+// 					Skip("SKIPPING: unstable feature: timed-out when waiting for some artifactbuilds and dependencybuilds complete")
+// 				}
+// 			}
+// 		})
+// 	})
+// })

--- a/tests/cluster-registration/clusters.go
+++ b/tests/cluster-registration/clusters.go
@@ -16,19 +16,19 @@ var _ = framework.ClusterRegistrationSuiteDescribe("Cluster Registration E2E tes
 
 	g.Context("infrastructure is running", func() {
 		g.It("verify the cluster-registration-installer-controller-manager is running", func() {
-			err := framework.CommonController.WaitForPodSelector(framework.CommonController.IsPodRunning, constants.CLUSTER_REG_NS, "cluster-registration-antiaffinity-selector", "cluster-registration-installer-controller", 60, 100)
+			err := framework.AppstudioUser.CommonController.WaitForPodSelector(framework.AppstudioUser.CommonController.IsPodRunning, constants.CLUSTER_REG_NS, "cluster-registration-antiaffinity-selector", "cluster-registration-installer-controller", 60, 100)
 			Expect(err).NotTo(HaveOccurred())
 		})
 		g.It("verify the correct roles are created", func() {
-			_, csaErr := framework.CommonController.GetRole("cluster-registration-installer-leader-election-role", constants.CLUSTER_REG_NS)
+			_, csaErr := framework.AppstudioUser.CommonController.GetRole("cluster-registration-installer-leader-election-role", constants.CLUSTER_REG_NS)
 			Expect(csaErr).NotTo(HaveOccurred())
 		})
 		g.It("verify the correct rolebindings are created", func() {
-			_, csaErr := framework.CommonController.GetRoleBinding("cluster-registration-installer-leader-election-rolebinding", constants.CLUSTER_REG_NS)
+			_, csaErr := framework.AppstudioUser.CommonController.GetRoleBinding("cluster-registration-installer-leader-election-rolebinding", constants.CLUSTER_REG_NS)
 			Expect(csaErr).NotTo(HaveOccurred())
 		})
 		g.It("verify the correct service account is created", func() {
-			_, err := framework.CommonController.GetServiceAccount("cluster-registration-installer-controller-manager", constants.CLUSTER_REG_NS)
+			_, err := framework.AppstudioUser.CommonController.GetServiceAccount("cluster-registration-installer-controller-manager", constants.CLUSTER_REG_NS)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/tests/cluster-registration/clusters.go
+++ b/tests/cluster-registration/clusters.go
@@ -16,19 +16,19 @@ var _ = framework.ClusterRegistrationSuiteDescribe("Cluster Registration E2E tes
 
 	g.Context("infrastructure is running", func() {
 		g.It("verify the cluster-registration-installer-controller-manager is running", func() {
-			err := framework.AppstudioUser.CommonController.WaitForPodSelector(framework.AppstudioUser.CommonController.IsPodRunning, constants.CLUSTER_REG_NS, "cluster-registration-antiaffinity-selector", "cluster-registration-installer-controller", 60, 100)
+			err := framework.AppstudioUserWs.CommonController.WaitForPodSelector(framework.AppstudioUserWs.CommonController.IsPodRunning, constants.CLUSTER_REG_NS, "cluster-registration-antiaffinity-selector", "cluster-registration-installer-controller", 60, 100)
 			Expect(err).NotTo(HaveOccurred())
 		})
 		g.It("verify the correct roles are created", func() {
-			_, csaErr := framework.AppstudioUser.CommonController.GetRole("cluster-registration-installer-leader-election-role", constants.CLUSTER_REG_NS)
+			_, csaErr := framework.AppstudioUserWs.CommonController.GetRole("cluster-registration-installer-leader-election-role", constants.CLUSTER_REG_NS)
 			Expect(csaErr).NotTo(HaveOccurred())
 		})
 		g.It("verify the correct rolebindings are created", func() {
-			_, csaErr := framework.AppstudioUser.CommonController.GetRoleBinding("cluster-registration-installer-leader-election-rolebinding", constants.CLUSTER_REG_NS)
+			_, csaErr := framework.AppstudioUserWs.CommonController.GetRoleBinding("cluster-registration-installer-leader-election-rolebinding", constants.CLUSTER_REG_NS)
 			Expect(csaErr).NotTo(HaveOccurred())
 		})
 		g.It("verify the correct service account is created", func() {
-			_, err := framework.AppstudioUser.CommonController.GetServiceAccount("cluster-registration-installer-controller-manager", constants.CLUSTER_REG_NS)
+			_, err := framework.AppstudioUserWs.CommonController.GetServiceAccount("cluster-registration-installer-controller-manager", constants.CLUSTER_REG_NS)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/tests/e2e-demos/e2e-demo.go
+++ b/tests/e2e-demos/e2e-demo.go
@@ -66,23 +66,23 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 				Expect(utils.CheckIfEnvironmentExists(constants.GITHUB_TOKEN_ENV)).Should(BeTrue(), "%s environment variable is not set", constants.GITHUB_TOKEN_ENV)
 				// Check if 'has-github-token' is present, unless SKIP_HAS_SECRET_CHECK env var is set
 				if !utils.CheckIfEnvironmentExists(constants.SKIP_HAS_SECRET_CHECK_ENV) {
-					_, err := fw.HasController.KubeInterface().CoreV1().Secrets(RedHatAppStudioApplicationNamespace).Get(context.TODO(), ApplicationServiceGHTokenSecrName, metav1.GetOptions{})
+					_, err := fw.AppstudioUser.HasController.KubeInterface().CoreV1().Secrets(RedHatAppStudioApplicationNamespace).Get(context.TODO(), ApplicationServiceGHTokenSecrName, metav1.GetOptions{})
 					Expect(err).NotTo(HaveOccurred(), "Error checking 'has-github-token' secret %s", err)
 				}
-				_, err := fw.CommonController.CreateTestNamespace(namespace)
+				_, err := fw.AppstudioUser.CommonController.CreateTestNamespace(namespace)
 				Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", namespace, err)
 			})
 			// Remove all resources created by the tests
 			AfterAll(func() {
-				Expect(fw.HasController.DeleteAllComponentsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
-				Expect(fw.HasController.DeleteAllApplicationsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
-				Expect(fw.GitOpsController.DeleteAllGitOpsDeploymentInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
+				Expect(fw.AppstudioUser.HasController.DeleteAllComponentsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
+				Expect(fw.AppstudioUser.HasController.DeleteAllApplicationsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
+				Expect(fw.AppstudioUser.GitOpsController.DeleteAllGitOpsDeploymentInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
 			})
 
 			// Create an application in a specific namespace
 			It("application is created", func() {
 				fmt.Printf("Parallel process %d", GinkgoParallelProcess())
-				createdApplication, err := fw.HasController.CreateHasApplication(appTest.ApplicationName, namespace)
+				createdApplication, err := fw.AppstudioUser.HasController.CreateHasApplication(appTest.ApplicationName, namespace)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(createdApplication.Spec.DisplayName).To(Equal(appTest.ApplicationName))
 				Expect(createdApplication.Namespace).To(Equal(namespace))
@@ -91,7 +91,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 			// Check the application health and check if a devfile was generated in the status
 			It("application is healthy", func() {
 				Eventually(func() string {
-					appstudioApp, err := fw.HasController.GetHasApplication(appTest.ApplicationName, namespace)
+					appstudioApp, err := fw.AppstudioUser.HasController.GetHasApplication(appTest.ApplicationName, namespace)
 					Expect(err).NotTo(HaveOccurred())
 					application = appstudioApp
 
@@ -101,7 +101,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 				Eventually(func() bool {
 					gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-					return fw.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+					return fw.AppstudioUser.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
 				}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "Has controller didn't create gitops repository")
 			})
 
@@ -119,12 +119,12 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 							// More info about manual token upload for quay.io here: https://github.com/redhat-appstudio/service-provider-integration-operator/pull/115
 							oauthCredentials := `{"access_token":"` + utils.GetEnv(constants.QUAY_OAUTH_TOKEN_ENV, "") + `", "username":"` + utils.GetEnv(constants.QUAY_OAUTH_USER_ENV, "") + `"}`
 
-							oauthSecretName = fw.SPIController.InjectManualSPIToken(namespace, componentTest.ContainerSource, oauthCredentials, v1.SecretTypeDockerConfigJson)
+							oauthSecretName = fw.AppstudioUser.SPIController.InjectManualSPIToken(namespace, componentTest.ContainerSource, oauthCredentials, v1.SecretTypeDockerConfigJson)
 						} else if componentTest.GitSourceUrl != "" {
 							// More info about manual token upload for github.com
 							oauthCredentials := `{"access_token":"` + utils.GetEnv(constants.GITHUB_TOKEN_ENV, "") + `"}`
 
-							oauthSecretName = fw.SPIController.InjectManualSPIToken(namespace, componentTest.GitSourceUrl, oauthCredentials, v1.SecretTypeBasicAuth)
+							oauthSecretName = fw.AppstudioUser.SPIController.InjectManualSPIToken(namespace, componentTest.GitSourceUrl, oauthCredentials, v1.SecretTypeBasicAuth)
 						}
 					})
 				}
@@ -132,14 +132,14 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 				// Components for now can be imported from gitUrl, container image or a devfile
 				if componentTest.ContainerSource != "" {
 					It(fmt.Sprintf("create component %s from %s container source", componentTest.Name, componentTest.Type), func() {
-						_, err := fw.HasController.CreateComponent(application.Name, componentTest.Name, namespace, "", "", componentTest.ContainerSource, outputContainerImage, oauthSecretName)
+						_, err := fw.AppstudioUser.HasController.CreateComponent(application.Name, componentTest.Name, namespace, "", "", componentTest.ContainerSource, outputContainerImage, oauthSecretName)
 						Expect(err).NotTo(HaveOccurred())
 					})
 
 					// User can define a git url and a devfile at the same time if multiple devfile exists into a repo
 				} else if componentTest.GitSourceUrl != "" && componentTest.Devfilesource != "" {
 					It(fmt.Sprintf("create component %s from %s git source %s and devfile %s", componentTest.Name, componentTest.Type, componentTest.GitSourceUrl, componentTest.Devfilesource), func() {
-						component, err = fw.HasController.CreateComponentFromDevfile(application.Name, componentTest.Name, namespace,
+						component, err = fw.AppstudioUser.HasController.CreateComponentFromDevfile(application.Name, componentTest.Name, namespace,
 							componentTest.GitSourceUrl, componentTest.Devfilesource, "", containerIMG, oauthSecretName)
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -147,7 +147,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 					// If component have only a git source application-service will start to fetch the devfile from the git root directory
 				} else if componentTest.GitSourceUrl != "" {
 					It(fmt.Sprintf("create component %s from %s git source %s", componentTest.Name, componentTest.Type, componentTest.GitSourceUrl), func() {
-						component, err = fw.HasController.CreateComponent(application.Name, componentTest.Name, namespace,
+						component, err = fw.AppstudioUser.HasController.CreateComponent(application.Name, componentTest.Name, namespace,
 							componentTest.GitSourceUrl, "", "", containerIMG, oauthSecretName)
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -162,14 +162,14 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 					if componentTest.ContainerSource != "" {
 						Skip(fmt.Sprintf("component %s was imported from quay.io/docker.io source. Skiping pipelinerun check.", componentTest.Name))
 					}
-					Expect(fw.HasController.WaitForComponentPipelineToBeFinished(component.Name, application.Name, namespace)).To(Succeed(), "Failed component pipeline %v", err)
+					Expect(fw.AppstudioUser.HasController.WaitForComponentPipelineToBeFinished(component.Name, application.Name, namespace)).To(Succeed(), "Failed component pipeline %v", err)
 				})
 
 				// Deploy the component using gitops and check for the health
 				It(fmt.Sprintf("deploy component %s using gitops", componentTest.Name), func() {
 
 					Eventually(func() bool {
-						deployment, err := fw.CommonController.GetAppDeploymentByName(componentTest.Name, namespace)
+						deployment, err := fw.AppstudioUser.CommonController.GetAppDeploymentByName(componentTest.Name, namespace)
 						if err != nil && !errors.IsNotFound(err) {
 							return false
 						}
@@ -185,9 +185,9 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 				It(fmt.Sprintf("check component %s health", componentTest.Name), func() {
 					Eventually(func() bool {
-						gitOpsRoute, err := fw.CommonController.GetOpenshiftRoute(componentTest.Name, namespace)
+						gitOpsRoute, err := fw.AppstudioUser.CommonController.GetOpenshiftRoute(componentTest.Name, namespace)
 						Expect(err).NotTo(HaveOccurred())
-						err = fw.GitOpsController.CheckGitOpsEndpoint(gitOpsRoute, componentTest.HealthEndpoint)
+						err = fw.AppstudioUser.GitOpsController.CheckGitOpsEndpoint(gitOpsRoute, componentTest.HealthEndpoint)
 						if err != nil {
 							klog.Info("Failed to request component endpoint. retrying...")
 						}
@@ -197,13 +197,13 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 				if componentTest.K8sSpec != (config.K8sSpec{}) && *componentTest.K8sSpec.Replicas > 1 {
 					It(fmt.Sprintf("scale component %s replicas", componentTest.Name), func() {
-						component, err := fw.HasController.GetHasComponent(componentTest.Name, namespace)
+						component, err := fw.AppstudioUser.HasController.GetHasComponent(componentTest.Name, namespace)
 						Expect(err).NotTo(HaveOccurred())
-						_, err = fw.HasController.ScaleComponentReplicas(component, int(*componentTest.K8sSpec.Replicas))
+						_, err = fw.AppstudioUser.HasController.ScaleComponentReplicas(component, int(*componentTest.K8sSpec.Replicas))
 						Expect(err).NotTo(HaveOccurred())
 
 						Eventually(func() bool {
-							deployment, _ := fw.CommonController.GetAppDeploymentByName(componentTest.Name, namespace)
+							deployment, _ := fw.AppstudioUser.CommonController.GetAppDeploymentByName(componentTest.Name, namespace)
 							if err != nil && !errors.IsNotFound(err) {
 								return false
 							}

--- a/tests/e2e-demos/e2e-demo.go
+++ b/tests/e2e-demos/e2e-demo.go
@@ -66,23 +66,23 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 				Expect(utils.CheckIfEnvironmentExists(constants.GITHUB_TOKEN_ENV)).Should(BeTrue(), "%s environment variable is not set", constants.GITHUB_TOKEN_ENV)
 				// Check if 'has-github-token' is present, unless SKIP_HAS_SECRET_CHECK env var is set
 				if !utils.CheckIfEnvironmentExists(constants.SKIP_HAS_SECRET_CHECK_ENV) {
-					_, err := fw.AppstudioUser.HasController.KubeInterface().CoreV1().Secrets(RedHatAppStudioApplicationNamespace).Get(context.TODO(), ApplicationServiceGHTokenSecrName, metav1.GetOptions{})
+					_, err := fw.AppstudioUserWs.HasController.KubeInterface().CoreV1().Secrets(RedHatAppStudioApplicationNamespace).Get(context.TODO(), ApplicationServiceGHTokenSecrName, metav1.GetOptions{})
 					Expect(err).NotTo(HaveOccurred(), "Error checking 'has-github-token' secret %s", err)
 				}
-				_, err := fw.AppstudioUser.CommonController.CreateTestNamespace(namespace)
+				_, err := fw.AppstudioUserWs.CommonController.CreateTestNamespace(namespace)
 				Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", namespace, err)
 			})
 			// Remove all resources created by the tests
 			AfterAll(func() {
-				Expect(fw.AppstudioUser.HasController.DeleteAllComponentsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
-				Expect(fw.AppstudioUser.HasController.DeleteAllApplicationsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
-				Expect(fw.AppstudioUser.GitOpsController.DeleteAllGitOpsDeploymentInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
+				Expect(fw.AppstudioUserWs.HasController.DeleteAllComponentsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
+				Expect(fw.AppstudioUserWs.HasController.DeleteAllApplicationsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
+				Expect(fw.AppstudioUserWs.GitOpsController.DeleteAllGitOpsDeploymentInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
 			})
 
 			// Create an application in a specific namespace
 			It("application is created", func() {
 				fmt.Printf("Parallel process %d", GinkgoParallelProcess())
-				createdApplication, err := fw.AppstudioUser.HasController.CreateHasApplication(appTest.ApplicationName, namespace)
+				createdApplication, err := fw.AppstudioUserWs.HasController.CreateHasApplication(appTest.ApplicationName, namespace)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(createdApplication.Spec.DisplayName).To(Equal(appTest.ApplicationName))
 				Expect(createdApplication.Namespace).To(Equal(namespace))
@@ -91,7 +91,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 			// Check the application health and check if a devfile was generated in the status
 			It("application is healthy", func() {
 				Eventually(func() string {
-					appstudioApp, err := fw.AppstudioUser.HasController.GetHasApplication(appTest.ApplicationName, namespace)
+					appstudioApp, err := fw.AppstudioUserWs.HasController.GetHasApplication(appTest.ApplicationName, namespace)
 					Expect(err).NotTo(HaveOccurred())
 					application = appstudioApp
 
@@ -101,7 +101,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 				Eventually(func() bool {
 					gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-					return fw.AppstudioUser.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+					return fw.AppstudioUserWs.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
 				}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "Has controller didn't create gitops repository")
 			})
 
@@ -119,12 +119,12 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 							// More info about manual token upload for quay.io here: https://github.com/redhat-appstudio/service-provider-integration-operator/pull/115
 							oauthCredentials := `{"access_token":"` + utils.GetEnv(constants.QUAY_OAUTH_TOKEN_ENV, "") + `", "username":"` + utils.GetEnv(constants.QUAY_OAUTH_USER_ENV, "") + `"}`
 
-							oauthSecretName = fw.AppstudioUser.SPIController.InjectManualSPIToken(namespace, componentTest.ContainerSource, oauthCredentials, v1.SecretTypeDockerConfigJson)
+							oauthSecretName = fw.AppstudioUserWs.SPIController.InjectManualSPIToken(namespace, componentTest.ContainerSource, oauthCredentials, v1.SecretTypeDockerConfigJson)
 						} else if componentTest.GitSourceUrl != "" {
 							// More info about manual token upload for github.com
 							oauthCredentials := `{"access_token":"` + utils.GetEnv(constants.GITHUB_TOKEN_ENV, "") + `"}`
 
-							oauthSecretName = fw.AppstudioUser.SPIController.InjectManualSPIToken(namespace, componentTest.GitSourceUrl, oauthCredentials, v1.SecretTypeBasicAuth)
+							oauthSecretName = fw.AppstudioUserWs.SPIController.InjectManualSPIToken(namespace, componentTest.GitSourceUrl, oauthCredentials, v1.SecretTypeBasicAuth)
 						}
 					})
 				}
@@ -132,14 +132,14 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 				// Components for now can be imported from gitUrl, container image or a devfile
 				if componentTest.ContainerSource != "" {
 					It(fmt.Sprintf("create component %s from %s container source", componentTest.Name, componentTest.Type), func() {
-						_, err := fw.AppstudioUser.HasController.CreateComponent(application.Name, componentTest.Name, namespace, "", "", componentTest.ContainerSource, outputContainerImage, oauthSecretName)
+						_, err := fw.AppstudioUserWs.HasController.CreateComponent(application.Name, componentTest.Name, namespace, "", "", componentTest.ContainerSource, outputContainerImage, oauthSecretName)
 						Expect(err).NotTo(HaveOccurred())
 					})
 
 					// User can define a git url and a devfile at the same time if multiple devfile exists into a repo
 				} else if componentTest.GitSourceUrl != "" && componentTest.Devfilesource != "" {
 					It(fmt.Sprintf("create component %s from %s git source %s and devfile %s", componentTest.Name, componentTest.Type, componentTest.GitSourceUrl, componentTest.Devfilesource), func() {
-						component, err = fw.AppstudioUser.HasController.CreateComponentFromDevfile(application.Name, componentTest.Name, namespace,
+						component, err = fw.AppstudioUserWs.HasController.CreateComponentFromDevfile(application.Name, componentTest.Name, namespace,
 							componentTest.GitSourceUrl, componentTest.Devfilesource, "", containerIMG, oauthSecretName)
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -147,7 +147,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 					// If component have only a git source application-service will start to fetch the devfile from the git root directory
 				} else if componentTest.GitSourceUrl != "" {
 					It(fmt.Sprintf("create component %s from %s git source %s", componentTest.Name, componentTest.Type, componentTest.GitSourceUrl), func() {
-						component, err = fw.AppstudioUser.HasController.CreateComponent(application.Name, componentTest.Name, namespace,
+						component, err = fw.AppstudioUserWs.HasController.CreateComponent(application.Name, componentTest.Name, namespace,
 							componentTest.GitSourceUrl, "", "", containerIMG, oauthSecretName)
 						Expect(err).NotTo(HaveOccurred())
 					})
@@ -162,14 +162,14 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 					if componentTest.ContainerSource != "" {
 						Skip(fmt.Sprintf("component %s was imported from quay.io/docker.io source. Skiping pipelinerun check.", componentTest.Name))
 					}
-					Expect(fw.AppstudioUser.HasController.WaitForComponentPipelineToBeFinished(component.Name, application.Name, namespace)).To(Succeed(), "Failed component pipeline %v", err)
+					Expect(fw.AppstudioUserWs.HasController.WaitForComponentPipelineToBeFinished(component.Name, application.Name, namespace)).To(Succeed(), "Failed component pipeline %v", err)
 				})
 
 				// Deploy the component using gitops and check for the health
 				It(fmt.Sprintf("deploy component %s using gitops", componentTest.Name), func() {
 
 					Eventually(func() bool {
-						deployment, err := fw.AppstudioUser.CommonController.GetAppDeploymentByName(componentTest.Name, namespace)
+						deployment, err := fw.AppstudioUserWs.CommonController.GetAppDeploymentByName(componentTest.Name, namespace)
 						if err != nil && !errors.IsNotFound(err) {
 							return false
 						}
@@ -185,9 +185,9 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 				It(fmt.Sprintf("check component %s health", componentTest.Name), func() {
 					Eventually(func() bool {
-						gitOpsRoute, err := fw.AppstudioUser.CommonController.GetOpenshiftRoute(componentTest.Name, namespace)
+						gitOpsRoute, err := fw.AppstudioUserWs.CommonController.GetOpenshiftRoute(componentTest.Name, namespace)
 						Expect(err).NotTo(HaveOccurred())
-						err = fw.AppstudioUser.GitOpsController.CheckGitOpsEndpoint(gitOpsRoute, componentTest.HealthEndpoint)
+						err = fw.AppstudioUserWs.GitOpsController.CheckGitOpsEndpoint(gitOpsRoute, componentTest.HealthEndpoint)
 						if err != nil {
 							klog.Info("Failed to request component endpoint. retrying...")
 						}
@@ -197,13 +197,13 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 				if componentTest.K8sSpec != (config.K8sSpec{}) && *componentTest.K8sSpec.Replicas > 1 {
 					It(fmt.Sprintf("scale component %s replicas", componentTest.Name), func() {
-						component, err := fw.AppstudioUser.HasController.GetHasComponent(componentTest.Name, namespace)
+						component, err := fw.AppstudioUserWs.HasController.GetHasComponent(componentTest.Name, namespace)
 						Expect(err).NotTo(HaveOccurred())
-						_, err = fw.AppstudioUser.HasController.ScaleComponentReplicas(component, int(*componentTest.K8sSpec.Replicas))
+						_, err = fw.AppstudioUserWs.HasController.ScaleComponentReplicas(component, int(*componentTest.K8sSpec.Replicas))
 						Expect(err).NotTo(HaveOccurred())
 
 						Eventually(func() bool {
-							deployment, _ := fw.AppstudioUser.CommonController.GetAppDeploymentByName(componentTest.Name, namespace)
+							deployment, _ := fw.AppstudioUserWs.CommonController.GetAppDeploymentByName(componentTest.Name, namespace)
 							if err != nil && !errors.IsNotFound(err) {
 								return false
 							}

--- a/tests/e2e-demos/multi-component.go
+++ b/tests/e2e-demos/multi-component.go
@@ -52,11 +52,11 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 		Expect(utils.CheckIfEnvironmentExists(constants.GITHUB_TOKEN_ENV)).Should(BeTrue(), "%s environment variable is not set", constants.GITHUB_TOKEN_ENV)
 		// Check if 'has-github-token' is present, unless SKIP_HAS_SECRET_CHECK env var is set
 		if !utils.CheckIfEnvironmentExists(constants.SKIP_HAS_SECRET_CHECK_ENV) {
-			_, err := fw.AppstudioUser.HasController.KubeInterface().CoreV1().Secrets(RedHatAppStudioApplicationNamespace).Get(context.TODO(), ApplicationServiceGHTokenSecrName, metav1.GetOptions{})
+			_, err := fw.AppstudioUserWs.HasController.KubeInterface().CoreV1().Secrets(RedHatAppStudioApplicationNamespace).Get(context.TODO(), ApplicationServiceGHTokenSecrName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred(), "Error checking 'has-github-token' secret %s", err)
 		}
 
-		_, err := fw.AppstudioUser.CommonController.CreateTestNamespace(AppStudioE2EApplicationsNamespace)
+		_, err := fw.AppstudioUserWs.CommonController.CreateTestNamespace(AppStudioE2EApplicationsNamespace)
 		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", AppStudioE2EApplicationsNamespace, err)
 
 		// Check test specification has at least one test defined
@@ -67,12 +67,12 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 	// Remove all resources created by the tests
 	AfterAll(func() {
-		Expect(fw.AppstudioUser.HasController.DeleteAllComponentsInASpecificNamespace(AppStudioE2EApplicationsNamespace, 30*time.Second)).To(Succeed())
-		Expect(fw.AppstudioUser.HasController.DeleteAllApplicationsInASpecificNamespace(AppStudioE2EApplicationsNamespace, 30*time.Second)).To(Succeed())
+		Expect(fw.AppstudioUserWs.HasController.DeleteAllComponentsInASpecificNamespace(AppStudioE2EApplicationsNamespace, 30*time.Second)).To(Succeed())
+		Expect(fw.AppstudioUserWs.HasController.DeleteAllApplicationsInASpecificNamespace(AppStudioE2EApplicationsNamespace, 30*time.Second)).To(Succeed())
 	})
 
 	It("Create Red Hat AppStudio Application", func() {
-		createdApplication, err := fw.AppstudioUser.HasController.CreateHasApplication(testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)
+		createdApplication, err := fw.AppstudioUserWs.HasController.CreateHasApplication(testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createdApplication.Spec.DisplayName).To(Equal(testSpecification.Tests[0].ApplicationName))
 		Expect(createdApplication.Namespace).To(Equal(AppStudioE2EApplicationsNamespace))
@@ -80,7 +80,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 	It("Check Red Hat AppStudio Application health", func() {
 		Eventually(func() string {
-			application, err = fw.AppstudioUser.HasController.GetHasApplication(testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)
+			application, err = fw.AppstudioUserWs.HasController.GetHasApplication(testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)
 			Expect(err).NotTo(HaveOccurred())
 
 			return application.Status.Devfile
@@ -90,12 +90,12 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 			// application info should be stored even after deleting the application in application variable
 			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-			return fw.AppstudioUser.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+			return fw.AppstudioUserWs.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
 		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "Has controller didn't create gitops repository")
 	})
 
 	It("Create Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
-		cdq, err := fw.AppstudioUser.HasController.CreateComponentDetectionQuery(testSpecification.Tests[0].Components[0].Name, AppStudioE2EApplicationsNamespace, testSpecification.Tests[0].Components[0].GitSourceUrl, "", false)
+		cdq, err := fw.AppstudioUserWs.HasController.CreateComponentDetectionQuery(testSpecification.Tests[0].Components[0].Name, AppStudioE2EApplicationsNamespace, testSpecification.Tests[0].Components[0].GitSourceUrl, "", false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cdq.Name).To(Equal(testSpecification.Tests[0].Components[0].Name))
 	})
@@ -104,7 +104,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 		// Validate that the CDQ completes successfully
 		Eventually(func() bool {
 			// application info should be stored even after deleting the application in application variable
-			cdq, err = fw.AppstudioUser.HasController.GetComponentDetectionQuery(testSpecification.Tests[0].Components[0].Name, AppStudioE2EApplicationsNamespace)
+			cdq, err = fw.AppstudioUserWs.HasController.GetComponentDetectionQuery(testSpecification.Tests[0].Components[0].Name, AppStudioE2EApplicationsNamespace)
 			return err == nil && len(cdq.Status.ComponentDetected) > 0
 		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "ComponentDetectionQuery did not complete successfully")
 
@@ -121,13 +121,13 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 		// Create Golang component from CDQ result
 		Expect(cdq.Status.ComponentDetected["go"].DevfileFound).To(BeTrue(), "DevfileFound was not set to true")
-		componentGo, err := fw.AppstudioUser.HasController.CreateComponentFromStub(cdq.Status.ComponentDetected["go"], compNameGo, AppStudioE2EApplicationsNamespace, "", testSpecification.Tests[0].ApplicationName)
+		componentGo, err := fw.AppstudioUserWs.HasController.CreateComponentFromStub(cdq.Status.ComponentDetected["go"], compNameGo, AppStudioE2EApplicationsNamespace, "", testSpecification.Tests[0].ApplicationName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(componentGo.Name).To(Equal(compNameGo))
 
 		// Create NodeJS component from CDQ result
 		Expect(cdq.Status.ComponentDetected["nodejs"].DevfileFound).To(BeTrue(), "DevfileFound was not set to true")
-		componentNode, err := fw.AppstudioUser.HasController.CreateComponentFromStub(cdq.Status.ComponentDetected["nodejs"], compNameNode, AppStudioE2EApplicationsNamespace, "", testSpecification.Tests[0].ApplicationName)
+		componentNode, err := fw.AppstudioUserWs.HasController.CreateComponentFromStub(cdq.Status.ComponentDetected["nodejs"], compNameNode, AppStudioE2EApplicationsNamespace, "", testSpecification.Tests[0].ApplicationName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(componentNode.Name).To(Equal(compNameNode))
 
@@ -136,8 +136,8 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 	// Start to watch the pipeline until is finished
 	It("Wait for all pipelines to be finished", func() {
 
-		Expect(fw.AppstudioUser.HasController.WaitForComponentPipelineToBeFinished(compNameGo, testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)).To(Succeed(), "Failed component pipeline %v", err)
-		Expect(fw.AppstudioUser.HasController.WaitForComponentPipelineToBeFinished(compNameNode, testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)).To(Succeed(), "Failed component pipeline %v", err)
+		Expect(fw.AppstudioUserWs.HasController.WaitForComponentPipelineToBeFinished(compNameGo, testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)).To(Succeed(), "Failed component pipeline %v", err)
+		Expect(fw.AppstudioUserWs.HasController.WaitForComponentPipelineToBeFinished(compNameNode, testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)).To(Succeed(), "Failed component pipeline %v", err)
 
 	})
 
@@ -145,12 +145,12 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 	It("Check multiple components are deployed", func() {
 
 		Eventually(func() bool {
-			deploymentGo, err := fw.AppstudioUser.CommonController.GetAppDeploymentByName(compNameGo, AppStudioE2EApplicationsNamespace)
+			deploymentGo, err := fw.AppstudioUserWs.CommonController.GetAppDeploymentByName(compNameGo, AppStudioE2EApplicationsNamespace)
 			if err != nil && !errors.IsNotFound(err) {
 				return false
 			}
 
-			deploymentNode, err := fw.AppstudioUser.CommonController.GetAppDeploymentByName(compNameNode, AppStudioE2EApplicationsNamespace)
+			deploymentNode, err := fw.AppstudioUserWs.CommonController.GetAppDeploymentByName(compNameNode, AppStudioE2EApplicationsNamespace)
 			if err != nil && !errors.IsNotFound(err) {
 				return false
 			}

--- a/tests/has/devfile_private_source.go
+++ b/tests/has/devfile_private_source.go
@@ -1,131 +1,131 @@
 package has
 
-// import (
-// 	"fmt"
-// 	"strings"
-// 	"time"
+import (
+	"fmt"
+	"strings"
+	"time"
 
-// 	"github.com/devfile/library/pkg/util"
-// 	"github.com/google/uuid"
-// 	appservice "github.com/redhat-appstudio/application-service/api/v1alpha1"
-// 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
-// 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
+	"github.com/devfile/library/pkg/util"
+	"github.com/google/uuid"
+	appservice "github.com/redhat-appstudio/application-service/api/v1alpha1"
+	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 
-// 	. "github.com/onsi/ginkgo/v2"
-// 	. "github.com/onsi/gomega"
-// 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
-// 	v1 "k8s.io/api/core/v1"
-// )
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
+	v1 "k8s.io/api/core/v1"
+)
 
-// var (
-// 	PrivateComponentContainerImage string = fmt.Sprintf("quay.io/%s/quarkus:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-// )
+var (
+	PrivateComponentContainerImage string = fmt.Sprintf("quay.io/%s/quarkus:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+)
 
-// /*
-//  * Component: application-service
-//  * Description: Contains tests about creating an application and a quarkus component from a source devfile
-//  */
+/*
+ * Component: application-service
+ * Description: Contains tests about creating an application and a quarkus component from a source devfile
+ */
 
-// var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label("has"), func() {
-// 	defer GinkgoRecover()
-// 	// Initialize the tests controllers
-// 	framework, err := framework.NewFramework()
-// 	Expect(err).NotTo(HaveOccurred())
-// 	var oauthSecretName = ""
-// 	var applicationName, componentName, testNamespace string
+var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label("has"), func() {
+	defer GinkgoRecover()
+	// Initialize the tests controllers
+	framework, err := framework.NewFramework()
+	Expect(err).NotTo(HaveOccurred())
+	var oauthSecretName = ""
+	var applicationName, componentName, testNamespace string
 
-// 	// Initialize the application struct
-// 	application := &appservice.Application{}
-// 	cdq := &appservice.ComponentDetectionQuery{}
-// 	compDetected := appservice.ComponentDetectionDescription{}
-// 	privateGitRepository := utils.GetEnv(constants.PRIVATE_DEVFILE_SAMPLE, PrivateQuarkusDevfileSource)
+	// Initialize the application struct
+	application := &appservice.Application{}
+	cdq := &appservice.ComponentDetectionQuery{}
+	compDetected := appservice.ComponentDetectionDescription{}
+	privateGitRepository := utils.GetEnv(constants.PRIVATE_DEVFILE_SAMPLE, PrivateQuarkusDevfileSource)
 
-// 	BeforeAll(func() {
-// 		testNamespace = utils.GetGeneratedNamespace("has-e2e")
-// 		// Generate names for the application and component resources
-// 		applicationName = fmt.Sprintf(RedHatAppStudioApplicationName+"-%s", util.GenerateRandomString(10))
-// 		componentName = fmt.Sprintf(QuarkusComponentName+"-%s", util.GenerateRandomString(10))
+	BeforeAll(func() {
+		testNamespace = utils.GetGeneratedNamespace("has-e2e")
+		// Generate names for the application and component resources
+		applicationName = fmt.Sprintf(RedHatAppStudioApplicationName+"-%s", util.GenerateRandomString(10))
+		componentName = fmt.Sprintf(QuarkusComponentName+"-%s", util.GenerateRandomString(10))
 
-// 		_, err = framework.CommonController.CreateTestNamespace(testNamespace)
-// 		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
-// 		credentials := `{"access_token":"` + utils.GetEnv(constants.GITHUB_TOKEN_ENV, "") + `"}`
-// 		oauthSecretName = framework.SPIController.InjectManualSPIToken(testNamespace, privateGitRepository, credentials, v1.SecretTypeBasicAuth)
-// 		// Check to see if the github token was provided
-// 		Expect(utils.CheckIfEnvironmentExists(constants.GITHUB_TOKEN_ENV)).Should(BeTrue(), "%s environment variable is not set", constants.GITHUB_TOKEN_ENV)
-// 	})
+		_, err = framework.AppstudioUser.CommonController.CreateTestNamespace(testNamespace)
+		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+		credentials := `{"access_token":"` + utils.GetEnv(constants.GITHUB_TOKEN_ENV, "") + `"}`
+		oauthSecretName = framework.AppstudioUser.SPIController.InjectManualSPIToken(testNamespace, privateGitRepository, credentials, v1.SecretTypeBasicAuth)
+		// Check to see if the github token was provided
+		Expect(utils.CheckIfEnvironmentExists(constants.GITHUB_TOKEN_ENV)).Should(BeTrue(), "%s environment variable is not set", constants.GITHUB_TOKEN_ENV)
+	})
 
-// 	AfterAll(func() {
-// 		err := framework.HasController.DeleteHasComponent(componentName, testNamespace, false)
-// 		Expect(err).NotTo(HaveOccurred())
+	AfterAll(func() {
+		err := framework.AppstudioUser.HasController.DeleteHasComponent(componentName, testNamespace, false)
+		Expect(err).NotTo(HaveOccurred())
 
-// 		err = framework.HasController.DeleteHasApplication(applicationName, testNamespace, false)
-// 		Expect(err).NotTo(HaveOccurred())
+		err = framework.AppstudioUser.HasController.DeleteHasApplication(applicationName, testNamespace, false)
+		Expect(err).NotTo(HaveOccurred())
 
-// 		err = framework.SPIController.DeleteAllBindingTokensInASpecificNamespace(testNamespace)
-// 		Expect(err).NotTo(HaveOccurred())
+		err = framework.AppstudioUser.SPIController.DeleteAllBindingTokensInASpecificNamespace(testNamespace)
+		Expect(err).NotTo(HaveOccurred())
 
-// 		Eventually(func() bool {
-// 			// application info should be stored even after deleting the application in application variable
-// 			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
+		Eventually(func() bool {
+			// application info should be stored even after deleting the application in application variable
+			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-// 			return framework.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
-// 		}, 1*time.Minute, 100*time.Millisecond).Should(BeFalse(), "Has controller didn't remove Red Hat AppStudio application gitops repository")
+			return framework.AppstudioUser.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+		}, 1*time.Minute, 100*time.Millisecond).Should(BeFalse(), "Has controller didn't remove Red Hat AppStudio application gitops repository")
 
-// 		Expect(framework.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
-// 	})
+		Expect(framework.AppstudioUser.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
+	})
 
-// 	It("Create Red Hat AppStudio Application", func() {
-// 		createdApplication, err := framework.HasController.CreateHasApplication(applicationName, testNamespace)
-// 		Expect(err).NotTo(HaveOccurred())
-// 		Expect(createdApplication.Spec.DisplayName).To(Equal(applicationName))
-// 		Expect(createdApplication.Namespace).To(Equal(testNamespace))
-// 	})
+	It("Create Red Hat AppStudio Application", func() {
+		createdApplication, err := framework.AppstudioUser.HasController.CreateHasApplication(applicationName, testNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(createdApplication.Spec.DisplayName).To(Equal(applicationName))
+		Expect(createdApplication.Namespace).To(Equal(testNamespace))
+	})
 
-// 	It("Check Red Hat AppStudio Application health", func() {
-// 		Eventually(func() string {
-// 			application, err = framework.HasController.GetHasApplication(applicationName, testNamespace)
-// 			Expect(err).NotTo(HaveOccurred())
+	It("Check Red Hat AppStudio Application health", func() {
+		Eventually(func() string {
+			application, err = framework.AppstudioUser.HasController.GetHasApplication(applicationName, testNamespace)
+			Expect(err).NotTo(HaveOccurred())
 
-// 			return application.Status.Devfile
-// 		}, 3*time.Minute, 100*time.Millisecond).Should(Not(BeEmpty()), "Error creating gitOps repository")
+			return application.Status.Devfile
+		}, 3*time.Minute, 100*time.Millisecond).Should(Not(BeEmpty()), "Error creating gitOps repository")
 
-// 		Eventually(func() bool {
-// 			// application info should be stored even after deleting the application in application variable
-// 			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
+		Eventually(func() bool {
+			// application info should be stored even after deleting the application in application variable
+			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-// 			return framework.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
-// 		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "Has controller didn't create gitops repository")
-// 	})
+			return framework.AppstudioUser.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "Has controller didn't create gitops repository")
+	})
 
-// 	It("Create Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
-// 		cdq, err := framework.HasController.CreateComponentDetectionQuery(componentName, testNamespace, QuarkusDevfileSource, "", false)
-// 		Expect(err).NotTo(HaveOccurred())
-// 		Expect(cdq.Name).To(Equal(componentName))
+	It("Create Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
+		cdq, err := framework.AppstudioUser.HasController.CreateComponentDetectionQuery(componentName, testNamespace, QuarkusDevfileSource, "", false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cdq.Name).To(Equal(componentName))
 
-// 	})
+	})
 
-// 	It("Check Red Hat AppStudio ComponentDetectionQuery status", func() {
-// 		// Validate that the CDQ completes successfully
-// 		Eventually(func() bool {
-// 			// application info should be stored even after deleting the application in application variable
-// 			cdq, err = framework.HasController.GetComponentDetectionQuery(componentName, testNamespace)
-// 			return err == nil && len(cdq.Status.ComponentDetected) > 0
-// 		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "ComponentDetectionQuery did not complete successfully")
+	It("Check Red Hat AppStudio ComponentDetectionQuery status", func() {
+		// Validate that the CDQ completes successfully
+		Eventually(func() bool {
+			// application info should be stored even after deleting the application in application variable
+			cdq, err = framework.AppstudioUser.HasController.GetComponentDetectionQuery(componentName, testNamespace)
+			return err == nil && len(cdq.Status.ComponentDetected) > 0
+		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "ComponentDetectionQuery did not complete successfully")
 
-// 		// Validate that the completed CDQ only has one detected component
-// 		Expect(len(cdq.Status.ComponentDetected)).To(Equal(1), "Expected length of the detected Components was not 1")
+		// Validate that the completed CDQ only has one detected component
+		Expect(len(cdq.Status.ComponentDetected)).To(Equal(1), "Expected length of the detected Components was not 1")
 
-// 		// Get the stub CDQ and validate its content
-// 		for _, compDetected = range cdq.Status.ComponentDetected {
-// 			Expect(compDetected.DevfileFound).To(BeTrue(), "DevfileFound was not set to true")
-// 			Expect(compDetected.Language).To(Equal("java"), "Detected language was not java")
-// 			Expect(compDetected.ProjectType).To(Equal("quarkus"), "Detected framework was not quarkus")
-// 		}
-// 	})
+		// Get the stub CDQ and validate its content
+		for _, compDetected = range cdq.Status.ComponentDetected {
+			Expect(compDetected.DevfileFound).To(BeTrue(), "DevfileFound was not set to true")
+			Expect(compDetected.Language).To(Equal("java"), "Detected language was not java")
+			Expect(compDetected.ProjectType).To(Equal("quarkus"), "Detected framework was not quarkus")
+		}
+	})
 
-// 	It("Create Red Hat AppStudio Quarkus component", func() {
-// 		component, err := framework.HasController.CreateComponentFromStub(compDetected, componentName, testNamespace, oauthSecretName, applicationName)
-// 		Expect(err).NotTo(HaveOccurred())
-// 		Expect(component.Name).To(Equal(componentName))
-// 	})
-// })
+	It("Create Red Hat AppStudio Quarkus component", func() {
+		component, err := framework.AppstudioUser.HasController.CreateComponentFromStub(compDetected, componentName, testNamespace, oauthSecretName, applicationName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(component.Name).To(Equal(componentName))
+	})
+})

--- a/tests/has/devfile_private_source.go
+++ b/tests/has/devfile_private_source.go
@@ -1,131 +1,131 @@
 package has
 
-import (
-	"fmt"
-	"strings"
-	"time"
+// import (
+// 	"fmt"
+// 	"strings"
+// 	"time"
 
-	"github.com/devfile/library/pkg/util"
-	"github.com/google/uuid"
-	appservice "github.com/redhat-appstudio/application-service/api/v1alpha1"
-	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
-	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
+// 	"github.com/devfile/library/pkg/util"
+// 	"github.com/google/uuid"
+// 	appservice "github.com/redhat-appstudio/application-service/api/v1alpha1"
+// 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
+// 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
-	v1 "k8s.io/api/core/v1"
-)
+// 	. "github.com/onsi/ginkgo/v2"
+// 	. "github.com/onsi/gomega"
+// 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
+// 	v1 "k8s.io/api/core/v1"
+// )
 
-var (
-	PrivateComponentContainerImage string = fmt.Sprintf("quay.io/%s/quarkus:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-)
+// var (
+// 	PrivateComponentContainerImage string = fmt.Sprintf("quay.io/%s/quarkus:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+// )
 
-/*
- * Component: application-service
- * Description: Contains tests about creating an application and a quarkus component from a source devfile
- */
+// /*
+//  * Component: application-service
+//  * Description: Contains tests about creating an application and a quarkus component from a source devfile
+//  */
 
-var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label("has"), func() {
-	defer GinkgoRecover()
-	// Initialize the tests controllers
-	framework, err := framework.NewFramework()
-	Expect(err).NotTo(HaveOccurred())
-	var oauthSecretName = ""
-	var applicationName, componentName, testNamespace string
+// var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label("has"), func() {
+// 	defer GinkgoRecover()
+// 	// Initialize the tests controllers
+// 	framework, err := framework.NewFramework()
+// 	Expect(err).NotTo(HaveOccurred())
+// 	var oauthSecretName = ""
+// 	var applicationName, componentName, testNamespace string
 
-	// Initialize the application struct
-	application := &appservice.Application{}
-	cdq := &appservice.ComponentDetectionQuery{}
-	compDetected := appservice.ComponentDetectionDescription{}
-	privateGitRepository := utils.GetEnv(constants.PRIVATE_DEVFILE_SAMPLE, PrivateQuarkusDevfileSource)
+// 	// Initialize the application struct
+// 	application := &appservice.Application{}
+// 	cdq := &appservice.ComponentDetectionQuery{}
+// 	compDetected := appservice.ComponentDetectionDescription{}
+// 	privateGitRepository := utils.GetEnv(constants.PRIVATE_DEVFILE_SAMPLE, PrivateQuarkusDevfileSource)
 
-	BeforeAll(func() {
-		testNamespace = utils.GetGeneratedNamespace("has-e2e")
-		// Generate names for the application and component resources
-		applicationName = fmt.Sprintf(RedHatAppStudioApplicationName+"-%s", util.GenerateRandomString(10))
-		componentName = fmt.Sprintf(QuarkusComponentName+"-%s", util.GenerateRandomString(10))
+// 	BeforeAll(func() {
+// 		testNamespace = utils.GetGeneratedNamespace("has-e2e")
+// 		// Generate names for the application and component resources
+// 		applicationName = fmt.Sprintf(RedHatAppStudioApplicationName+"-%s", util.GenerateRandomString(10))
+// 		componentName = fmt.Sprintf(QuarkusComponentName+"-%s", util.GenerateRandomString(10))
 
-		_, err = framework.CommonController.CreateTestNamespace(testNamespace)
-		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
-		credentials := `{"access_token":"` + utils.GetEnv(constants.GITHUB_TOKEN_ENV, "") + `"}`
-		oauthSecretName = framework.SPIController.InjectManualSPIToken(testNamespace, privateGitRepository, credentials, v1.SecretTypeBasicAuth)
-		// Check to see if the github token was provided
-		Expect(utils.CheckIfEnvironmentExists(constants.GITHUB_TOKEN_ENV)).Should(BeTrue(), "%s environment variable is not set", constants.GITHUB_TOKEN_ENV)
-	})
+// 		_, err = framework.CommonController.CreateTestNamespace(testNamespace)
+// 		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
+// 		credentials := `{"access_token":"` + utils.GetEnv(constants.GITHUB_TOKEN_ENV, "") + `"}`
+// 		oauthSecretName = framework.SPIController.InjectManualSPIToken(testNamespace, privateGitRepository, credentials, v1.SecretTypeBasicAuth)
+// 		// Check to see if the github token was provided
+// 		Expect(utils.CheckIfEnvironmentExists(constants.GITHUB_TOKEN_ENV)).Should(BeTrue(), "%s environment variable is not set", constants.GITHUB_TOKEN_ENV)
+// 	})
 
-	AfterAll(func() {
-		err := framework.HasController.DeleteHasComponent(componentName, testNamespace, false)
-		Expect(err).NotTo(HaveOccurred())
+// 	AfterAll(func() {
+// 		err := framework.HasController.DeleteHasComponent(componentName, testNamespace, false)
+// 		Expect(err).NotTo(HaveOccurred())
 
-		err = framework.HasController.DeleteHasApplication(applicationName, testNamespace, false)
-		Expect(err).NotTo(HaveOccurred())
+// 		err = framework.HasController.DeleteHasApplication(applicationName, testNamespace, false)
+// 		Expect(err).NotTo(HaveOccurred())
 
-		err = framework.SPIController.DeleteAllBindingTokensInASpecificNamespace(testNamespace)
-		Expect(err).NotTo(HaveOccurred())
+// 		err = framework.SPIController.DeleteAllBindingTokensInASpecificNamespace(testNamespace)
+// 		Expect(err).NotTo(HaveOccurred())
 
-		Eventually(func() bool {
-			// application info should be stored even after deleting the application in application variable
-			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
+// 		Eventually(func() bool {
+// 			// application info should be stored even after deleting the application in application variable
+// 			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-			return framework.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
-		}, 1*time.Minute, 100*time.Millisecond).Should(BeFalse(), "Has controller didn't remove Red Hat AppStudio application gitops repository")
+// 			return framework.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+// 		}, 1*time.Minute, 100*time.Millisecond).Should(BeFalse(), "Has controller didn't remove Red Hat AppStudio application gitops repository")
 
-		Expect(framework.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
-	})
+// 		Expect(framework.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
+// 	})
 
-	It("Create Red Hat AppStudio Application", func() {
-		createdApplication, err := framework.HasController.CreateHasApplication(applicationName, testNamespace)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(createdApplication.Spec.DisplayName).To(Equal(applicationName))
-		Expect(createdApplication.Namespace).To(Equal(testNamespace))
-	})
+// 	It("Create Red Hat AppStudio Application", func() {
+// 		createdApplication, err := framework.HasController.CreateHasApplication(applicationName, testNamespace)
+// 		Expect(err).NotTo(HaveOccurred())
+// 		Expect(createdApplication.Spec.DisplayName).To(Equal(applicationName))
+// 		Expect(createdApplication.Namespace).To(Equal(testNamespace))
+// 	})
 
-	It("Check Red Hat AppStudio Application health", func() {
-		Eventually(func() string {
-			application, err = framework.HasController.GetHasApplication(applicationName, testNamespace)
-			Expect(err).NotTo(HaveOccurred())
+// 	It("Check Red Hat AppStudio Application health", func() {
+// 		Eventually(func() string {
+// 			application, err = framework.HasController.GetHasApplication(applicationName, testNamespace)
+// 			Expect(err).NotTo(HaveOccurred())
 
-			return application.Status.Devfile
-		}, 3*time.Minute, 100*time.Millisecond).Should(Not(BeEmpty()), "Error creating gitOps repository")
+// 			return application.Status.Devfile
+// 		}, 3*time.Minute, 100*time.Millisecond).Should(Not(BeEmpty()), "Error creating gitOps repository")
 
-		Eventually(func() bool {
-			// application info should be stored even after deleting the application in application variable
-			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
+// 		Eventually(func() bool {
+// 			// application info should be stored even after deleting the application in application variable
+// 			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-			return framework.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
-		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "Has controller didn't create gitops repository")
-	})
+// 			return framework.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+// 		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "Has controller didn't create gitops repository")
+// 	})
 
-	It("Create Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
-		cdq, err := framework.HasController.CreateComponentDetectionQuery(componentName, testNamespace, QuarkusDevfileSource, "", false)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(cdq.Name).To(Equal(componentName))
+// 	It("Create Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
+// 		cdq, err := framework.HasController.CreateComponentDetectionQuery(componentName, testNamespace, QuarkusDevfileSource, "", false)
+// 		Expect(err).NotTo(HaveOccurred())
+// 		Expect(cdq.Name).To(Equal(componentName))
 
-	})
+// 	})
 
-	It("Check Red Hat AppStudio ComponentDetectionQuery status", func() {
-		// Validate that the CDQ completes successfully
-		Eventually(func() bool {
-			// application info should be stored even after deleting the application in application variable
-			cdq, err = framework.HasController.GetComponentDetectionQuery(componentName, testNamespace)
-			return err == nil && len(cdq.Status.ComponentDetected) > 0
-		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "ComponentDetectionQuery did not complete successfully")
+// 	It("Check Red Hat AppStudio ComponentDetectionQuery status", func() {
+// 		// Validate that the CDQ completes successfully
+// 		Eventually(func() bool {
+// 			// application info should be stored even after deleting the application in application variable
+// 			cdq, err = framework.HasController.GetComponentDetectionQuery(componentName, testNamespace)
+// 			return err == nil && len(cdq.Status.ComponentDetected) > 0
+// 		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "ComponentDetectionQuery did not complete successfully")
 
-		// Validate that the completed CDQ only has one detected component
-		Expect(len(cdq.Status.ComponentDetected)).To(Equal(1), "Expected length of the detected Components was not 1")
+// 		// Validate that the completed CDQ only has one detected component
+// 		Expect(len(cdq.Status.ComponentDetected)).To(Equal(1), "Expected length of the detected Components was not 1")
 
-		// Get the stub CDQ and validate its content
-		for _, compDetected = range cdq.Status.ComponentDetected {
-			Expect(compDetected.DevfileFound).To(BeTrue(), "DevfileFound was not set to true")
-			Expect(compDetected.Language).To(Equal("java"), "Detected language was not java")
-			Expect(compDetected.ProjectType).To(Equal("quarkus"), "Detected framework was not quarkus")
-		}
-	})
+// 		// Get the stub CDQ and validate its content
+// 		for _, compDetected = range cdq.Status.ComponentDetected {
+// 			Expect(compDetected.DevfileFound).To(BeTrue(), "DevfileFound was not set to true")
+// 			Expect(compDetected.Language).To(Equal("java"), "Detected language was not java")
+// 			Expect(compDetected.ProjectType).To(Equal("quarkus"), "Detected framework was not quarkus")
+// 		}
+// 	})
 
-	It("Create Red Hat AppStudio Quarkus component", func() {
-		component, err := framework.HasController.CreateComponentFromStub(compDetected, componentName, testNamespace, oauthSecretName, applicationName)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(component.Name).To(Equal(componentName))
-	})
-})
+// 	It("Create Red Hat AppStudio Quarkus component", func() {
+// 		component, err := framework.HasController.CreateComponentFromStub(compDetected, componentName, testNamespace, oauthSecretName, applicationName)
+// 		Expect(err).NotTo(HaveOccurred())
+// 		Expect(component.Name).To(Equal(componentName))
+// 	})
+// })

--- a/tests/has/devfile_private_source.go
+++ b/tests/has/devfile_private_source.go
@@ -46,36 +46,36 @@ var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label(
 		applicationName = fmt.Sprintf(RedHatAppStudioApplicationName+"-%s", util.GenerateRandomString(10))
 		componentName = fmt.Sprintf(QuarkusComponentName+"-%s", util.GenerateRandomString(10))
 
-		_, err = framework.AppstudioUser.CommonController.CreateTestNamespace(testNamespace)
+		_, err = framework.AppstudioUserWs.CommonController.CreateTestNamespace(testNamespace)
 		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
 		credentials := `{"access_token":"` + utils.GetEnv(constants.GITHUB_TOKEN_ENV, "") + `"}`
-		oauthSecretName = framework.AppstudioUser.SPIController.InjectManualSPIToken(testNamespace, privateGitRepository, credentials, v1.SecretTypeBasicAuth)
+		oauthSecretName = framework.AppstudioUserWs.SPIController.InjectManualSPIToken(testNamespace, privateGitRepository, credentials, v1.SecretTypeBasicAuth)
 		// Check to see if the github token was provided
 		Expect(utils.CheckIfEnvironmentExists(constants.GITHUB_TOKEN_ENV)).Should(BeTrue(), "%s environment variable is not set", constants.GITHUB_TOKEN_ENV)
 	})
 
 	AfterAll(func() {
-		err := framework.AppstudioUser.HasController.DeleteHasComponent(componentName, testNamespace, false)
+		err := framework.AppstudioUserWs.HasController.DeleteHasComponent(componentName, testNamespace, false)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = framework.AppstudioUser.HasController.DeleteHasApplication(applicationName, testNamespace, false)
+		err = framework.AppstudioUserWs.HasController.DeleteHasApplication(applicationName, testNamespace, false)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = framework.AppstudioUser.SPIController.DeleteAllBindingTokensInASpecificNamespace(testNamespace)
+		err = framework.AppstudioUserWs.SPIController.DeleteAllBindingTokensInASpecificNamespace(testNamespace)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() bool {
 			// application info should be stored even after deleting the application in application variable
 			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-			return framework.AppstudioUser.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+			return framework.AppstudioUserWs.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
 		}, 1*time.Minute, 100*time.Millisecond).Should(BeFalse(), "Has controller didn't remove Red Hat AppStudio application gitops repository")
 
-		Expect(framework.AppstudioUser.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
+		Expect(framework.AppstudioUserWs.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
 	})
 
 	It("Create Red Hat AppStudio Application", func() {
-		createdApplication, err := framework.AppstudioUser.HasController.CreateHasApplication(applicationName, testNamespace)
+		createdApplication, err := framework.AppstudioUserWs.HasController.CreateHasApplication(applicationName, testNamespace)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createdApplication.Spec.DisplayName).To(Equal(applicationName))
 		Expect(createdApplication.Namespace).To(Equal(testNamespace))
@@ -83,7 +83,7 @@ var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label(
 
 	It("Check Red Hat AppStudio Application health", func() {
 		Eventually(func() string {
-			application, err = framework.AppstudioUser.HasController.GetHasApplication(applicationName, testNamespace)
+			application, err = framework.AppstudioUserWs.HasController.GetHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
 
 			return application.Status.Devfile
@@ -93,12 +93,12 @@ var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label(
 			// application info should be stored even after deleting the application in application variable
 			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-			return framework.AppstudioUser.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+			return framework.AppstudioUserWs.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
 		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "Has controller didn't create gitops repository")
 	})
 
 	It("Create Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
-		cdq, err := framework.AppstudioUser.HasController.CreateComponentDetectionQuery(componentName, testNamespace, QuarkusDevfileSource, "", false)
+		cdq, err := framework.AppstudioUserWs.HasController.CreateComponentDetectionQuery(componentName, testNamespace, QuarkusDevfileSource, "", false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cdq.Name).To(Equal(componentName))
 
@@ -108,7 +108,7 @@ var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label(
 		// Validate that the CDQ completes successfully
 		Eventually(func() bool {
 			// application info should be stored even after deleting the application in application variable
-			cdq, err = framework.AppstudioUser.HasController.GetComponentDetectionQuery(componentName, testNamespace)
+			cdq, err = framework.AppstudioUserWs.HasController.GetComponentDetectionQuery(componentName, testNamespace)
 			return err == nil && len(cdq.Status.ComponentDetected) > 0
 		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "ComponentDetectionQuery did not complete successfully")
 
@@ -124,7 +124,7 @@ var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label(
 	})
 
 	It("Create Red Hat AppStudio Quarkus component", func() {
-		component, err := framework.AppstudioUser.HasController.CreateComponentFromStub(compDetected, componentName, testNamespace, oauthSecretName, applicationName)
+		component, err := framework.AppstudioUserWs.HasController.CreateComponentFromStub(compDetected, componentName, testNamespace, oauthSecretName, applicationName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(component.Name).To(Equal(componentName))
 	})

--- a/tests/has/devfile_source.go
+++ b/tests/has/devfile_source.go
@@ -45,30 +45,30 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 		componentName = fmt.Sprintf(QuarkusComponentName+"-%s", util.GenerateRandomString(10))
 		// Check to see if the github token was provided
 		Expect(utils.CheckIfEnvironmentExists(constants.GITHUB_TOKEN_ENV)).Should(BeTrue(), "%s environment variable is not set", constants.GITHUB_TOKEN_ENV)
-		_, err := framework.CommonController.CreateTestNamespace(testNamespace)
+		_, err := framework.AppstudioUser.CommonController.CreateTestNamespace(testNamespace)
 		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
 
 	})
 
 	AfterAll(func() {
 
-		err = framework.HasController.DeleteHasComponentDetectionQuery(componentName, testNamespace)
+		err = framework.AppstudioUser.HasController.DeleteHasComponentDetectionQuery(componentName, testNamespace)
 		Expect(err).NotTo(HaveOccurred())
-		err = framework.HasController.DeleteAllComponentsInASpecificNamespace(testNamespace, 1*time.Minute)
+		err = framework.AppstudioUser.HasController.DeleteAllComponentsInASpecificNamespace(testNamespace, 1*time.Minute)
 		Expect(err).NotTo(HaveOccurred())
-		err = framework.HasController.DeleteAllApplicationsInASpecificNamespace(testNamespace, 1*time.Minute)
+		err = framework.AppstudioUser.HasController.DeleteAllApplicationsInASpecificNamespace(testNamespace, 1*time.Minute)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() bool {
 			// application info should be stored even after deleting the application in application variable
 			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-			return framework.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+			return framework.AppstudioUser.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
 		}, 1*time.Minute, 100*time.Millisecond).Should(BeFalse(), "Has controller didn't remove Red Hat AppStudio application gitops repository")
 	})
 
 	It("Create Red Hat AppStudio Application", func() {
-		createdApplication, err := framework.HasController.CreateHasApplication(applicationName, testNamespace)
+		createdApplication, err := framework.AppstudioUser.HasController.CreateHasApplication(applicationName, testNamespace)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createdApplication.Spec.DisplayName).To(Equal(applicationName))
 		Expect(createdApplication.Namespace).To(Equal(testNamespace))
@@ -76,7 +76,7 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 
 	It("Check Red Hat AppStudio Application health", func() {
 		Eventually(func() string {
-			application, err = framework.HasController.GetHasApplication(applicationName, testNamespace)
+			application, err = framework.AppstudioUser.HasController.GetHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
 
 			return application.Status.Devfile
@@ -86,12 +86,12 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 			// application info should be stored even after deleting the application in application variable
 			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-			return framework.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+			return framework.AppstudioUser.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
 		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "Has controller didn't create gitops repository")
 	})
 
 	It("Create Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
-		cdq, err := framework.HasController.CreateComponentDetectionQuery(componentName, testNamespace, QuarkusDevfileSource, "", false)
+		cdq, err := framework.AppstudioUser.HasController.CreateComponentDetectionQuery(componentName, testNamespace, QuarkusDevfileSource, "", false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cdq.Name).To(Equal(componentName))
 
@@ -101,7 +101,7 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 		// Validate that the CDQ completes successfully
 		Eventually(func() bool {
 			// application info should be stored even after deleting the application in application variable
-			cdq, err = framework.HasController.GetComponentDetectionQuery(componentName, testNamespace)
+			cdq, err = framework.AppstudioUser.HasController.GetComponentDetectionQuery(componentName, testNamespace)
 			return err == nil && len(cdq.Status.ComponentDetected) > 0
 		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "ComponentDetectionQuery did not complete successfully")
 
@@ -117,7 +117,7 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 	})
 
 	It("Create Red Hat AppStudio Quarkus component", func() {
-		component, err := framework.HasController.CreateComponentFromStub(compDetected, componentName, testNamespace, "", applicationName)
+		component, err := framework.AppstudioUser.HasController.CreateComponentFromStub(compDetected, componentName, testNamespace, "", applicationName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(component.Name).To(Equal(componentName))
 	})
@@ -130,26 +130,26 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 			comp2Detected.ComponentStub.ComponentName = "java-quarkus2"
 		}
 		component2Name := fmt.Sprintf(QuarkusComponentName+"-%s", util.GenerateRandomString(10))
-		component2, err := framework.HasController.CreateComponentFromStub(comp2Detected, component2Name, testNamespace, "", applicationName)
+		component2, err := framework.AppstudioUser.HasController.CreateComponentFromStub(comp2Detected, component2Name, testNamespace, "", applicationName)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = framework.HasController.DeleteHasComponent(component2.Name, testNamespace, false)
+		err = framework.AppstudioUser.HasController.DeleteHasComponent(component2.Name, testNamespace, false)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() bool {
 			// application info should be stored even after deleting the application in application variable
 			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-			return framework.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+			return framework.AppstudioUser.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
 		}, 1*time.Minute, 100*time.Millisecond).Should(BeTrue(), "Gitops repository deleted after component was deleted")
 	})
 
 	It("Check a Component gets deleted when its application is deleted", func() {
 		Skip("This feature is not available in the KCP world yet. Issue: https://issues.redhat.com/browse/DEVHAS-182")
-		err = framework.HasController.DeleteHasApplication(applicationName, testNamespace, false)
+		err = framework.AppstudioUser.HasController.DeleteHasApplication(applicationName, testNamespace, false)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(func() bool {
-			_, err := framework.HasController.GetHasComponent(componentName, testNamespace)
+			_, err := framework.AppstudioUser.HasController.GetHasComponent(componentName, testNamespace)
 			if err != nil && errors.IsNotFound(err) {
 				return true
 			}

--- a/tests/has/devfile_source.go
+++ b/tests/has/devfile_source.go
@@ -45,30 +45,30 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 		componentName = fmt.Sprintf(QuarkusComponentName+"-%s", util.GenerateRandomString(10))
 		// Check to see if the github token was provided
 		Expect(utils.CheckIfEnvironmentExists(constants.GITHUB_TOKEN_ENV)).Should(BeTrue(), "%s environment variable is not set", constants.GITHUB_TOKEN_ENV)
-		_, err := framework.AppstudioUser.CommonController.CreateTestNamespace(testNamespace)
+		_, err := framework.AppstudioUserWs.CommonController.CreateTestNamespace(testNamespace)
 		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", testNamespace, err)
 
 	})
 
 	AfterAll(func() {
 
-		err = framework.AppstudioUser.HasController.DeleteHasComponentDetectionQuery(componentName, testNamespace)
+		err = framework.AppstudioUserWs.HasController.DeleteHasComponentDetectionQuery(componentName, testNamespace)
 		Expect(err).NotTo(HaveOccurred())
-		err = framework.AppstudioUser.HasController.DeleteAllComponentsInASpecificNamespace(testNamespace, 1*time.Minute)
+		err = framework.AppstudioUserWs.HasController.DeleteAllComponentsInASpecificNamespace(testNamespace, 1*time.Minute)
 		Expect(err).NotTo(HaveOccurred())
-		err = framework.AppstudioUser.HasController.DeleteAllApplicationsInASpecificNamespace(testNamespace, 1*time.Minute)
+		err = framework.AppstudioUserWs.HasController.DeleteAllApplicationsInASpecificNamespace(testNamespace, 1*time.Minute)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() bool {
 			// application info should be stored even after deleting the application in application variable
 			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-			return framework.AppstudioUser.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+			return framework.AppstudioUserWs.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
 		}, 1*time.Minute, 100*time.Millisecond).Should(BeFalse(), "Has controller didn't remove Red Hat AppStudio application gitops repository")
 	})
 
 	It("Create Red Hat AppStudio Application", func() {
-		createdApplication, err := framework.AppstudioUser.HasController.CreateHasApplication(applicationName, testNamespace)
+		createdApplication, err := framework.AppstudioUserWs.HasController.CreateHasApplication(applicationName, testNamespace)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createdApplication.Spec.DisplayName).To(Equal(applicationName))
 		Expect(createdApplication.Namespace).To(Equal(testNamespace))
@@ -76,7 +76,7 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 
 	It("Check Red Hat AppStudio Application health", func() {
 		Eventually(func() string {
-			application, err = framework.AppstudioUser.HasController.GetHasApplication(applicationName, testNamespace)
+			application, err = framework.AppstudioUserWs.HasController.GetHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
 
 			return application.Status.Devfile
@@ -86,12 +86,12 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 			// application info should be stored even after deleting the application in application variable
 			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-			return framework.AppstudioUser.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+			return framework.AppstudioUserWs.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
 		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "Has controller didn't create gitops repository")
 	})
 
 	It("Create Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
-		cdq, err := framework.AppstudioUser.HasController.CreateComponentDetectionQuery(componentName, testNamespace, QuarkusDevfileSource, "", false)
+		cdq, err := framework.AppstudioUserWs.HasController.CreateComponentDetectionQuery(componentName, testNamespace, QuarkusDevfileSource, "", false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cdq.Name).To(Equal(componentName))
 
@@ -101,7 +101,7 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 		// Validate that the CDQ completes successfully
 		Eventually(func() bool {
 			// application info should be stored even after deleting the application in application variable
-			cdq, err = framework.AppstudioUser.HasController.GetComponentDetectionQuery(componentName, testNamespace)
+			cdq, err = framework.AppstudioUserWs.HasController.GetComponentDetectionQuery(componentName, testNamespace)
 			return err == nil && len(cdq.Status.ComponentDetected) > 0
 		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "ComponentDetectionQuery did not complete successfully")
 
@@ -117,7 +117,7 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 	})
 
 	It("Create Red Hat AppStudio Quarkus component", func() {
-		component, err := framework.AppstudioUser.HasController.CreateComponentFromStub(compDetected, componentName, testNamespace, "", applicationName)
+		component, err := framework.AppstudioUserWs.HasController.CreateComponentFromStub(compDetected, componentName, testNamespace, "", applicationName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(component.Name).To(Equal(componentName))
 	})
@@ -130,26 +130,26 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 			comp2Detected.ComponentStub.ComponentName = "java-quarkus2"
 		}
 		component2Name := fmt.Sprintf(QuarkusComponentName+"-%s", util.GenerateRandomString(10))
-		component2, err := framework.AppstudioUser.HasController.CreateComponentFromStub(comp2Detected, component2Name, testNamespace, "", applicationName)
+		component2, err := framework.AppstudioUserWs.HasController.CreateComponentFromStub(comp2Detected, component2Name, testNamespace, "", applicationName)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = framework.AppstudioUser.HasController.DeleteHasComponent(component2.Name, testNamespace, false)
+		err = framework.AppstudioUserWs.HasController.DeleteHasComponent(component2.Name, testNamespace, false)
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(func() bool {
 			// application info should be stored even after deleting the application in application variable
 			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-			return framework.AppstudioUser.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+			return framework.AppstudioUserWs.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
 		}, 1*time.Minute, 100*time.Millisecond).Should(BeTrue(), "Gitops repository deleted after component was deleted")
 	})
 
 	It("Check a Component gets deleted when its application is deleted", func() {
 		Skip("This feature is not available in the KCP world yet. Issue: https://issues.redhat.com/browse/DEVHAS-182")
-		err = framework.AppstudioUser.HasController.DeleteHasApplication(applicationName, testNamespace, false)
+		err = framework.AppstudioUserWs.HasController.DeleteHasApplication(applicationName, testNamespace, false)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(func() bool {
-			_, err := framework.AppstudioUser.HasController.GetHasComponent(componentName, testNamespace)
+			_, err := framework.AppstudioUserWs.HasController.GetHasComponent(componentName, testNamespace)
 			if err != nil && errors.IsNotFound(err) {
 				return true
 			}

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -53,15 +53,15 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		applicationName = fmt.Sprintf("integration-suite-test-application-%s", util.GenerateRandomString(4))
 		appStudioE2EApplicationsNamespace = utils.GetGeneratedNamespace("integration-e2e")
 
-		_, err := f.HacbsUser.CommonController.CreateTestNamespace(appStudioE2EApplicationsNamespace)
+		_, err := f.HacbsUserWs.CommonController.CreateTestNamespace(appStudioE2EApplicationsNamespace)
 		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", appStudioE2EApplicationsNamespace, err)
 
-		app, err := f.HacbsUser.HasController.CreateHasApplication(applicationName, appStudioE2EApplicationsNamespace)
+		app, err := f.HacbsUserWs.HasController.CreateHasApplication(applicationName, appStudioE2EApplicationsNamespace)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(utils.WaitUntil(f.HacbsUser.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+		Expect(utils.WaitUntil(f.HacbsUserWs.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 			Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 		)
-		DeferCleanup(f.HacbsUser.HasController.DeleteHasApplication, applicationName, appStudioE2EApplicationsNamespace, false)
+		DeferCleanup(f.HacbsUserWs.HasController.DeleteHasApplication, applicationName, appStudioE2EApplicationsNamespace, false)
 
 	})
 
@@ -72,14 +72,14 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			timeout = time.Minute * 5
 			interval = time.Second * 1
 			// Create a component with containerImageSource being defined
-			component, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, "", "", containerImageSource, outputContainerImage, "")
+			component, err = f.HacbsUserWs.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, "", "", containerImageSource, outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
 
-			DeferCleanup(f.HacbsUser.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace, false)
+			DeferCleanup(f.HacbsUserWs.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace, false)
 		})
 		It("should not trigger a PipelineRun", func() {
 			Consistently(func() bool {
-				pipelineRun, err = f.HacbsUser.HasController.GetComponentPipelineRun(component.Name, applicationName, appStudioE2EApplicationsNamespace, false, "")
+				pipelineRun, err = f.HacbsUserWs.HasController.GetComponentPipelineRun(component.Name, applicationName, appStudioE2EApplicationsNamespace, false, "")
 				Expect(pipelineRun.Name).To(BeEmpty())
 
 				return strings.Contains(err.Error(), "no pipelinerun found")
@@ -95,11 +95,11 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			timeout = time.Minute * 4
 			interval = time.Second * 1
 			// Create a component with Git Source URL being defined
-			component, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, gitSourceURL, "", "", outputContainerImage, "")
+			component, err = f.HacbsUserWs.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, gitSourceURL, "", "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			DeferCleanup(f.HacbsUser.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace, false)
+			DeferCleanup(f.HacbsUserWs.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace, false)
 
-			defaultBundleConfigMap, err = f.HacbsUser.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
+			defaultBundleConfigMap, err = f.HacbsUserWs.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
 			if err != nil {
 				if errors.IsForbidden(err) {
 					klog.Infof("don't have enough permissions to get a configmap with default pipeline in %s namespace\n", constants.BuildPipelinesConfigMapDefaultNamespace)
@@ -112,7 +112,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		})
 		It("triggers a PipelineRun", func() {
 			Eventually(func() bool {
-				pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false, "")
+				pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false, "")
 				if err != nil {
 					klog.Infoln("PipelineRun has not been created yet")
 					return false
@@ -128,7 +128,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			})
 			It("should eventually finish successfully", func() {
 				Eventually(func() bool {
-					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false, "")
+					pipelineRun, err := f.HacbsUserWs.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false, "")
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, condition := range pipelineRun.Status.Conditions {
@@ -144,19 +144,19 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		})
 
 		//	It("check if the ApplicationSnapshot are created",func() {
-		//		applicationSnapshots, err = f.HacbsUser.IntegrationController.GetAllApplicationSnapshots(applicationName, appStudioE2EApplicationsNamespace)
+		//		applicationSnapshots, err = f.HacbsUserWs.IntegrationController.GetAllApplicationSnapshots(applicationName, appStudioE2EApplicationsNamespace)
 		//		Expect(err).ShouldNot(HaveOccurred())
 		// TBD
 		//
 		//		 })
 		//		It("IntegrationTestScenarios are configed", Label("slow"), func() {
-		//			integrationTestScenarios, err := f.HacbsUser.IntegrationController.GetIntegrationTestScenarios(applicationName, appStudioE2EApplicationsNamespace)
+		//			integrationTestScenarios, err := f.HacbsUserWs.IntegrationController.GetIntegrationTestScenarios(applicationName, appStudioE2EApplicationsNamespace)
 		//			Expect(err).ShouldNot(HaveOccurred())
 		//                       for _, testScenario := range *integrationTestScenarios {
 		//      It("check if Integration Service PipelineRun is started"),func() {
 		// TBD
 		//     })
-		//			Expect(f.HacbsUser.IntegrationController.WaitForIntegrationPipelineToBeFinished(&testScenario, applicationSnapshots, applicationName, appStudioE2EApplicationsNamespace)).To(Succeed(), "Error when waiting for a integration pipeline to finish")
+		//			Expect(f.HacbsUserWs.IntegrationController.WaitForIntegrationPipelineToBeFinished(&testScenario, applicationSnapshots, applicationName, appStudioE2EApplicationsNamespace)).To(Succeed(), "Error when waiting for a integration pipeline to finish")
 		//                       }
 		//		})
 	})

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -53,15 +53,15 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		applicationName = fmt.Sprintf("integration-suite-test-application-%s", util.GenerateRandomString(4))
 		appStudioE2EApplicationsNamespace = utils.GetGeneratedNamespace("integration-e2e")
 
-		_, err := f.CommonController.CreateTestNamespace(appStudioE2EApplicationsNamespace)
+		_, err := f.HacbsUser.CommonController.CreateTestNamespace(appStudioE2EApplicationsNamespace)
 		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", appStudioE2EApplicationsNamespace, err)
 
-		app, err := f.HasController.CreateHasApplication(applicationName, appStudioE2EApplicationsNamespace)
+		app, err := f.HacbsUser.HasController.CreateHasApplication(applicationName, appStudioE2EApplicationsNamespace)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(utils.WaitUntil(f.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+		Expect(utils.WaitUntil(f.HacbsUser.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 			Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 		)
-		DeferCleanup(f.HasController.DeleteHasApplication, applicationName, appStudioE2EApplicationsNamespace, false)
+		DeferCleanup(f.HacbsUser.HasController.DeleteHasApplication, applicationName, appStudioE2EApplicationsNamespace, false)
 
 	})
 
@@ -72,14 +72,14 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			timeout = time.Minute * 5
 			interval = time.Second * 1
 			// Create a component with containerImageSource being defined
-			component, err = f.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, "", "", containerImageSource, outputContainerImage, "")
+			component, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, "", "", containerImageSource, outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
 
-			DeferCleanup(f.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace, false)
+			DeferCleanup(f.HacbsUser.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace, false)
 		})
 		It("should not trigger a PipelineRun", func() {
 			Consistently(func() bool {
-				pipelineRun, err = f.HasController.GetComponentPipelineRun(component.Name, applicationName, appStudioE2EApplicationsNamespace, false, "")
+				pipelineRun, err = f.HacbsUser.HasController.GetComponentPipelineRun(component.Name, applicationName, appStudioE2EApplicationsNamespace, false, "")
 				Expect(pipelineRun.Name).To(BeEmpty())
 
 				return strings.Contains(err.Error(), "no pipelinerun found")
@@ -95,11 +95,11 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			timeout = time.Minute * 4
 			interval = time.Second * 1
 			// Create a component with Git Source URL being defined
-			component, err = f.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, gitSourceURL, "", "", outputContainerImage, "")
+			component, err = f.HacbsUser.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, gitSourceURL, "", "", outputContainerImage, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			DeferCleanup(f.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace, false)
+			DeferCleanup(f.HacbsUser.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace, false)
 
-			defaultBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
+			defaultBundleConfigMap, err = f.HacbsUser.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
 			if err != nil {
 				if errors.IsForbidden(err) {
 					klog.Infof("don't have enough permissions to get a configmap with default pipeline in %s namespace\n", constants.BuildPipelinesConfigMapDefaultNamespace)
@@ -112,7 +112,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		})
 		It("triggers a PipelineRun", func() {
 			Eventually(func() bool {
-				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false, "")
+				pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false, "")
 				if err != nil {
 					klog.Infoln("PipelineRun has not been created yet")
 					return false
@@ -128,7 +128,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			})
 			It("should eventually finish successfully", func() {
 				Eventually(func() bool {
-					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false, "")
+					pipelineRun, err := f.HacbsUser.HasController.GetComponentPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false, "")
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, condition := range pipelineRun.Status.Conditions {
@@ -144,19 +144,19 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		})
 
 		//	It("check if the ApplicationSnapshot are created",func() {
-		//		applicationSnapshots, err = f.IntegrationController.GetAllApplicationSnapshots(applicationName, appStudioE2EApplicationsNamespace)
+		//		applicationSnapshots, err = f.HacbsUser.IntegrationController.GetAllApplicationSnapshots(applicationName, appStudioE2EApplicationsNamespace)
 		//		Expect(err).ShouldNot(HaveOccurred())
 		// TBD
 		//
 		//		 })
 		//		It("IntegrationTestScenarios are configed", Label("slow"), func() {
-		//			integrationTestScenarios, err := f.IntegrationController.GetIntegrationTestScenarios(applicationName, appStudioE2EApplicationsNamespace)
+		//			integrationTestScenarios, err := f.HacbsUser.IntegrationController.GetIntegrationTestScenarios(applicationName, appStudioE2EApplicationsNamespace)
 		//			Expect(err).ShouldNot(HaveOccurred())
 		//                       for _, testScenario := range *integrationTestScenarios {
 		//      It("check if Integration Service PipelineRun is started"),func() {
 		// TBD
 		//     })
-		//			Expect(f.IntegrationController.WaitForIntegrationPipelineToBeFinished(&testScenario, applicationSnapshots, applicationName, appStudioE2EApplicationsNamespace)).To(Succeed(), "Error when waiting for a integration pipeline to finish")
+		//			Expect(f.HacbsUser.IntegrationController.WaitForIntegrationPipelineToBeFinished(&testScenario, applicationSnapshots, applicationName, appStudioE2EApplicationsNamespace)).To(Succeed(), "Error when waiting for a integration pipeline to finish")
 		//                       }
 		//		})
 	})


### PR DESCRIPTION
# Description

### Refactoring of kubernetes client initialization
It results in having 5 different clients
* 4 for kcp workspaces:
  * appstudio user workspace - for running appstudio tests (i.e. for working with appstudio-specific resources - application, component CRs etc)
  * hacbs user workspace - for running hacbs tests (i.e. for working with appstudio **and hacbs specific** resources - integrationtestscenarios, release CRs etc)
  * appstudio workspace (redhat-appstudio) - for accessing resources specific for appstudio (appstudio controllers' deployments, configmaps, secrets etc)
  * hacbs workspace (redhat-hacbs) - for accessing resources specific for hacbs (hacbs controllers' deployments, configmaps, secrets etc)
* 1 for workload cluster - for gathering resources we are not able to collect via kcp (yet), for example pods' logs from PipelineRuns

Each of them has all available controllers bound to them, so they can be used in each of the tests after framework initialization

### HACBS E2E demo test
A placeholder for full HACBS E2E demo that presents functionality of all hacbs services on an example of a single user story

## Issue ticket number and link
https://issues.redhat.com/browse/HACBS-1351

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

```bash
# Make sure you're currently targeting KCP-stable
export CLUSTER_KUBECONFIG=/path/to/associated/workload/cluster
# WORKSPACE_ID=abc assumes workspaces have the suffix -abc
# i.e. appstudio-abc, redhat-hacbs-abc etc
# if empty, workspaces without suffix are expected, i.e. appstudio, redhat-hacbs etc
export WORKSPACE_ID="<id-without-dash"
export GITHUB_TOKEN=$APPSTUDIO_GITHUB_TOKEN QUAY_TOKEN=$(base64 < ~/.docker/config.json) GITHUB_E2E_ORGANIZATION=<your-org> QUAY_E2E_ORGANIZATION=<your-org>
make local/test/e2e
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
