### PR TITLE
fix: remove references to "pre-kcp" branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Container build & push
 # Controls when the workflow will run
 on:
   push:
-    branches: [pre-kcp]
+    branches: [main]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -18,7 +18,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           image: e2e-tests
-          tags: pre-kcp ${{ github.sha }}
+          tags: main ${{ github.sha }}
           dockerfiles: |
             ./Dockerfile
       - name: Push To quay.io

--- a/scripts/e2e-openshift-ci.sh
+++ b/scripts/e2e-openshift-ci.sh
@@ -15,7 +15,7 @@ mkdir -p tmp/
 
 export ROOT_E2E="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
 export WORKSPACE=${WORKSPACE:-${ROOT_E2E}}
-export E2E_CLONE_BRANCH="pre-kcp"
+export E2E_CLONE_BRANCH="main"
 export E2E_REPO_LINK="https://github.com/redhat-appstudio/e2e-tests.git"
 export AUTHOR_E2E_BRANCH=""
 export PULL_NUMBER=${PULL_NUMBER:-"periodic"}

--- a/scripts/install-appstudio-e2e-mode.sh
+++ b/scripts/install-appstudio-e2e-mode.sh
@@ -47,9 +47,6 @@ function cloneInfraDeployments() {
 
     git clone https://$GITHUB_TOKEN@github.com/redhat-appstudio/infra-deployments.git "$WORKSPACE"/tmp/infra-deployments
     cd "$WORKSPACE"/tmp/infra-deployments
-    # TODO remove this once CI is ready to run with kcp (main branch)
-    # Allow dependent services (like jvm-build-service/build-service) to still use CI for testing features/bugfixes
-    git checkout pre-kcp
 }
 
 # Add a custom remote for infra-deployments repository.

--- a/scripts/install-appstudio.sh
+++ b/scripts/install-appstudio.sh
@@ -30,7 +30,7 @@ export HAS_DEFAULT_IMAGE_REPOSITORY="quay.io/${QUAY_E2E_ORGANIZATION:-redhat-app
 pushd "${TMP_DIR}"
 
 INFRA_DEPLOYMENTS_ORG="${INFRA_DEPLOYMENTS_ORG:-"redhat-appstudio"}"
-INFRA_DEPLOYMENTS_BRANCH="${INFRA_DEPLOYMENTS_BRANCH:-"pre-kcp"}"
+INFRA_DEPLOYMENTS_BRANCH="${INFRA_DEPLOYMENTS_BRANCH:-"main"}"
 git clone --no-checkout "https://${MY_GITHUB_TOKEN}@github.com/${INFRA_DEPLOYMENTS_ORG}/infra-deployments.git" .
 git checkout "${INFRA_DEPLOYMENTS_BRANCH}"
 # Add a custom remote for infra-deployments repository.


### PR DESCRIPTION
# Description

infra-deployments' "pre-kcp" branch merged to "main", accordingly the pre-kcp branch of this repo was renamed to "main"
This PR removes references to "pre-kcp" branch in scripts

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
