### PR TITLE
fix: infra-deployments PR pairing

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -196,10 +196,7 @@ func (CI) setRequiredEnvVars() error {
 			os.Setenv("E2E_TEST_SUITE_LABEL", testSuiteLabel)
 
 		} else if openshiftJobSpec.Refs.Repo == "infra-deployments" {
-
-			if !strings.Contains(pr.Author, "[bot]") {
-				os.Setenv("INFRA_DEPLOYMENTS_ORG", pr.Author)
-			}
+			os.Setenv("INFRA_DEPLOYMENTS_ORG", pr.RemoteName)
 			os.Setenv("INFRA_DEPLOYMENTS_BRANCH", pr.BranchName)
 		}
 

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -230,7 +230,7 @@ func BootstrapCluster() error {
 
 func (CI) isPRPairingRequired() bool {
 	var ghBranches []GithubBranch
-	url := fmt.Sprintf("https://api.github.com/repos/%s/e2e-tests/branches", pr.Author)
+	url := fmt.Sprintf("https://api.github.com/repos/%s/e2e-tests/branches", pr.RemoteName)
 	if err := sendHttpRequestAndParseResponse(url, "GET", &ghBranches); err != nil {
 		klog.Infof("cannot determine e2e-tests Github branches for author %s: %v. will stick with the redhat-appstudio/e2e-tests main branch for running tests", pr.Author, err)
 		return false

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -229,13 +229,14 @@ func BootstrapCluster() error {
 }
 
 func (CI) isPRPairingRequired() bool {
-	ghBranches := &GithubBranches{}
-	if err := sendHttpRequestAndParseResponse(fmt.Sprintf("https://api.github.com/repos/%s/e2e-tests/branches", pr.Author), "GET", ghBranches); err != nil {
-		klog.Infof("cannot determine e2e-tests Github branches for author %s: %v. will stick with the redhat-appstudio/e2e-tests main branch for running testss", pr.Author, err)
+	var ghBranches []GithubBranch
+	url := fmt.Sprintf("https://api.github.com/repos/%s/e2e-tests/branches", pr.Author)
+	if err := sendHttpRequestAndParseResponse(url, "GET", &ghBranches); err != nil {
+		klog.Infof("cannot determine e2e-tests Github branches for author %s: %v. will stick with the redhat-appstudio/e2e-tests main branch for running tests", pr.Author, err)
 		return false
 	}
 
-	for _, b := range ghBranches.Branches {
+	for _, b := range ghBranches {
 		if b.Name == pr.BranchName {
 			return true
 		}

--- a/magefiles/types.go
+++ b/magefiles/types.go
@@ -31,11 +31,7 @@ type Head struct {
 	Label string `json:"label"`
 }
 
-type GithubBranches struct {
-	Branches []Branch
-}
-
-type Branch struct {
+type GithubBranch struct {
 	Name string `json:"name"`
 }
 

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"k8s.io/klog/v2"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	"k8s.io/klog/v2"
 
 	"github.com/magefile/mage/sh"
 )


### PR DESCRIPTION
# Description

We saw [the issue](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/redhat-appstudio_infra-deployments/957/pull-ci-redhat-appstudio-infra-deployments-main-appstudio-e2e-tests/1595670670245629952#1:build-log.txt%3A65) during PR pairing when there was a PR created (by a bot) in infra-deployments from an upstream branch

It was hot-fixed by https://github.com/redhat-appstudio/e2e-tests/pull/245, but the proper solution comes with this PR

With this change, the infra-deployments org will be determined from the PR's `.head.label` value. The value is split to `RemoteName:BranchName`

Examples (see `.head.label` values):
1. [Case when the PR is created from a fork](https://api.github.com/repos/redhat-appstudio/infra-deployments/pulls/954)
1. [Case when the PR is created from an upstream branch (usually by redhat-appstudio-ci-bot)](https://api.github.com/repos/redhat-appstudio/infra-deployments/pulls/957)

Also this PR fixes an [issue with pairing of a repo and an e2e-tests branch](https://github.com/redhat-appstudio/infra-deployments/pull/954#issuecomment-1326323249)

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

locally with job specs from pull 957 and 954

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
