### PR TITLE
chore: Allow more flexible control vault podname and namespace

### DIFF
--- a/scripts/spi-e2e-setup.sh
+++ b/scripts/spi-e2e-setup.sh
@@ -5,6 +5,8 @@ set -e
 set -o pipefail
 # error on unset variables
 set -u
+VAULT_NAMESPACE=${VAULT_NAMESPACE:-spi-system}
+VAULT_PODNAME=${VAULT_PODNAME:-spi-vault-0}
 
 echo '[INFO] Deploying SPI OAuth2 config'
 
@@ -67,7 +69,7 @@ oc apply -f -
 
 rm "$tmpfile"
 
-curl https://raw.githubusercontent.com/redhat-appstudio/service-provider-integration-operator/main/hack/vault-init.sh | VAULT_PODNAME=spi-vault-0 VAULT_NAMESPACE="spi-system" bash -s
+curl https://raw.githubusercontent.com/redhat-appstudio/service-provider-integration-operator/main/hack/vault-init.sh | VAULT_PODNAME=${VAULT_PODNAME} VAULT_NAMESPACE=${VAULT_NAMESPACE} bash -s
 
 oc rollout restart deployment/spi-controller-manager -n spi-system
 oc rollout restart deployment/spi-oauth-service -n spi-system


### PR DESCRIPTION
# Description
With this pr https://github.com/redhat-appstudio/infra-deployments/pull/948 spi team want to change the way how vault is deployed with infra-deployment. We would like to separate it from spi main component namespace.  In the mentioned pr we changed vault namespace from "spi-system" to "spi-vault" and we no longer want to prefix all objects. That is why the default vault pod name is also changed to the one that comes from Vault's Helm chart. 

One of the parts of https://github.com/redhat-appstudio/infra-deployments development process is the usage of https://github.com/redhat-appstudio/infra-deployments/blob/main/hack/preview.sh which is calling `scripts/spi-e2e-setup.sh`. To maintain backward compatibility at least for the time when https://github.com/redhat-appstudio/infra-deployments/pull/948  I left defaults as it is now.


## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
   n/a
# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
