### PR TITLE
fix: build: point to a test repo's default org

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -37,7 +37,7 @@ const (
 var (
 	componentUrls                   = strings.Split(utils.GetEnv(COMPONENT_REPO_URLS_ENV, pythonComponentGitSourceURL), ",") //multiple urls
 	componentNames                  []string
-	helloWorldComponentGitSourceURL = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv("GITHUB_E2E_ORGANIZATION", "redhat-appstudio-qe"), helloWorldComponentGitSourceRepoName)
+	helloWorldComponentGitSourceURL = fmt.Sprintf("https://github.com/redhat-appstudio-qe/%s", helloWorldComponentGitSourceRepoName)
 )
 
 var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "HACBS"), func() {


### PR DESCRIPTION
# Description

Previously I assumed that the component repo used in build test is forked by a user (it's a leftover from my debugging). It should be removed

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
