### PR TITLE
fix: fix some issues with rp_preproc reporting

### DIFF
--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -72,7 +72,7 @@ var _ = ginkgo.ReportAfterSuite("RP Preproc reporter", func(report types.Report)
 		framework.GenerateRPPreprocReport(report, rpPreprocDir)
 		//Generate modified JUnit xml file
 		resultsPath := rpPreprocDir + "/rp_preproc/results/"
-		if err := os.Mkdir(resultsPath, os.ModePerm); err != nil {
+		if err := os.MkdirAll(resultsPath, os.ModePerm); err != nil {
 			klog.Error(err)
 		}
 		err := framework.GenerateCustomJUnitReport(report, resultsPath+"xunit.xml")

--- a/pkg/framework/custom_junit_reporter.go
+++ b/pkg/framework/custom_junit_reporter.go
@@ -75,6 +75,10 @@ func GenerateCustomJUnitReportWithConfig(report types.Report, dst string, config
 		},
 	}
 	for _, spec := range report.SpecReports {
+
+		if spec.LeafNodeType != types.NodeTypeIt {
+			continue
+		}
 		test := JUnitTestCase{
 			Name:      shortenStringAddHash(spec),
 			Classname: getClassnameFromReport(spec),
@@ -162,7 +166,7 @@ func GenerateCustomJUnitReportWithConfig(report types.Report, dst string, config
 // This function generates folder structure for the rp_preproc tool with logs for upload in Report Portal
 func GenerateRPPreprocReport(report types.Report, rpPreprocDir string) {
 	//Delete directory, if existss
-	if _, err := os.Stat("/path/to/whatever"); !os.IsNotExist(err) {
+	if _, err := os.Stat(rpPreprocDir); !os.IsNotExist(err) {
 		err2 := os.RemoveAll(rpPreprocDir)
 		if err2 != nil {
 			klog.Error(err2)


### PR DESCRIPTION
 * Resolved issue where it was failing to create the intial directory cause the parent directories didn't exist

 * Resolved issue where the Before/AfterSuites were being filtered out but still showing up as empty test cases in the xunit file

 * Resolved issue where we weren't stat checking the correct rp preproc directory for its existence

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Refer to the list above

## Issue ticket number and link

## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Ran manually with a command like this and no prior rp_preproc directories created.

`ginkgo run --dry-run --label-filter "manual" ./cmd/ -- --generate-rppreproc-report=true --rp-preproc-dir=.`

# Checklist:

- [ x] I have performed a self-review of my code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
