### PR TITLE
fix: fix generating template spec in a package dir that exists

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -369,7 +369,7 @@ func (Local) GenerateTestSpecFile() error {
 	}
 
 	templateDirPath = fmt.Sprintf("tests/%s", templateDirName)
-	err = os.Mkdir(templateDirPath, 0775)
+	err = os.MkdirAll(templateDirPath, 0775)
 	if err != nil {
 		klog.Errorf("failed to create package directory, %s, template with: %v", templateDirPath, err)
 		return err


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

I had a regression where if you try to generate a template spec file in a test package directory that parent directory already existed it would fail rather than creating the spec file. 

## Issue ticket number and link

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

manually
 - I tested creating

# Checklist:

- [ x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
