### PR TITLE
fix: add OWNERS file for build

### DIFF
--- a/tests/build/OWNERS
+++ b/tests/build/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- simonbaird
+- lcarva
+- zregvart
+- joejstuart
+- robnester-rh
+- cuipinghuo


### PR DESCRIPTION
# Description

add OWNERS file to subdirectories e2e-tests/tests/build, to help Enterprise Contract develpoper and QE to have complete control over.
## Issue ticket number and link
https://issues.redhat.com/browse/HACBS-1528
