### PR TITLE
fix: disable release tests

### DIFF
--- a/tests/release/release.go
+++ b/tests/release/release.go
@@ -36,7 +36,7 @@ var ecPolicy = ecp.EnterpriseContractPolicySpec{
 
 var paramsReleaseStrategy = []appstudiov1alpha1.Params{}
 
-var _ = framework.ReleaseSuiteDescribe("[HACBS-1108]test-release-service-happy-path", Label("release", "HACBS"), func() {
+var _ = framework.ReleaseSuiteDescribe("[HACBS-1108]test-release-service-happy-path", Label("release", "HACBS"), Pending, func() {
 	defer GinkgoRecover()
 	// Initialize the tests controllers
 	framework, err := framework.NewFramework()


### PR DESCRIPTION

# Description

A backwards incompatible change was done in the CRD EnterprisePolicyConfig. Changes in the e2e tests and infra-deployments must happen at the same time in order to proceed. Updating one without the other causes CI to fail. Since updating both at the same time is not possible, the release tests are disabled. This was also done for the EC/Chains tests.

Once the changes are merged in infra-deployments, we can change the tests to accommodate the new CRD format and re-enable them.

## Issue ticket number and link

https://issues.redhat.com/browse/HACBS-1525

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on my development environment running on quicklab.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
