### PR TITLE
fix: Add build team members to build/OWNERS

### DIFF
--- a/tests/build/OWNERS
+++ b/tests/build/OWNERS
@@ -5,3 +5,7 @@ approvers:
 - joejstuart
 - robnester-rh
 - cuipinghuo
+- Michkov
+- mmorhun
+- tkdchen
+- stuartwdouglas


### PR DESCRIPTION
# Description

Add build team members to build/OWNERS