### PR TITLE
feat: speed-up pipelines by skipping checks for initial runs

### DIFF
--- a/pkg/utils/has/controller.go
+++ b/pkg/utils/has/controller.go
@@ -162,6 +162,9 @@ func (h *SuiteController) CreateComponent(applicationName, componentName, namesp
 	}
 	component := &appservice.Component{
 		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"skip-initial-checks": "true",
+			},
 			Name:      componentName,
 			Namespace: namespace,
 		},

--- a/pkg/utils/tekton/pipelines.go
+++ b/pkg/utils/tekton/pipelines.go
@@ -45,6 +45,10 @@ func (g BuildahDemo) Generate() *v1beta1.PipelineRun {
 					Name:  "git-url",
 					Value: *v1beta1.NewArrayOrString("https://github.com/ziwoshixianzhe/simple_docker_app.git"),
 				},
+				{
+					Name:  "skip-checks",
+					Value: *v1beta1.NewArrayOrString("true"),
+				},
 			},
 			PipelineRef: &v1beta1.PipelineRef{
 				Name:   "docker-build",

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -572,6 +572,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			})
 
 			It("should validate HACBS taskrun results", func() {
+				Skip("skipping - should be updated by PLNSRVCE-914")
 				// List Of Taskruns Expected to Get Taskrun Results
 				gatherResult := []string{"conftest-clair", "sanity-inspect-image", "sanity-label-check"}
 				// TODO: once we migrate "build" e2e tests to kcp, remove this condition


### PR DESCRIPTION
Skip execution of full pipelineRun on direct component creation with quick workflow. The checks are still enabled for PipelineAsCode workflows.

[PLNSRVCE-958](https://issues.redhat.com//browse/PLNSRVCE-958)

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
