### PR TITLE
fix: language in devfile changed from java to Java

### DIFF
--- a/tests/has/devfile_private_source.go
+++ b/tests/has/devfile_private_source.go
@@ -136,8 +136,8 @@ var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label(
 		// Get the stub CDQ and validate its content
 		for _, compDetected = range cdq.Status.ComponentDetected {
 			Expect(compDetected.DevfileFound).To(BeTrue(), "DevfileFound was not set to true")
-			Expect(compDetected.Language).To(Equal("java"), "Detected language was not java")
-			Expect(compDetected.ProjectType).To(Equal("quarkus"), "Detected framework was not quarkus")
+			Expect(compDetected.Language).To(Equal("Java"), "Detected language was not java")
+			Expect(compDetected.ProjectType).To(Equal("Quarkus"), "Detected framework was not quarkus")
 		}
 	})
 

--- a/tests/has/devfile_source.go
+++ b/tests/has/devfile_source.go
@@ -122,8 +122,8 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 		// Get the stub CDQ and validate its content
 		for _, compDetected = range cdq.Status.ComponentDetected {
 			Expect(compDetected.DevfileFound).To(BeTrue(), "DevfileFound was not set to true")
-			Expect(compDetected.Language).To(Equal("java"), "Detected language was not java")
-			Expect(compDetected.ProjectType).To(Equal("quarkus"), "Detected framework was not quarkus")
+			Expect(compDetected.Language).To(Equal("Java"), "Detected language was not java")
+			Expect(compDetected.ProjectType).To(Equal("Quarkus"), "Detected framework was not quarkus")
 		}
 	})
 


### PR DESCRIPTION
# Description

e2e-tests started to fail on:
```
   [FAILED] Detected language was not java
  Expected
      <string>: Java
  to equal
      <string>: java
  In [It] at: /tmp/tmp.mJACcl6qYh/tests/has/devfile_source.go:125 @ 01/02/23 15:15:36.176 
```

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
