### PR TITLE
fix: update the chains and release tests to use the ec-defaults configMap

### DIFF
--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -92,15 +92,17 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 			}).WithTimeout(1*time.Minute).WithPolling(100*time.Millisecond).Should(
 				BeTrue(), "timed out when waiting for the %q SA to be created", serviceAccountName)
 
+			cm, err := kubeController.Commonctrl.GetConfigMap("ec-defaults", "enterprise-contract-service")
+			Expect(err).ToNot(HaveOccurred())
 			// the default policy source
 			policySource = []ecp.Source{
 				{
 					Name: "ec-policies",
 					Policy: []string{
-						"git::https://github.com/hacbs-contract/ec-policies.git//policy",
+						cm.Data["ec_policy_source"],
 					},
 					Data: []string{
-						"git::https://github.com/hacbs-contract/ec-policies.git//data",
+						cm.Data["ec_data_source"],
 					},
 				},
 			}

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -97,13 +97,9 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 			// the default policy source
 			policySource = []ecp.Source{
 				{
-					Name: "ec-policies",
-					Policy: []string{
-						cm.Data["ec_policy_source"],
-					},
-					Data: []string{
-						cm.Data["ec_data_source"],
-					},
+					Name:   "ec-policies",
+					Policy: []string{cm.Data["ec_policy_source"]},
+					Data:   []string{cm.Data["ec_data_source"]},
 				},
 			}
 

--- a/tests/release/release.go
+++ b/tests/release/release.go
@@ -67,8 +67,8 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1108]test-release-service-happy-p
 					Data:   []string{cm.Data["ec_data_source"]},
 				},
 			},
-			Exceptions: &ecp.EnterpriseContractPolicyExceptions{
-				NonBlocking: []string{"tasks", "attestation_task_bundle", "java", "test", "not_useful"},
+			Configuration: &ecp.EnterpriseContractPolicyConfiguration{
+				Exclude: []string{"tasks", "attestation_task_bundle", "java", "test", "not_useful"},
 			},
 		}
 	})

--- a/tests/release/release.go
+++ b/tests/release/release.go
@@ -62,13 +62,9 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1108]test-release-service-happy-p
 			Description: "Red Hat's enterprise requirements",
 			Sources: []ecp.Source{
 				{
-					Name: "ec-policies",
-					Policy: []string{
-						cm.Data["ec_policy_source"],
-					},
-					Data: []string{
-						cm.Data["ec_data_source"],
-					},
+					Name:   "ec-policies",
+					Policy: []string{cm.Data["ec_policy_source"]},
+					Data:   []string{cm.Data["ec_data_source"]},
 				},
 			},
 			Exceptions: &ecp.EnterpriseContractPolicyExceptions{


### PR DESCRIPTION
# Description

This change allows the e2e tests to use the latest ec-policies policy and data source. It also will pin the policy and data to a specific version.

## Issue ticket number and link

https://issues.redhat.com/browse/HACBS-1116

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This was tested by running the e2e tests on cluster-bot.


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
