### PR TITLE
fix: increatese timeout to prevent failure in CI

### DIFF
--- a/tests/release/const.go
+++ b/tests/release/const.go
@@ -27,7 +27,7 @@ const (
 	releasePlanAdmissionCreationTimeout   = 1 * time.Second
 	releaseCreationTimeout                = 1 * time.Second
 	releasePipelineRunCreationTimeout     = 1 * time.Second
-	releasePipelineRunCompletionTimeout   = 20 * time.Second
+	releasePipelineRunCompletionTimeout   = 120 * time.Second
 	avgControllerQueryTimeout             = 1 * time.Second
 	pipelineServiceAccountCreationTimeout = 1 * time.Minute
 

--- a/tests/release/const.go
+++ b/tests/release/const.go
@@ -18,18 +18,18 @@ const (
 	environment                         = "test-environment"
 	releaseStrategyServiceAccount       = "pipeline"
 
-	namespaceCreationTimeout              = 20 * time.Second
-	namespaceDeletionTimeout              = 20 * time.Second
-	snapshotCreationTimeout               = 2 * time.Second
-	releaseStrategyCreationTimeout        = 1 * time.Second
-	releasePlanCreationTimeout            = 1 * time.Second
-	EnterpriseContractPolicyTimeout       = 1 * time.Second
-	releasePlanAdmissionCreationTimeout   = 1 * time.Second
-	releaseCreationTimeout                = 1 * time.Second
-	releasePipelineRunCreationTimeout     = 1 * time.Second
-	releasePipelineRunCompletionTimeout   = 120 * time.Second
-	avgControllerQueryTimeout             = 1 * time.Second
-	pipelineServiceAccountCreationTimeout = 1 * time.Minute
+	namespaceCreationTimeout              = 1 * time.Minute
+	namespaceDeletionTimeout              = 1 * time.Minute
+	snapshotCreationTimeout               = 1 * time.Minute
+	releaseStrategyCreationTimeout        = 1 * time.Minute
+	releasePlanCreationTimeout            = 1 * time.Minute
+	EnterpriseContractPolicyTimeout       = 1 * time.Minute
+	releasePlanAdmissionCreationTimeout   = 1 * time.Minute
+	releaseCreationTimeout                = 1 * time.Minute
+	releasePipelineRunCreationTimeout     = 5 * time.Minute
+	releasePipelineRunCompletionTimeout   = 10 * time.Minute
+	avgControllerQueryTimeout             = 1 * time.Minute
+	pipelineServiceAccountCreationTimeout = 3 * time.Minute
 
 	defaultInterval = 100 * time.Millisecond
 )


### PR DESCRIPTION
# Description

release e2e-test happy path fails in CI , to fix issue we increased the timeout 

## [HACBS-1572](https://issues.redhat.com//browse/HACBS-1572)
https://issues.redhat.com/browse/HACBS-1572

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
