### PR TITLE
test(RHDP-579): remove 'Ordered' in [e2e-demos-suite]

### DIFF
--- a/pkg/framework/describe.go
+++ b/pkg/framework/describe.go
@@ -11,7 +11,7 @@ func HASSuiteDescribe(text string, args ...interface{}) bool {
 
 // E2ESuiteDescribe annotates the e2e scenarios tests with the e2e-scenarios label.
 func E2ESuiteDescribe(args ...interface{}) bool {
-	return Describe("[e2e-demos-suite]", args, Ordered)
+	return Describe("[e2e-demos-suite]", args)
 }
 
 // CommonSuiteDescribe annotates the common tests with the application label.

--- a/tests/e2e-demos/multi-component.go
+++ b/tests/e2e-demos/multi-component.go
@@ -54,145 +54,147 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 	var removeApplication = true
 
-	BeforeAll(func() {
-		// Check to see if the github token was provided
-		Expect(utils.CheckIfEnvironmentExists(constants.GITHUB_TOKEN_ENV)).Should(BeTrue(), "%s environment variable is not set", constants.GITHUB_TOKEN_ENV)
-		// Check if 'has-github-token' is present, unless SKIP_HAS_SECRET_CHECK env var is set
-		if !utils.CheckIfEnvironmentExists(constants.SKIP_HAS_SECRET_CHECK_ENV) {
-			_, err := fw.HasController.KubeInterface().CoreV1().Secrets(RedHatAppStudioApplicationNamespace).Get(context.TODO(), ApplicationServiceGHTokenSecrName, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred(), "Error checking 'has-github-token' secret %s", err)
-		}
+	Describe(testSpecification.Tests[0].ApplicationName, Ordered, func() {
+		BeforeAll(func() {
+			// Check to see if the github token was provided
+			Expect(utils.CheckIfEnvironmentExists(constants.GITHUB_TOKEN_ENV)).Should(BeTrue(), "%s environment variable is not set", constants.GITHUB_TOKEN_ENV)
+			// Check if 'has-github-token' is present, unless SKIP_HAS_SECRET_CHECK env var is set
+			if !utils.CheckIfEnvironmentExists(constants.SKIP_HAS_SECRET_CHECK_ENV) {
+				_, err := fw.HasController.KubeInterface().CoreV1().Secrets(RedHatAppStudioApplicationNamespace).Get(context.TODO(), ApplicationServiceGHTokenSecrName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred(), "Error checking 'has-github-token' secret %s", err)
+			}
 
-		_, err := fw.CommonController.CreateTestNamespace(AppStudioE2EApplicationsNamespace)
-		Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", AppStudioE2EApplicationsNamespace, err)
+			_, err := fw.CommonController.CreateTestNamespace(AppStudioE2EApplicationsNamespace)
+			Expect(err).NotTo(HaveOccurred(), "Error when creating/updating '%s' namespace: %v", AppStudioE2EApplicationsNamespace, err)
 
-		// Check test specification has at least one test defined
-		Expect(len(testSpecification.Tests)).To(BeNumerically(">", 0))
-	})
+			// Check test specification has at least one test defined
+			Expect(len(testSpecification.Tests)).To(BeNumerically(">", 0))
+		})
 
-	// Remove all resources created by the tests
-	AfterAll(func() {
-		if removeApplication {
-			Expect(fw.HasController.DeleteAllComponentsInASpecificNamespace(AppStudioE2EApplicationsNamespace, 30*time.Second)).To(Succeed())
-			Expect(fw.HasController.DeleteAllApplicationsInASpecificNamespace(AppStudioE2EApplicationsNamespace, 30*time.Second)).To(Succeed())
-		}
-	})
+		// Remove all resources created by the tests
+		AfterAll(func() {
+			if removeApplication {
+				Expect(fw.HasController.DeleteAllComponentsInASpecificNamespace(AppStudioE2EApplicationsNamespace, 30*time.Second)).To(Succeed())
+				Expect(fw.HasController.DeleteAllApplicationsInASpecificNamespace(AppStudioE2EApplicationsNamespace, 30*time.Second)).To(Succeed())
+			}
+		})
 
-	It("Create Red Hat AppStudio Application", func() {
-		createdApplication, err := fw.HasController.CreateHasApplication(testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(createdApplication.Spec.DisplayName).To(Equal(testSpecification.Tests[0].ApplicationName))
-		Expect(createdApplication.Namespace).To(Equal(AppStudioE2EApplicationsNamespace))
-	})
-
-	It("Check Red Hat AppStudio Application health", func() {
-		Eventually(func() string {
-			application, err = fw.HasController.GetHasApplication(testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)
+		It("Create Red Hat AppStudio Application", func() {
+			createdApplication, err := fw.HasController.CreateHasApplication(testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(createdApplication.Spec.DisplayName).To(Equal(testSpecification.Tests[0].ApplicationName))
+			Expect(createdApplication.Namespace).To(Equal(AppStudioE2EApplicationsNamespace))
+		})
 
-			return application.Status.Devfile
-		}, 3*time.Minute, 100*time.Millisecond).Should(Not(BeEmpty()), "Error creating gitOps repository")
+		It("Check Red Hat AppStudio Application health", func() {
+			Eventually(func() string {
+				application, err = fw.HasController.GetHasApplication(testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)
+				Expect(err).NotTo(HaveOccurred())
 
-		Eventually(func() bool {
-			// application info should be stored even after deleting the application in application variable
-			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
+				return application.Status.Devfile
+			}, 3*time.Minute, 100*time.Millisecond).Should(Not(BeEmpty()), "Error creating gitOps repository")
 
-			return fw.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
-		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "Has controller didn't create gitops repository")
-	})
+			Eventually(func() bool {
+				// application info should be stored even after deleting the application in application variable
+				gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-	It("Create Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
-		cdq, err := fw.HasController.CreateComponentDetectionQuery(testSpecification.Tests[0].Components[0].Name, AppStudioE2EApplicationsNamespace, testSpecification.Tests[0].Components[0].GitSourceUrl, "", false)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(cdq.Name).To(Equal(testSpecification.Tests[0].Components[0].Name))
-	})
+				return fw.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+			}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "Has controller didn't create gitops repository")
+		})
 
-	It("Check Red Hat AppStudio ComponentDetectionQuery status", func() {
-		// Validate that the CDQ completes successfully
-		Eventually(func() bool {
-			// application info should be stored even after deleting the application in application variable
-			cdq, err = fw.HasController.GetComponentDetectionQuery(testSpecification.Tests[0].Components[0].Name, AppStudioE2EApplicationsNamespace)
-			return err == nil && len(cdq.Status.ComponentDetected) > 0
-		}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "ComponentDetectionQuery did not complete successfully")
+		It("Create Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
+			cdq, err := fw.HasController.CreateComponentDetectionQuery(testSpecification.Tests[0].Components[0].Name, AppStudioE2EApplicationsNamespace, testSpecification.Tests[0].Components[0].GitSourceUrl, "", false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cdq.Name).To(Equal(testSpecification.Tests[0].Components[0].Name))
+		})
 
-		// Validate that the completed CDQ only has detected the two components (nodejs and go)
-		Expect(len(cdq.Status.ComponentDetected)).To(Equal(2), "Expected length of the detected Components was not 2")
+		It("Check Red Hat AppStudio ComponentDetectionQuery status", func() {
+			// Validate that the CDQ completes successfully
+			Eventually(func() bool {
+				// application info should be stored even after deleting the application in application variable
+				cdq, err = fw.HasController.GetComponentDetectionQuery(testSpecification.Tests[0].Components[0].Name, AppStudioE2EApplicationsNamespace)
+				return err == nil && len(cdq.Status.ComponentDetected) > 0
+			}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "ComponentDetectionQuery did not complete successfully")
 
-		// get the name of the components for future use and validate they are go and nodejs
-		for key, element := range cdq.Status.ComponentDetected {
-			if element.Language == "go" {
-				compNameGo = key
+			// Validate that the completed CDQ only has detected the two components (nodejs and go)
+			Expect(len(cdq.Status.ComponentDetected)).To(Equal(2), "Expected length of the detected Components was not 2")
+
+			// get the name of the components for future use and validate they are go and nodejs
+			for key, element := range cdq.Status.ComponentDetected {
+				if element.Language == "go" {
+					compNameGo = key
+				}
+				if element.Language == "nodejs" {
+					compNameNode = key
+				}
 			}
-			if element.Language == "nodejs" {
-				compNameNode = key
+
+			_, golang := cdq.Status.ComponentDetected[compNameGo]
+			Expect(golang).To(BeTrue(), "Expect Golang component to be detected")
+			_, nodejs := cdq.Status.ComponentDetected[compNameNode]
+			Expect(nodejs).To(BeTrue(), "Expect NodeJS component to be detected")
+
+		})
+
+		It("Create multiple components", func() {
+
+			// Create Golang component from CDQ result
+			Expect(cdq.Status.ComponentDetected[compNameGo].DevfileFound).To(BeTrue(), "DevfileFound was not set to true")
+			componentDescritpion := cdq.Status.ComponentDetected[compNameGo]
+			componentDescritpion.ComponentStub.ContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+			componentGo, err := fw.HasController.CreateComponentFromStub(componentDescritpion, compNameGo, AppStudioE2EApplicationsNamespace, "", testSpecification.Tests[0].ApplicationName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(componentGo.Name).To(Equal(compNameGo))
+
+			// Create NodeJS component from CDQ result
+			Expect(cdq.Status.ComponentDetected[compNameNode].DevfileFound).To(BeTrue(), "DevfileFound was not set to true")
+			componentDescritpion = cdq.Status.ComponentDetected[compNameNode]
+			componentDescritpion.ComponentStub.ContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
+			componentNode, err := fw.HasController.CreateComponentFromStub(componentDescritpion, compNameNode, AppStudioE2EApplicationsNamespace, "", testSpecification.Tests[0].ApplicationName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(componentNode.Name).To(Equal(compNameNode))
+
+		})
+
+		// Start to watch the pipeline until is finished
+		It("Wait for all pipelines to be finished", func() {
+
+			err := fw.HasController.WaitForComponentPipelineToBeFinished(compNameGo, testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)
+			if err != nil {
+				removeApplication = false
 			}
-		}
+			Expect(err).NotTo(HaveOccurred(), "Failed component pipeline %v", err)
 
-		_, golang := cdq.Status.ComponentDetected[compNameGo]
-		Expect(golang).To(BeTrue(), "Expect Golang component to be detected")
-		_, nodejs := cdq.Status.ComponentDetected[compNameNode]
-		Expect(nodejs).To(BeTrue(), "Expect NodeJS component to be detected")
+			err = fw.HasController.WaitForComponentPipelineToBeFinished(compNameNode, testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)
+			if err != nil {
+				removeApplication = false
+			}
+			Expect(err).NotTo(HaveOccurred(), "Failed component pipeline %v", err)
 
-	})
+		})
 
-	It("Create multiple components", func() {
+		// Check components are deployed
+		// TODO re-enable once the issue with GitopsDeployment creation is resolved
+		It("Check multiple components are deployed", Pending, func() {
 
-		// Create Golang component from CDQ result
-		Expect(cdq.Status.ComponentDetected[compNameGo].DevfileFound).To(BeTrue(), "DevfileFound was not set to true")
-		componentDescritpion := cdq.Status.ComponentDetected[compNameGo]
-		componentDescritpion.ComponentStub.ContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-		componentGo, err := fw.HasController.CreateComponentFromStub(componentDescritpion, compNameGo, AppStudioE2EApplicationsNamespace, "", testSpecification.Tests[0].ApplicationName)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(componentGo.Name).To(Equal(compNameGo))
+			Eventually(func() bool {
+				deploymentGo, err := fw.CommonController.GetAppDeploymentByName(compNameGo, AppStudioE2EApplicationsNamespace)
+				if err != nil && !errors.IsNotFound(err) {
+					return false
+				}
 
-		// Create NodeJS component from CDQ result
-		Expect(cdq.Status.ComponentDetected[compNameNode].DevfileFound).To(BeTrue(), "DevfileFound was not set to true")
-		componentDescritpion = cdq.Status.ComponentDetected[compNameNode]
-		componentDescritpion.ComponentStub.ContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
-		componentNode, err := fw.HasController.CreateComponentFromStub(componentDescritpion, compNameNode, AppStudioE2EApplicationsNamespace, "", testSpecification.Tests[0].ApplicationName)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(componentNode.Name).To(Equal(compNameNode))
+				deploymentNode, err := fw.CommonController.GetAppDeploymentByName(compNameNode, AppStudioE2EApplicationsNamespace)
+				if err != nil && !errors.IsNotFound(err) {
+					return false
+				}
 
-	})
+				if deploymentGo.Status.AvailableReplicas == 1 && deploymentNode.Status.AvailableReplicas == 1 {
+					return true
+				}
 
-	// Start to watch the pipeline until is finished
-	It("Wait for all pipelines to be finished", func() {
-
-		err := fw.HasController.WaitForComponentPipelineToBeFinished(compNameGo, testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)
-		if err != nil {
-			removeApplication = false
-		}
-		Expect(err).NotTo(HaveOccurred(), "Failed component pipeline %v", err)
-
-		err = fw.HasController.WaitForComponentPipelineToBeFinished(compNameNode, testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)
-		if err != nil {
-			removeApplication = false
-		}
-		Expect(err).NotTo(HaveOccurred(), "Failed component pipeline %v", err)
-
-	})
-
-	// Check components are deployed
-	// TODO re-enable once the issue with GitopsDeployment creation is resolved
-	It("Check multiple components are deployed", Pending, func() {
-
-		Eventually(func() bool {
-			deploymentGo, err := fw.CommonController.GetAppDeploymentByName(compNameGo, AppStudioE2EApplicationsNamespace)
-			if err != nil && !errors.IsNotFound(err) {
 				return false
-			}
-
-			deploymentNode, err := fw.CommonController.GetAppDeploymentByName(compNameNode, AppStudioE2EApplicationsNamespace)
-			if err != nil && !errors.IsNotFound(err) {
-				return false
-			}
-
-			if deploymentGo.Status.AvailableReplicas == 1 && deploymentNode.Status.AvailableReplicas == 1 {
-				return true
-			}
-
-			return false
-		}, 15*time.Minute, 10*time.Second).Should(BeTrue(), "Component deployment didn't become ready")
-		Expect(err).NotTo(HaveOccurred())
+			}, 15*time.Minute, 10*time.Second).Should(BeTrue(), "Component deployment didn't become ready")
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
# Description
When `Ordered` is used, the scenarios tests "will never be randomized and they will never run in parallel with one another, though they may run in parallel with other specs".

Since the order in which the e2e-demos-suite (nodejs, dotnet, etc...) is running is irrelevant, we can remove it in order to run them in parallel.

## Issue ticket number and link
[RHDP-579](https://issues.redhat.com/browse/RHDP-579)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`make local/test/e2e`

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
