### PR TITLE
chore: disable the verbose output

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The following environments are used to launch the Red Hat AppStudio installation
 | `QUAY_OAUTH_TOKEN` | no | A valid quay quay robot account token to make oauth against quay.io. | '' |
 | `INFRA_DEPLOYMENTS_ORG` | no | A specific github organization from where to download infra-deployments repository | `redhat-appstudio` |
 | `INFRA_DEPLOYMENTS_BRANCH` | no | A valid infra-deployments branch. | `main` |
+| `E2E_TEST_SUITE_LABEL` | no | Run only test suites with the given Giknkgo label | '' |
+| `KLOG_VERBOSITY` | no | Level of verbosity for `klog` | 1 |
 
 3. Install dependencies:
 
@@ -144,6 +146,12 @@ For more information refer to [Generate Tests](docs/DeveloperGenerateTest.md).
 * Every new test should have correct [labels](docs/LabelsNaming.md).
 * Every test should have meaningful description with JIRA/GitHub issue key.
 * (Recommended) Use JIRA integration for linking issues and commits (just add JIRA issue key in the commit message). You can found more information about GitHub-JIRA integration [here](https://docs.engineering.redhat.com/display/JiraAid/GitHub-Jira+integration).
+* When running via mage you can filter the suites run by specifying the
+  `E2E_TEST_SUITE_LABEL` environment variable. For example:
+  `E2E_TEST_SUITE_LABEL=ec ./mage runE2ETests`
+* `klog` level can be controled via `KLOG_VERBOSITY` environment variable. For
+  example: `KLOG_VERBOSITY=9 ./mage runE2ETests` would output `curl` commands
+  issued via Kubernetes client from sigs.k8s.io/controller-runtime
 
 ```golang
 // cmd/e2e_test.go

--- a/cmd/e2e_test.go
+++ b/cmd/e2e_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
@@ -47,6 +48,19 @@ func init() {
 	flag.StringVar(&polarionOutputFile, "polarion-output-file", "polarion.xml", "Generated polarion test cases")
 	flag.StringVar(&polarionProjectID, "project-id", "AppStudio", "Set the Polarion project ID")
 	flag.BoolVar(&generateTestCases, "generate-test-cases", false, "Generate Test Cases for Polarion")
+
+	klog.SetLogger(ginkgo.GinkgoLogr)
+
+	verbosity := 1
+	if v, err := strconv.ParseUint(os.Getenv("KLOG_VERBOSITY"), 10, 8); err == nil {
+		verbosity = int(v)
+	}
+
+	flags := &flag.FlagSet{}
+	klog.InitFlags(flags)
+	if err := flags.Set("v", fmt.Sprintf("%d", verbosity)); err != nil {
+		panic(err)
+	}
 }
 
 func TestE2E(t *testing.T) {

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -214,7 +214,7 @@ func (ci CI) TestE2E() error {
 func RunE2ETests() error {
 	cwd, _ := os.Getwd()
 
-	return sh.RunV("ginkgo", "-p", "--timeout=90m", fmt.Sprintf("--output-dir=%s", artifactDir), "--junit-report=e2e-report.xml", "--v", "--no-color", "--label-filter=$E2E_TEST_SUITE_LABEL", "./cmd", "--", fmt.Sprintf("--config-suites=%s/tests/e2e-demos/config/default.yaml", cwd), "--generate-rppreproc-report=true", fmt.Sprintf("--rp-preproc-dir=%s", artifactDir))
+	return sh.RunV("ginkgo", "-p", "--timeout=90m", fmt.Sprintf("--output-dir=%s", artifactDir), "--junit-report=e2e-report.xml", "--no-color", "--label-filter=$E2E_TEST_SUITE_LABEL", "./cmd", "--", fmt.Sprintf("--config-suites=%s/tests/e2e-demos/config/default.yaml", cwd), "--generate-rppreproc-report=true", fmt.Sprintf("--rp-preproc-dir=%s", artifactDir))
 }
 
 func PreflightChecks() error {

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -214,7 +214,7 @@ func (ci CI) TestE2E() error {
 func RunE2ETests() error {
 	cwd, _ := os.Getwd()
 
-	return sh.RunV("ginkgo", "-p", "--timeout=90m", fmt.Sprintf("--output-dir=%s", artifactDir), "--junit-report=e2e-report.xml", "--no-color", "--label-filter=$E2E_TEST_SUITE_LABEL", "./cmd", "--", fmt.Sprintf("--config-suites=%s/tests/e2e-demos/config/default.yaml", cwd), "--generate-rppreproc-report=true", fmt.Sprintf("--rp-preproc-dir=%s", artifactDir))
+	return sh.RunV("ginkgo", "-p", "--timeout=90m", fmt.Sprintf("--output-dir=%s", artifactDir), "--junit-report=e2e-report.xml", "--label-filter=$E2E_TEST_SUITE_LABEL", "./cmd", "--", fmt.Sprintf("--config-suites=%s/tests/e2e-demos/config/default.yaml", cwd), "--generate-rppreproc-report=true", fmt.Sprintf("--rp-preproc-dir=%s", artifactDir))
 }
 
 func PreflightChecks() error {

--- a/pkg/apis/github/repositories.go
+++ b/pkg/apis/github/repositories.go
@@ -5,16 +5,16 @@ import (
 	"fmt"
 
 	"github.com/google/go-github/v44/github"
-	"k8s.io/klog/v2"
+	. "github.com/onsi/ginkgo/v2"
 )
 
 func (g *Github) CheckIfRepositoryExist(repository string) bool {
 	_, resp, err := g.client.Repositories.Get(context.Background(), g.organization, repository)
 	if err != nil {
-		klog.Errorf("error when sending request to Github API: %v", err)
+		GinkgoWriter.Printf("error when sending request to Github API: %v\n", err)
 		return false
 	}
-	klog.Infof("repository %s status request to github: %d", repository, resp.StatusCode)
+	GinkgoWriter.Printf("repository %s status request to github: %d\n", repository, resp.StatusCode)
 	return resp.StatusCode == 200
 }
 
@@ -113,7 +113,7 @@ func (g *Github) GetAllRepositories() ([]*github.Repository, error) {
 }
 
 func (g *Github) DeleteRepository(repository *github.Repository) error {
-	klog.Infof("Deleting repository %s\n", *repository.Name)
+	GinkgoWriter.Printf("Deleting repository %s\n", *repository.Name)
 	_, err := g.client.Repositories.Delete(context.Background(), g.organization, *repository.Name)
 	if err != nil {
 		return err

--- a/pkg/utils/build/sbom.go
+++ b/pkg/utils/build/sbom.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"os"
 
+	. "github.com/onsi/ginkgo/v2"
 	"github.com/openshift/library-go/pkg/image/reference"
 	"github.com/openshift/oc/pkg/cli/image/extract"
 	"github.com/openshift/oc/pkg/cli/image/imagesource"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/klog"
 )
 
 func GetParsedSbomFilesContentFromImage(image string) (*SbomPurl, *SbomCyclonedx, error) {
@@ -22,7 +22,7 @@ func GetParsedSbomFilesContentFromImage(image string) (*SbomPurl, *SbomCyclonedx
 	if err != nil {
 		return nil, nil, fmt.Errorf("error when creating a temp directory for extracting files: %+v", err)
 	}
-	klog.Infof("extracting contents of container image %s to dir: %s", image, tmpDir)
+	GinkgoWriter.Printf("extracting contents of container image %s to dir: %s\n", image, tmpDir)
 	eMapping := extract.Mapping{
 		ImageRef: imagesource.TypedImageReference{Type: "docker", Ref: dockerImageRef},
 		To:       tmpDir,

--- a/pkg/utils/has/controller.go
+++ b/pkg/utils/has/controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 
+	. "github.com/onsi/ginkgo/v2"
 	routev1 "github.com/openshift/api/route/v1"
 	appservice "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	kubeCl "github.com/redhat-appstudio/e2e-tests/pkg/apis/kubernetes"
@@ -22,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
 	rclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -402,12 +402,12 @@ func (h *SuiteController) WaitForComponentPipelineToBeFinished(componentName str
 		pipelineRun, err := h.GetComponentPipelineRun(componentName, applicationName, componentNamespace, false, "")
 
 		if err != nil {
-			klog.Infoln("PipelineRun has not been created yet")
+			GinkgoWriter.Println("PipelineRun has not been created yet")
 			return false, nil
 		}
 
 		for _, condition := range pipelineRun.Status.Conditions {
-			klog.Infof("PipelineRun %s reason: %s", pipelineRun.Name, condition.Reason)
+			GinkgoWriter.Printf("PipelineRun %s reason: %s\n", pipelineRun.Name, condition.Reason)
 
 			if condition.Reason == "Failed" {
 				return false, fmt.Errorf("component %s pipeline failed", pipelineRun.Name)

--- a/pkg/utils/integration/controller.go
+++ b/pkg/utils/integration/controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	appstudioApi "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	kubeCl "github.com/redhat-appstudio/e2e-tests/pkg/apis/kubernetes"
 	integrationv1alpha1 "github.com/redhat-appstudio/integration-service/api/v1alpha1"
@@ -15,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -106,7 +106,7 @@ func (h *SuiteController) GetReleasesWithApplicationSnapshot(applicationSnapshot
 	}
 
 	for _, release := range releases.Items {
-		klog.Infof("Release %s is found", release.Name)
+		GinkgoWriter.Printf("Release %s is found\n", release.Name)
 	}
 
 	return &releases.Items, nil
@@ -292,7 +292,7 @@ func (h *SuiteController) WaitForIntegrationPipelineToBeFinished(testScenario *i
 		pipelineRun, _ := h.GetIntegrationPipelineRun(testScenario.Name, applicationSnapshot.Name, appNamespace)
 
 		for _, condition := range pipelineRun.Status.Conditions {
-			klog.Infof("PipelineRun %s reason: %s", pipelineRun.Name, condition.Reason)
+			GinkgoWriter.Printf("PipelineRun %s reason: %s\n", pipelineRun.Name, condition.Reason)
 
 			if condition.Reason == "Failed" {
 				return false, fmt.Errorf("component %s pipeline failed", pipelineRun.Name)

--- a/pkg/utils/release/controller.go
+++ b/pkg/utils/release/controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	appstudioApi "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	kubeCl "github.com/redhat-appstudio/e2e-tests/pkg/apis/kubernetes"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
@@ -15,7 +16,6 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -216,7 +216,7 @@ func (s *SuiteController) CreateReleasePlanAdmission(name, originNamespace, appl
 
 // CreateRegistryJsonSecret creates a secret for registry repository in namespace given with key passed.
 func (s *SuiteController) CreateRegistryJsonSecret(name, namespace, authKey, keyName string) (*corev1.Secret, error) {
-	klog.Info("Key is : ", authKey)
+	GinkgoWriter.Println("Key is : ", authKey)
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		Type:       corev1.SecretTypeDockerConfigJson,

--- a/pkg/utils/tekton/controller.go
+++ b/pkg/utils/tekton/controller.go
@@ -301,7 +301,7 @@ func (s *SuiteController) DeleteAllPipelineRunsInASpecificNamespace(ns string) e
 					// PipelinerRun CR is already removed
 					return true, nil
 				}
-				g.GinkgoWriter.Printf("unable to retrieve PipelineRun '%s' in '%s': %v", pipelineRunCR.Name, pipelineRunCR.Namespace, err)
+				g.GinkgoWriter.Printf("unable to retrieve PipelineRun '%s' in '%s': %v\n", pipelineRunCR.Name, pipelineRunCR.Namespace, err)
 				return false, nil
 
 			}
@@ -309,12 +309,12 @@ func (s *SuiteController) DeleteAllPipelineRunsInASpecificNamespace(ns string) e
 			// Remove the finalizer, so that it can be deleted.
 			pipelineRunCR.Finalizers = []string{}
 			if err := s.K8sClient.KubeRest().Update(context.TODO(), &pipelineRunCR); err != nil {
-				g.GinkgoWriter.Printf("unable to remove finalizers from PipelineRun '%s' in '%s': %v", pipelineRunCR.Name, pipelineRunCR.Namespace, err)
+				g.GinkgoWriter.Printf("unable to remove finalizers from PipelineRun '%s' in '%s': %v\n", pipelineRunCR.Name, pipelineRunCR.Namespace, err)
 				return false, nil
 			}
 
 			if err := s.K8sClient.KubeRest().Delete(context.TODO(), &pipelineRunCR); err != nil {
-				g.GinkgoWriter.Printf("unable to delete PipelineRun '%s' in '%s': %v", pipelineRunCR.Name, pipelineRunCR.Namespace, err)
+				g.GinkgoWriter.Printf("unable to delete PipelineRun '%s' in '%s': %v\n", pipelineRunCR.Name, pipelineRunCR.Namespace, err)
 				return false, nil
 			}
 			return true, nil

--- a/templates/test_suite_cmd.tmpl
+++ b/templates/test_suite_cmd.tmpl
@@ -16,8 +16,6 @@ import (
 	"flag"
 
 	"github.com/spf13/viper"
-
-	"k8s.io/klog/v2"
 )
 
 const ()
@@ -41,7 +39,7 @@ func init() {
 }
 
 func {{ .SuiteName }}Test(t *testing.T) {
-	klog.Info("Starting {{ .SuiteName }} tests...")
+	GinkgoWriter.Println("Starting {{ .SuiteName }} tests...")
 
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "{{ .SuiteName }} tests")
@@ -50,7 +48,7 @@ func {{ .SuiteName }}Test(t *testing.T) {
 var _ = ginkgo.SynchronizedAfterSuite(func() {}, func() {
 	//Send webhook only it the parameter configPath is not empty
 	if len(webhookConfigPath) > 0 {
-		klog.Info("Send webhook")
+		GinkgoWriter.Println("Send webhook")
 		framework.SendWebhook(webhookConfigPath)
 	}
 })

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -25,7 +25,6 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/klog/v2"
 	"knative.dev/pkg/apis"
 )
 
@@ -134,7 +133,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			Eventually(func() bool {
 				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, "")
 				if err != nil {
-					klog.Infoln("PipelineRun has not been created yet")
+					GinkgoWriter.Println("PipelineRun has not been created yet")
 					return false
 				}
 				return pipelineRun.HasStarted()
@@ -171,7 +170,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, condition := range pipelineRun.Status.Conditions {
-						klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+						GinkgoWriter.Printf("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
 
 						if !pipelineRun.IsDone() {
 							return false
@@ -224,7 +223,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				Expect(err).NotTo(HaveOccurred())
 
 				createdFileSHA = createdFile.GetSHA()
-				klog.Infoln("created file sha:", createdFileSHA)
+				GinkgoWriter.Println("created file sha:", createdFileSHA)
 			})
 
 			It("eventually leads to triggering another PipelineRun", func() {
@@ -234,7 +233,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				Eventually(func() bool {
 					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, createdFileSHA)
 					if err != nil {
-						klog.Infoln("PipelineRun has not been created yet")
+						GinkgoWriter.Println("PipelineRun has not been created yet")
 						return false
 					}
 					return pipelineRun.HasStarted()
@@ -249,7 +248,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, condition := range pipelineRun.Status.Conditions {
-						klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+						GinkgoWriter.Printf("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
 
 						if !pipelineRun.IsDone() {
 							return false
@@ -300,7 +299,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				}, time.Minute).Should(BeNil(), fmt.Sprintf("error when merging PaC pull request: %+v", err))
 
 				mergeResultSha = mergeResult.GetSHA()
-				klog.Infoln("merged result sha:", mergeResultSha)
+				GinkgoWriter.Println("merged result sha:", mergeResultSha)
 			})
 
 			It("eventually leads to triggering another PipelineRun", func() {
@@ -310,7 +309,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				Eventually(func() bool {
 					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, mergeResultSha)
 					if err != nil {
-						klog.Infoln("PipelineRun has not been created yet")
+						GinkgoWriter.Println("PipelineRun has not been created yet")
 						return false
 					}
 					return pipelineRun.HasStarted()
@@ -325,7 +324,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, condition := range pipelineRun.Status.Conditions {
-						klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+						GinkgoWriter.Printf("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
 
 						if !pipelineRun.IsDone() {
 							return false
@@ -439,7 +438,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				Eventually(func() bool {
 					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false, "")
 					if err != nil {
-						klog.Infoln("PipelineRun has not been created yet")
+						GinkgoWriter.Println("PipelineRun has not been created yet")
 						return false
 					}
 					return pipelineRun.HasStarted()
@@ -458,7 +457,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 					Expect(err).ShouldNot(HaveOccurred())
 
 					for _, condition := range pipelineRun.Status.Conditions {
-						klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+						GinkgoWriter.Printf("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
 
 						if !pipelineRun.IsDone() {
 							return false
@@ -664,7 +663,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			Eventually(func() bool {
 				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
 				if err != nil {
-					klog.Infoln("PipelineRun has not been created yet")
+					GinkgoWriter.Println("PipelineRun has not been created yet")
 					return false
 				}
 				return pipelineRun.HasStarted()
@@ -686,7 +685,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			Eventually(func() bool {
 				pipelineRun, err := f.HasController.GetComponentPipelineRun(notMatchingComponentName, applicationName, testNamespace, false, "")
 				if err != nil {
-					klog.Infoln("PipelineRun has not been created yet")
+					GinkgoWriter.Println("PipelineRun has not been created yet")
 					return false
 				}
 				return pipelineRun.HasStarted()
@@ -756,7 +755,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			Eventually(func() bool {
 				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
 				if err != nil {
-					klog.Infoln("PipelineRun has not been created yet")
+					GinkgoWriter.Println("PipelineRun has not been created yet")
 					return false
 				}
 				return pipelineRun.HasStarted()
@@ -782,7 +781,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				Expect(err).ShouldNot(HaveOccurred())
 
 				for _, condition := range pipelineRun.Status.Conditions {
-					klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+					GinkgoWriter.Printf("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
 					return condition.Reason == "Failed"
 				}
 				return false

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -344,21 +344,21 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 
 func printTaskRunStatus(tr *v1beta1.PipelineRunTaskRunStatus, namespace string, sc common.SuiteController) {
 	if tr.Status == nil {
-		GinkgoWriter.Printf("*** TaskRun status: nil")
+		GinkgoWriter.Println("*** TaskRun status: nil")
 		return
 	}
 
 	if y, err := yaml.Marshal(tr.Status); err == nil {
 		GinkgoWriter.Printf("*** TaskRun status:\n%s\n", string(y))
 	} else {
-		GinkgoWriter.Printf("*** Unable to serialize TaskRunStatus to YAML: %#v; error: %s", tr.Status, err)
+		GinkgoWriter.Printf("*** Unable to serialize TaskRunStatus to YAML: %#v; error: %s\n", tr.Status, err)
 	}
 
 	for _, s := range tr.Status.TaskRunStatusFields.Steps {
 		if logs, err := sc.GetContainerLogs(tr.Status.PodName, s.ContainerName, namespace); err == nil {
 			GinkgoWriter.Printf("*** Logs from pod '%s', container '%s':\n----- START -----%s----- END -----\n", tr.Status.PodName, s.ContainerName, logs)
 		} else {
-			GinkgoWriter.Printf("*** Can't fetch logs from pod '%s', container '%s': %s", tr.Status.PodName, s.ContainerName, err)
+			GinkgoWriter.Printf("*** Can't fetch logs from pod '%s', container '%s': %s\n", tr.Status.PodName, s.ContainerName, err)
 		}
 	}
 }

--- a/tests/e2e-demos/e2e-demo.go
+++ b/tests/e2e-demos/e2e-demo.go
@@ -21,7 +21,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -58,7 +57,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 	// Initialize the e2e demo configuration
 	configTestFile := viper.GetString("config-suites")
-	klog.Infof("Starting e2e-demo test suites from config: %s", configTestFile)
+	GinkgoWriter.Printf("Starting e2e-demo test suites from config: %s\n", configTestFile)
 
 	// Initialize the tests controllers
 	fw, err := framework.NewFramework()
@@ -72,8 +71,8 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 			var namespace = utils.GetGeneratedNamespace("e2e-demo")
 			BeforeAll(func() {
 				suiteConfig, _ := GinkgoConfiguration()
-				fmt.Printf("Parallel processes: %d", suiteConfig.ParallelTotal)
-				fmt.Printf("Running on namespace: %s", namespace)
+				GinkgoWriter.Printf("Parallel processes: %d\n", suiteConfig.ParallelTotal)
+				GinkgoWriter.Printf("Running on namespace: %s\n", namespace)
 				// Check to see if the github token was provided
 				Expect(utils.CheckIfEnvironmentExists(constants.GITHUB_TOKEN_ENV)).Should(BeTrue(), "%s environment variable is not set", constants.GITHUB_TOKEN_ENV)
 				// Check if 'has-github-token' is present, unless SKIP_HAS_SECRET_CHECK env var is set
@@ -96,7 +95,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 			// Create an application in a specific namespace
 			It("application is created", func() {
-				fmt.Printf("Parallel process %d", GinkgoParallelProcess())
+				GinkgoWriter.Printf("Parallel process %d\n", GinkgoParallelProcess())
 				createdApplication, err := fw.HasController.CreateHasApplication(appTest.ApplicationName, namespace)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(createdApplication.Spec.DisplayName).To(Equal(appTest.ApplicationName))
@@ -221,7 +220,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 							return false
 						}
 						if deployment.Status.AvailableReplicas == 1 {
-							klog.Infof("Deployment %s is ready", deployment.Name)
+							GinkgoWriter.Printf("Deployment %s is ready\n", deployment.Name)
 							return true
 						}
 
@@ -236,7 +235,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 						Expect(err).NotTo(HaveOccurred())
 						err = fw.GitOpsController.CheckGitOpsEndpoint(gitOpsRoute, componentTest.HealthEndpoint)
 						if err != nil {
-							klog.Info("Failed to request component endpoint. retrying...")
+							GinkgoWriter.Println("Failed to request component endpoint. retrying...")
 						}
 						return true
 					}, 5*time.Minute, 10*time.Second).Should(BeTrue())
@@ -255,7 +254,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 								return false
 							}
 							if deployment.Status.AvailableReplicas == *componentTest.K8sSpec.Replicas {
-								klog.Infof("Replicas scaled to %s ", componentTest.K8sSpec.Replicas)
+								GinkgoWriter.Printf("Replicas scaled to %s\n", componentTest.K8sSpec.Replicas)
 								return true
 							}
 

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -14,7 +14,6 @@ import (
 
 	appstudioApi "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
-	klog "k8s.io/klog/v2"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -69,7 +68,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			defaultBundleConfigMap, err = f.CommonController.GetConfigMap(constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace)
 			if err != nil {
 				if errors.IsForbidden(err) {
-					klog.Infof("don't have enough permissions to get a configmap with default pipeline in %s namespace\n", constants.BuildPipelinesConfigMapDefaultNamespace)
+					GinkgoWriter.Printf("don't have enough permissions to get a configmap with default pipeline in %s namespace\n", constants.BuildPipelinesConfigMapDefaultNamespace)
 				} else {
 					Fail(fmt.Sprintf("error occurred when trying to get configmap %s in %s namespace: %v", constants.BuildPipelinesConfigMapName, constants.BuildPipelinesConfigMapDefaultNamespace, err))
 				}
@@ -99,7 +98,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			Eventually(func() bool {
 				pipelineRun, err := f.IntegrationController.GetBuildPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false, "")
 				if err != nil {
-					klog.Infoln("PipelineRun has not been created yet")
+					GinkgoWriter.Println("PipelineRun has not been created yet")
 					return false
 				}
 				return pipelineRun.HasStarted()
@@ -111,7 +110,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				Expect(err).ShouldNot(HaveOccurred())
 
 				for _, condition := range pipelineRun.Status.Conditions {
-					klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+					GinkgoWriter.Printf("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
 
 					if condition.Reason == "Failed" {
 						Fail(fmt.Sprintf("Pipelinerun %s has failed", pipelineRun.Name))
@@ -127,7 +126,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				// snapshotName is sent as empty since it is unknown at this stage
 				applicationSnapshot, err = f.IntegrationController.GetApplicationSnapshot("", applicationName, appStudioE2EApplicationsNamespace, componentName)
 				Expect(err).ShouldNot(HaveOccurred())
-				klog.Infof("applicationSnapshot %s is found", applicationSnapshot.Name)
+				GinkgoWriter.Printf("applicationSnapshot %s is found\n", applicationSnapshot.Name)
 			})
 			It("check if all of the integrationPipelineRuns passed", Label("slow"), func() {
 				integrationTestScenarios, err := f.IntegrationController.GetIntegrationTestScenarios(applicationName, appStudioE2EApplicationsNamespace)
@@ -138,7 +137,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 					Eventually(func() bool {
 						pipelineRun, err := f.IntegrationController.GetIntegrationPipelineRun(testScenario.Name, applicationSnapshot.Name, appStudioE2EApplicationsNamespace)
 						if err != nil {
-							klog.Infof("cannot get the Integration PipelineRun: %v", err)
+							GinkgoWriter.Printf("cannot get the Integration PipelineRun: %v\n", err)
 							return false
 						}
 						return pipelineRun.HasStarted()
@@ -161,14 +160,14 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			testScenarios, err := f.IntegrationController.GetIntegrationTestScenarios(applicationName, appStudioE2EApplicationsNamespace)
 			Expect(err).ShouldNot(HaveOccurred())
 			for _, testScenario := range *testScenarios {
-				klog.Infof("IntegrationTestScenario %s is found", testScenario.Name)
+				GinkgoWriter.Printf("IntegrationTestScenario %s is found\n", testScenario.Name)
 			}
 		})
 
 		It("create an applicationSnapshot of push event", func() {
 			applicationSnapshot_push, err = f.IntegrationController.CreateApplicationSnapshot(applicationName, appStudioE2EApplicationsNamespace, componentName)
 			Expect(err).ShouldNot(HaveOccurred())
-			klog.Infof("applicationSnapshot %s is found", applicationSnapshot_push.Name)
+			GinkgoWriter.Printf("applicationSnapshot %s is found\n", applicationSnapshot_push.Name)
 		})
 
 		When("An applicationSnapshot of push event is created", func() {
@@ -182,7 +181,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 					Eventually(func() bool {
 						pipelineRun, err := f.IntegrationController.GetIntegrationPipelineRun(testScenario.Name, applicationSnapshot_push.Name, appStudioE2EApplicationsNamespace)
 						if err != nil {
-							klog.Infof("cannot get the Integration PipelineRun: %v", err)
+							GinkgoWriter.Printf("cannot get the Integration PipelineRun: %v\n", err)
 							return false
 						}
 						return pipelineRun.HasStarted()
@@ -195,7 +194,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 						Expect(err).ShouldNot(HaveOccurred())
 
 						for _, condition := range pipelineRun.Status.Conditions {
-							klog.Infof("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
+							GinkgoWriter.Printf("PipelineRun %s Status.Conditions.Reason: %s\n", pipelineRun.Name, condition.Reason)
 							if condition.Reason == "Failed" {
 								Fail(fmt.Sprintf("Pipelinerun %s has failed", pipelineRun.Name))
 							}
@@ -212,7 +211,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 					if f.IntegrationController.HaveHACBSTestsSucceeded(applicationSnapshot_push) {
 						component, _ := f.IntegrationController.GetComponent(applicationName, appStudioE2EApplicationsNamespace)
 						Expect(component.Spec.ContainerImage != "").To(BeTrue())
-						klog.Infof("Global candidate is updated\n")
+						GinkgoWriter.Printf("Global candidate is updated\n")
 						return true
 					}
 					applicationSnapshot_push, err = f.IntegrationController.GetApplicationSnapshot(applicationSnapshot_push.Name, "", appStudioE2EApplicationsNamespace, "")
@@ -229,7 +228,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 						Expect(err).ShouldNot(HaveOccurred())
 						if len(*releases) != 0 {
 							for _, release := range *releases {
-								klog.Infof("Release %s is found\n", release.Name)
+								GinkgoWriter.Printf("Release %s is found\n", release.Name)
 							}
 						} else {
 							Fail("No Release found")
@@ -249,7 +248,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 						envbinding, err := f.IntegrationController.GetSnapshotEnvironmentBinding(applicationName, appStudioE2EApplicationsNamespace, env)
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(envbinding != nil).To(BeTrue())
-						klog.Infof("The EnvironmentBinding is created\n")
+						GinkgoWriter.Printf("The EnvironmentBinding is created\n")
 						return true
 					}
 					applicationSnapshot_push, err = f.IntegrationController.GetApplicationSnapshot(applicationSnapshot_push.Name, "", appStudioE2EApplicationsNamespace, "")

--- a/tests/release/release.go
+++ b/tests/release/release.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	klog "k8s.io/klog/v2"
 	"knative.dev/pkg/apis"
 )
 
@@ -40,15 +39,15 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1108]test-release-service-happy-p
 		// Create the dev namespace
 		_, err := framework.CommonController.CreateTestNamespace(devNamespace)
 		Expect(err).NotTo(HaveOccurred(), "Error when creating namespace '%s': %v", devNamespace, err)
-		klog.Info("Dev Namespace :", devNamespace)
+		GinkgoWriter.Println("Dev Namespace :", devNamespace)
 
 		// Create the managed namespace
 		_, err = framework.CommonController.CreateTestNamespace(managedNamespace)
 		Expect(err).NotTo(HaveOccurred(), "Error when creating namespace '%s': %v", managedNamespace, err)
-		klog.Info("Managed Namespace :", managedNamespace)
+		GinkgoWriter.Println("Managed Namespace :", managedNamespace)
 
 		// Wait until the "pipeline" SA is created and ready with secrets by the openshift-pipelines operator
-		klog.Infof("Wait until the 'pipeline' SA is created in %s namespace \n", managedNamespace)
+		GinkgoWriter.Printf("Wait until the 'pipeline' SA is created in %s namespace \n", managedNamespace)
 		Eventually(func() bool {
 			sa, err := framework.CommonController.GetServiceAccount(serviceAccount, managedNamespace)
 			return sa != nil && err == nil
@@ -120,7 +119,7 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1108]test-release-service-happy-p
 			Eventually(func() bool {
 				prList, err := framework.TektonController.ListAllPipelineRuns(managedNamespace)
 				if err != nil || prList == nil || len(prList.Items) < 1 {
-					klog.Error(err)
+					GinkgoWriter.Println(err)
 					return false
 				}
 
@@ -132,7 +131,7 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1108]test-release-service-happy-p
 			Eventually(func() bool {
 				prList, err := framework.TektonController.ListAllPipelineRuns(managedNamespace)
 				if prList == nil || err != nil || len(prList.Items) < 1 {
-					klog.Error(err)
+					GinkgoWriter.Println(err)
 					return false
 				}
 
@@ -165,7 +164,7 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1108]test-release-service-happy-p
 
 			release, err := framework.ReleaseController.GetRelease(releaseName, devNamespace)
 			if err != nil {
-				klog.Error(err)
+				GinkgoWriter.Println(err)
 			}
 			Expect(release.Status.ReleasePipelineRun == (fmt.Sprintf("%s/%s", pipelineRunList.Items[0].Namespace, pipelineRunList.Items[0].Name))).Should(BeTrue())
 			// We add the namespace deletion timeout as this is the last test so must also take into account the code in AfterAll


### PR DESCRIPTION
Gikngo should display the output accumulated in `GinkgoWriter` when a scenario fails, otherwise the output is quite verbose and displayed for both failing and succeeding scenarios.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
