### PR TITLE
feat: e2e-demo print deployment when failed to deploy

### DIFF
--- a/tests/e2e-demos/e2e-demo.go
+++ b/tests/e2e-demos/e2e-demo.go
@@ -17,6 +17,7 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/tests/e2e-demos/config"
 	e2eConfig "github.com/redhat-appstudio/e2e-tests/tests/e2e-demos/config"
 	"github.com/spf13/viper"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -213,9 +214,9 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 				// Deploy the component using gitops and check for the health
 				It(fmt.Sprintf("deploy component %s using gitops", componentTest.Name), func() {
-
+					var deployment *appsv1.Deployment
 					Eventually(func() bool {
-						deployment, err := fw.CommonController.GetAppDeploymentByName(componentTest.Name, namespace)
+						deployment, err = fw.CommonController.GetAppDeploymentByName(componentTest.Name, namespace)
 						if err != nil && !errors.IsNotFound(err) {
 							return false
 						}
@@ -225,7 +226,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 						}
 
 						return false
-					}, 25*time.Minute, 10*time.Second).Should(BeTrue(), "Component deployment didn't become ready")
+					}, 25*time.Minute, 10*time.Second).Should(BeTrue(), fmt.Sprintf("Component deployment didn't become ready: %+v", deployment))
 					Expect(err).NotTo(HaveOccurred())
 				})
 


### PR DESCRIPTION
Print deployment in output when it did not become ready in time.

Related to https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/redhat-appstudio_infra-deployments/1149/pull-ci-redhat-appstudio-infra-deployments-main-appstudio-e2e-tests/1613653821949480960 where deployment timeouted and it's not possible to see what happened.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
