### PR TITLE
fix: sync timeouts of component ready and print component

### DIFF
--- a/pkg/utils/has/controller.go
+++ b/pkg/utils/has/controller.go
@@ -196,7 +196,7 @@ func (h *SuiteController) CreateComponent(applicationName, componentName, namesp
 		return nil, err
 	}
 	if err = utils.WaitUntil(h.ComponentReady(component), time.Minute*2); err != nil {
-		return nil, fmt.Errorf("timed out when waiting for component %s to be ready in %s namespace: %+v", componentName, namespace, err)
+		return nil, fmt.Errorf("timed out when waiting for component %s to be ready in %s namespace: %+v, component: %+v", componentName, namespace, component, err)
 	}
 	return component, nil
 }
@@ -250,8 +250,8 @@ func (h *SuiteController) CreateComponentWithPaCEnabled(applicationName, compone
 	if err != nil {
 		return nil, err
 	}
-	if err = utils.WaitUntil(h.ComponentReady(component), time.Second*30); err != nil {
-		return nil, fmt.Errorf("timed out when waiting for component %s to be ready in %s namespace: %+v", componentName, namespace, err)
+	if err = utils.WaitUntil(h.ComponentReady(component), time.Minute*2); err != nil {
+		return nil, fmt.Errorf("timed out when waiting for component %s to be ready in %s namespace: %+v, component: %+v", componentName, namespace, component, err)
 	}
 	return component, nil
 }
@@ -275,8 +275,8 @@ func (h *SuiteController) CreateComponentFromStub(compDetected appservice.Compon
 	if err != nil {
 		return nil, err
 	}
-	if err = utils.WaitUntil(h.ComponentReady(component), time.Second*30); err != nil {
-		return nil, fmt.Errorf("timed out when waiting for component %s to be ready in %s namespace: %+v", componentName, namespace, err)
+	if err = utils.WaitUntil(h.ComponentReady(component), time.Minute*2); err != nil {
+		return nil, fmt.Errorf("timed out when waiting for component %s to be ready in %s namespace: %+v, component: %+v", componentName, namespace, component, err)
 	}
 	return component, nil
 }
@@ -457,8 +457,8 @@ func (h *SuiteController) CreateComponentFromDevfile(applicationName, componentN
 	if err != nil {
 		return nil, err
 	}
-	if err = utils.WaitUntil(h.ComponentReady(component), time.Second*30); err != nil {
-		return nil, fmt.Errorf("timed out when waiting for component %s to be ready in %s namespace: %+v", componentName, namespace, err)
+	if err = utils.WaitUntil(h.ComponentReady(component), time.Minute*2); err != nil {
+		return nil, fmt.Errorf("timed out when waiting for component %s to be ready in %s namespace: %+v, component: %+v", componentName, namespace, component, err)
 	}
 	return component, nil
 }


### PR DESCRIPTION
Set timeout to 2 minutes for all component ready checks.

Print component in the timeout message.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
