### PR TITLE
fix: use unique base branch in PaC build test

### DIFF
--- a/pkg/apis/github/git.go
+++ b/pkg/apis/github/git.go
@@ -3,12 +3,29 @@ package github
 import (
 	"context"
 	"fmt"
+	"github.com/google/go-github/v44/github"
 )
 
 func (g *Github) DeleteRef(repository, branchName string) error {
 	_, err := g.client.Git.DeleteRef(context.Background(), g.organization, repository, fmt.Sprintf("heads/%s", branchName))
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+// CreateRef creates a new ref (GitHub branch) in a specified GitHub repository,
+// that will be based on the latest commit from a specified branch name
+func (g *Github) CreateRef(repository, baseBranchName, newBranchName string) error {
+	ctx := context.Background()
+	ref, _, err := g.client.Git.GetRef(ctx, g.organization, repository, fmt.Sprintf("heads/%s", baseBranchName))
+	if err != nil {
+		return fmt.Errorf("error when getting the base branch name '%s' for the repo '%s': %+v", baseBranchName, repository, err)
+	}
+	ref.Ref = github.String(fmt.Sprintf("heads/%s", newBranchName))
+	_, _, err = g.client.Git.CreateRef(ctx, g.organization, repository, ref)
+	if err != nil {
+		return fmt.Errorf("error when creating a new branch '%s' for the repo '%s': %+v", newBranchName, repository, err)
 	}
 	return nil
 }

--- a/pkg/utils/has/controller.go
+++ b/pkg/utils/has/controller.go
@@ -224,7 +224,7 @@ func (h *SuiteController) ComponentDeleted(component *appservice.Component) wait
 }
 
 // CreateComponentWithPaCEnabled creates a component with "pipelinesascode: '1'" annotation that is used for triggering PaC builds
-func (h *SuiteController) CreateComponentWithPaCEnabled(applicationName, componentName, namespace, gitSourceURL, outputContainerImage string) (*appservice.Component, error) {
+func (h *SuiteController) CreateComponentWithPaCEnabled(applicationName, componentName, namespace, gitSourceURL, baseBranch, outputContainerImage string) (*appservice.Component, error) {
 	component := &appservice.Component{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
@@ -239,7 +239,8 @@ func (h *SuiteController) CreateComponentWithPaCEnabled(applicationName, compone
 			Source: appservice.ComponentSource{
 				ComponentSourceUnion: appservice.ComponentSourceUnion{
 					GitSource: &appservice.GitSource{
-						URL: gitSourceURL,
+						URL:      gitSourceURL,
+						Revision: baseBranch,
 					},
 				},
 			},

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -41,7 +41,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 	// Initialize the tests controllers
 	f, err := framework.NewFramework()
 	Expect(err).NotTo(HaveOccurred())
-	Describe("the component with git source (GitHub) is created", Ordered, Label("github-webhook"), func() {
+	Describe("the component with git source (GitHub) is created", Ordered, func() {
 		BeforeAll(func() {
 			applicationName = fmt.Sprintf("integ-app-%s", util.GenerateRandomString(4))
 			appStudioE2EApplicationsNamespace = utils.GetGeneratedNamespace("integ-e2e")


### PR DESCRIPTION
# Description

Improved PaC build test to use unique branch as a base branch for PaC pull requests. Since every test instance will work with a unique branch, it should eliminate the issue seen in CI when 2 or more CI jobs could have affect each other by merging to the same (`main`) branch.
See [this discussion](https://redhat-internal.slack.com/archives/C02FANRBZQD/p1673527525131399?thread_ts=1673428220.340109&cid=C02FANRBZQD) for more info

Changes in this test depend on [these changes in build-service](https://github.com/redhat-appstudio/build-service/pull/100) being merged to infra-deployments

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
