### PR TITLE
fix: improve PR pairing

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -301,15 +301,16 @@ func BootstrapCluster() error {
 }
 
 func (CI) isPRPairingRequired() bool {
-	var ghBranches []GithubBranch
-	url := fmt.Sprintf("https://api.github.com/repos/%s/e2e-tests/branches", pr.RemoteName)
-	if err := sendHttpRequestAndParseResponse(url, "GET", &ghBranches); err != nil {
+	var pullRequests []gh.PullRequest
+
+	url := "https://api.github.com/repos/redhat-appstudio/e2e-tests/pulls?per_page=100"
+	if err := sendHttpRequestAndParseResponse(url, "GET", &pullRequests); err != nil {
 		klog.Infof("cannot determine e2e-tests Github branches for author %s: %v. will stick with the redhat-appstudio/e2e-tests main branch for running tests", pr.Author, err)
 		return false
 	}
 
-	for _, b := range ghBranches {
-		if b.Name == pr.BranchName {
+	for _, pull := range pullRequests {
+		if pull.GetHead().GetRef() == pr.BranchName && pull.GetUser().GetLogin() == pr.RemoteName {
 			return true
 		}
 	}

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -60,19 +60,19 @@ func sendHttpRequestAndParseResponse(url, method string, v interface{}) error {
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("token %s", os.Getenv("GITHUB_TOKEN")))
 	res, err := http.DefaultClient.Do(req)
-	klog.Infof("request statuscode %s, error: %v", res.StatusCode, err)
+	klog.Infof("response status code: '%d'", res.StatusCode)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error when sending request to '%s': %+v", url, err)
 	}
 	defer res.Body.Close()
 	body, err := io.ReadAll(res.Body)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error when reading the response body from URL '%s': %+v", url, err)
 	}
 	if err := json.Unmarshal(body, v); err != nil {
-		return err
+		return fmt.Errorf("error when unmarshalling the response body from URL '%s': %+v", url, err)
 	}
 
 	return nil


### PR DESCRIPTION
# Description

PR pairing was not working in case an author had more than 30 branches in e2e-tests repo fork ([see the default `per_page` value for listing branches](https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#list-branches))

With this change we are requesting the list of PRs in e2e-tests repo (instead of author's e2e-tests repo branches) during PR pairing with the limit of 100 PRs (which should be usually sufficient)

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested locally with the openshift-ci metadata from the PR in infra-deployments (where this issue was spotted):
```bash
export JOB_SPEC='{"type":"presubmit","job":"pull-ci-redhat-appstudio-infra-deployments-main-appstudio-e2e-tests","buildid":"1614921393185492992","prowjobid":"4cd242da-9582-11ed-9f4d-0a580a812ae0","refs":{"org":"redhat-appstudio","repo":"infra-deployments","repo_link":"https://github.com/redhat-appstudio/infra-deployments","base_ref":"main","base_sha":"7b57b383e881a851ab31cfd4db884c22007e3a1f","base_link":"https://github.com/redhat-appstudio/infra-deployments/commit/7b57b383e881a851ab31cfd4db884c22007e3a1f","pulls":[{"number":1154,"author":"psturc","sha":"4205a0994f8b06739e32ffa12fd59afa7f7b750f","title":"build-service update","link":"https://github.com/redhat-appstudio/infra-deployments/pull/1154","commit_link":"https://github.com/redhat-appstudio/infra-deployments/pull/1154/commits/4205a0994f8b06739e32ffa12fd59afa7f7b750f","author_link":"https://github.com/psturc"}]},"decoration_config":{"timeout":"4h0m0s","grace_period":"1h0m0s","utility_images":{"clonerefs":"gcr.io/k8s-prow/clonerefs:v20230113-8f2ffbe0d4","initupload":"gcr.io/k8s-prow/initupload:v20230113-8f2ffbe0d4","entrypoint":"gcr.io/k8s-prow/entrypoint:v20230113-8f2ffbe0d4","sidecar":"gcr.io/k8s-prow/sidecar:v20230113-8f2ffbe0d4"},"resources":{"clonerefs":{"limits":{"memory":"3Gi"},"requests":{"cpu":"100m","memory":"500Mi"}},"initupload":{"limits":{"memory":"200Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"place_entrypoint":{"limits":{"memory":"100Mi"},"requests":{"cpu":"100m","memory":"25Mi"}},"sidecar":{"limits":{"memory":"2Gi"},"requests":{"cpu":"100m","memory":"250Mi"}}},"gcs_configuration":{"bucket":"origin-ci-test","path_strategy":"single","default_org":"openshift","default_repo":"origin","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"gce-sa-credentials-gcs-publisher","skip_cloning":true,"censor_secrets":true}}'
export GITHUB_TOKEN=$APPSTUDIO_GITHUB_TOKEN QUAY_TOKEN=$(base64 < ~/.docker/config.json) MY_GITHUB_ORG=<MY_GH_ORG> QUAY_E2E_ORGANIZATION=<MY_QUAY_ORG>
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
