### PR TITLE
fix: user kubeconfig should be generated by k8s client not mage files

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -192,9 +192,6 @@ func (ci CI) TestE2E() error {
 	if err := RegisterUser(); err != nil {
 		return fmt.Errorf("error when registerin user via toolchain operators: %v", err)
 	}
-	if err := GenerateUserKubeconfig(); err != nil {
-		return fmt.Errorf("error while generating user's kubeconfig file: %v", err)
-	}
 
 	if err := RunE2ETests(); err != nil {
 		testFailure = true


### PR DESCRIPTION
# Description

Generation of kubeconfig should be happen in k8s client. This will be handle by https://github.com/redhat-appstudio/e2e-tests/pull/296

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
