### PR TITLE
fix(STONE-336): refactored e2e-demos.go to use integration service for Snapshot and SnapshotEnvironmentBinding creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is recommended to install AppStudio in E2E mode, but the E2E suite can be als
 * Ability to run the test suites separately.
 
 # Running the tests
-Whnen you want to run the E2E tests for AppStudio you need to have installed tools(in Requirements chapter), installed the AppStudio in E2E mode and compiled `e2e-appstudio` binary.
+When you want to run the E2E tests for AppStudio you need to have installed tools(in Requirements chapter), installed the AppStudio in E2E mode and compiled `e2e-appstudio` binary.
 
 ## Requirements
 Requirements for installing AppStudio in E2E mode and running the E2E tests:

--- a/docs/DeveloperGenerateTest.md
+++ b/docs/DeveloperGenerateTest.md
@@ -61,7 +61,7 @@ var _ = framework.ChaosSuiteDescribe("Chaos tests", Label("Chaos"), func() {
 
 		})
 
-		It("Chaos does some test action", func() {
+		It("chaos does some test action", func() {
 
 			// Implement test and assertions here
 
@@ -86,4 +86,4 @@ var _ = framework.ChaosSuiteDescribe("Chaos tests", Label("Chaos"), func() {
 
 This command will help setup a test suite file within the `cmd/` directory. It will do the test package import based on the value of `TEMPLATE_SUITE_PACKAGE_NAME`. So using the example above it will assume there is a `tests/chaos` package to import as well. It uses a simplified version of the `cmd/e2e_test.go` as a template to allow you to leverage the existing functionality built into the framework like webhooks eventing and Polarion formatted XML test case generation. Edit this file as you feel necessary.
 
-NOTE: You may not need to generate this file. This is useful when you want to move a type of testing into a separate suite that wouldn't go into the existing e2e test suite package. i.e. chaos testing. We have a current exmaple with the existing `cmd/loadsTest.go` which are used the run the AppStudio Load tests.
+NOTE: You may not need to generate this file. This is useful when you want to move a type of testing into a separate suite that wouldn't go into the existing e2e test suite package. i.e. chaos testing. We have a current example with the existing `cmd/loadsTest.go` which are used the run the AppStudio Load tests.

--- a/docs/LoadTests.md
+++ b/docs/LoadTests.md
@@ -29,5 +29,5 @@ The Script works in Steps
 - Creating the Component will start the pipelines , if the `-w` flag is given it will wait for the pipelines to finish then print results 
 - Then after the tests are completed it will dump the results / stats , on error the stats will still get dumped along with the trace
 
-## How to contrubute 
+## How to contribute
 Just edit the file `cmd/loadTests.go` 

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	k8s.io/apimachinery v0.26.0
 	k8s.io/cli-runtime v0.24.3
 	k8s.io/client-go v0.25.4
-	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.80.1
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	knative.dev/pkg v0.0.0-20221011175852-714b7630a836
@@ -234,6 +233,7 @@ require (
 	gotest.tools/v3 v3.3.0 // indirect
 	k8s.io/apiextensions-apiserver v0.25.2 // indirect
 	k8s.io/component-base v0.25.2 // indirect
+	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	k8s.io/kubectl v0.24.1 // indirect
 	k8s.io/metrics v0.24.1 // indirect

--- a/magefiles/installation/install.go
+++ b/magefiles/installation/install.go
@@ -15,7 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 const (

--- a/magefiles/installation/oauth.go
+++ b/magefiles/installation/oauth.go
@@ -13,7 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -143,7 +143,7 @@ func (Local) CleanupGithubOrg() error {
 		// Add only repos older than 24 hours
 		dayDuration, _ := time.ParseDuration("24h")
 		if time.Since(repo.GetCreatedAt().Time) > dayDuration {
-			// Add only repos machting the regex
+			// Add only repos matching the regex
 			if r.MatchString(*repo.Name) {
 				reposToDelete = append(reposToDelete, repo)
 			}
@@ -190,7 +190,7 @@ func (ci CI) TestE2E() error {
 		return fmt.Errorf("error when bootstrapping cluster: %v", err)
 	}
 	if err := RegisterUser(); err != nil {
-		return fmt.Errorf("error when registerin user via toolchain operators: %v", err)
+		return fmt.Errorf("error when registering user via toolchain operators: %v", err)
 	}
 	if err := GenerateUserKubeconfig(); err != nil {
 		return fmt.Errorf("error while generating user's kubeconfig file: %v", err)
@@ -481,7 +481,7 @@ func (Local) GenerateTestSpecFile() error {
 
 }
 
-// Creates preapproved userSignup CR cluster and waits for its reconcilliation
+// Creates preapproved userSignup CR cluster and waits for its reconciliation
 func RegisterUser() error {
 	kubeClient, err := client.NewK8SClient()
 	if err != nil {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -14,7 +14,7 @@ const (
 	// The quay.io username to perform container builds and puush
 	QUAY_OAUTH_USER_ENV string = "QUAY_OAUTH_USER" // #nosec
 
-	// The quay.io token to perform container builds and puush. The token must be corelated with the QUAY_OAUTH_USER environment
+	// The quay.io token to perform container builds and push. The token must be correlated with the QUAY_OAUTH_USER environment
 	QUAY_OAUTH_TOKEN_ENV string = "QUAY_OAUTH_TOKEN" // #nosec
 
 	// The private devfile sample git repository to use in certain HAS e2e tests

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -16,13 +16,13 @@ import (
 
 // Framework struct to store all controllers
 type Framework struct {
-	HasController     *has.SuiteController
-	CommonController  *common.SuiteController
-	TektonController  *tekton.SuiteController
-	GitOpsController  *gitops.SuiteController
-	SPIController     *spi.SuiteController
-	ReleaseController *release.SuiteController
-	IntegrationController *integration.SuiteController
+	HasController             *has.SuiteController
+	CommonController          *common.SuiteController
+	TektonController          *tekton.SuiteController
+	GitOpsController          *gitops.SuiteController
+	SPIController             *spi.SuiteController
+	ReleaseController         *release.SuiteController
+	IntegrationController     *integration.SuiteController
 	JvmbuildserviceController *jvmbuildservice.SuiteController
 }
 
@@ -83,13 +83,13 @@ func NewFramework() (*Framework, error) {
 	}
 
 	return &Framework{
-		CommonController:  commonCtrl,
-		HasController:     hasController,
-		TektonController:  tektonController,
-		GitOpsController:  gitopsController,
-		SPIController:     spiController,
-		ReleaseController: releaseController,
-		IntegrationController: integrationController,
+		CommonController:          commonCtrl,
+		HasController:             hasController,
+		TektonController:          tektonController,
+		GitOpsController:          gitopsController,
+		SPIController:             spiController,
+		ReleaseController:         releaseController,
+		IntegrationController:     integrationController,
 		JvmbuildserviceController: jvmbuildserviceController,
 	}, nil
 }

--- a/pkg/utils/release/controller.go
+++ b/pkg/utils/release/controller.go
@@ -178,7 +178,7 @@ func (s *SuiteController) GetReleasePlan(name, namespace string) (*appstudiov1al
 	return releasePlan, err
 }
 
-// DeletetReleasePlan deletes a given ReleasePlan name in given namespace.
+// DeleteReleasePlan deletes a given ReleasePlan name in given namespace.
 func (s *SuiteController) DeleteReleasePlan(name, namespace string, failOnNotFound bool) error {
 	releasePlan := &appstudiov1alpha1.ReleasePlan{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/utils/tekton/controller.go
+++ b/pkg/utils/tekton/controller.go
@@ -403,7 +403,7 @@ func findCosignResultsForImage(imageRef string, client crclient.Client) (*Cosign
 
 	if attestationTag, err := findTagWithName(client, namespace, cosignImagePrefix+".att"); err == nil {
 		// we want two layers, one for TaskRun and one for PipelineRun
-		// attestations, i.e. that the Chains controller reconcilled both and
+		// attestations, i.e. that the Chains controller reconciled both and
 		// uploaded them as layers
 		img, ok := attestationTag.Object["image"]
 		if ok {

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -326,7 +326,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 					return pipelineRun.HasStarted()
 				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
 			})
-			It("PipelineRun should eventually finish", func() {
+			It("pipelineRun should eventually finish", func() {
 				timeout = time.Minute * 5
 				interval = time.Second * 10
 
@@ -430,7 +430,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			// Do cleanup only in case the test succeeded
 			if !CurrentSpecReport().Failed() {
 				// Clean up only Application CR (Component and Pipelines are included) in case we are targeting specific namespace
-				// Used e.g. in build-defintions e2e tests, where we are targeting build-templates-e2e namespace
+				// Used e.g. in build-definitions e2e tests, where we are targeting build-templates-e2e namespace
 				if os.Getenv(constants.E2E_APPLICATIONS_NAMESPACE_ENV) != "" {
 					DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace, false)
 				} else {

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -30,27 +30,27 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 	})
 
 	Context("infrastructure is running", func() {
-		It("verify the chains controller is running", func() {
+		It("verifies if the chains controller is running", func() {
 			err := fwk.CommonController.WaitForPodSelector(fwk.CommonController.IsPodRunning, constants.TEKTON_CHAINS_NS, "app", "tekton-chains-controller", 60, 100)
 			Expect(err).NotTo(HaveOccurred())
 		})
-		It("verify the correct secrets have been created", func() {
+		It("verifies if the correct secrets have been created", func() {
 			_, err := fwk.CommonController.GetSecret(constants.TEKTON_CHAINS_NS, "chains-ca-cert")
 			Expect(err).NotTo(HaveOccurred())
 		})
-		It("verify the correct roles are created", func() {
+		It("verifies if the correct roles are created", func() {
 			_, csaErr := fwk.CommonController.GetRole("chains-secret-admin", constants.TEKTON_CHAINS_NS)
 			Expect(csaErr).NotTo(HaveOccurred())
 			_, srErr := fwk.CommonController.GetRole("secret-reader", "openshift-ingress-operator")
 			Expect(srErr).NotTo(HaveOccurred())
 		})
-		It("verify the correct rolebindings are created", func() {
+		It("verifies if the correct rolebindings are created", func() {
 			_, csaErr := fwk.CommonController.GetRoleBinding("chains-secret-admin", constants.TEKTON_CHAINS_NS)
 			Expect(csaErr).NotTo(HaveOccurred())
 			_, csrErr := fwk.CommonController.GetRoleBinding("chains-secret-reader", "openshift-ingress-operator")
 			Expect(csrErr).NotTo(HaveOccurred())
 		})
-		It("verify the correct service account is created", func() {
+		It("verifies if the correct service account is created", func() {
 			_, err := fwk.CommonController.GetServiceAccount("chains-secrets-admin", constants.TEKTON_CHAINS_NS)
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/tests/cluster-registration/README.md
+++ b/tests/cluster-registration/README.md
@@ -1,4 +1,4 @@
-# Cluser Registration
+# Cluster Registration
 
 Contains E2E tests related with [Cluster Registration Operator](https://github.com/stolostron/cluster-registration-operator).
 

--- a/tests/cluster-registration/clusters.go
+++ b/tests/cluster-registration/clusters.go
@@ -15,19 +15,19 @@ var _ = framework.ClusterRegistrationSuiteDescribe("Cluster Registration E2E tes
 	Expect(err).NotTo(HaveOccurred())
 
 	g.Context("infrastructure is running", func() {
-		g.It("verify the cluster-registration-installer-controller-manager is running", func() {
+		g.It("verifies if the cluster-registration-installer-controller-manager is running", func() {
 			err := framework.CommonController.WaitForPodSelector(framework.CommonController.IsPodRunning, constants.CLUSTER_REG_NS, "cluster-registration-antiaffinity-selector", "cluster-registration-installer-controller", 60, 100)
 			Expect(err).NotTo(HaveOccurred())
 		})
-		g.It("verify the correct roles are created", func() {
+		g.It("verifies if the correct roles are created", func() {
 			_, csaErr := framework.CommonController.GetRole("cluster-registration-installer-leader-election-role", constants.CLUSTER_REG_NS)
 			Expect(csaErr).NotTo(HaveOccurred())
 		})
-		g.It("verify the correct rolebindings are created", func() {
+		g.It("verifies if the correct rolebindings are created", func() {
 			_, csaErr := framework.CommonController.GetRoleBinding("cluster-registration-installer-leader-election-rolebinding", constants.CLUSTER_REG_NS)
 			Expect(csaErr).NotTo(HaveOccurred())
 		})
-		g.It("verify the correct service account is created", func() {
+		g.It("verifies if the correct service account is created", func() {
 			_, err := framework.CommonController.GetServiceAccount("cluster-registration-installer-controller-manager", constants.CLUSTER_REG_NS)
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/tests/e2e-demos/config/types.go
+++ b/tests/e2e-demos/config/types.go
@@ -33,7 +33,7 @@ type ComponentSpec struct {
 	// The component name which will be created
 	Name string `yaml:"name"`
 
-	// The type indicate if the component comes from a private source like quay or github. Posible values: "private" or "public"
+	// The type indicate if the component comes from a private source like quay or github. Possible values: "private" or "public"
 	Type string `yaml:"type"`
 
 	// Indicate the container value

--- a/tests/e2e-demos/e2e-demo.go
+++ b/tests/e2e-demos/e2e-demo.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/devfile/library/pkg/util"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,25 +34,18 @@ const (
 
 	// GitOps repository branch to use
 	GitOpsRepositoryRevision string = "main"
-
-	// Name for the Environment resource
-	EnvironmentName string = "environment-e2e"
-
-	// Name for the Snapshot resource
-	SnapshotName string = "snapshot-e2e"
-
-	// Name for the SnapshotEnvironmentBinding resource
-	SnapshotEnvironmentBindingName string = "snapshot-environment-binding-e2e"
 )
 
 var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 	defer GinkgoRecover()
 	var outputContainerImage = ""
+	var timeout, interval time.Duration
 
 	// Initialize the application struct
 	application := &appservice.Application{}
 	component := &appservice.Component{}
 	snapshot := &appservice.Snapshot{}
+	env := &appservice.Environment{}
 
 	// Initialize the e2e demo configuration
 	configTestFile := viper.GetString("config-suites")
@@ -100,7 +92,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 			})
 
 			// Create an application in a specific namespace
-			It("application is created", func() {
+			It("creates an application", func() {
 				GinkgoWriter.Printf("Parallel process %d\n", GinkgoParallelProcess())
 				createdApplication, err := fw.HasController.CreateHasApplication(appTest.ApplicationName, namespace)
 				Expect(err).NotTo(HaveOccurred())
@@ -109,7 +101,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 			})
 
 			// Check the application health and check if a devfile was generated in the status
-			It("application is healthy", func() {
+			It("checks if application is healthy", func() {
 				Eventually(func() string {
 					appstudioApp, err := fw.HasController.GetHasApplication(appTest.ApplicationName, namespace)
 					Expect(err).NotTo(HaveOccurred())
@@ -125,11 +117,10 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 				}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "Has controller didn't create gitops repository")
 			})
 
-			It("environment is created", func() {
-				createdEnvironment, err := fw.GitOpsController.CreateEnvironment(EnvironmentName, namespace)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(createdEnvironment.Spec.DisplayName).To(Equal(EnvironmentName))
-				Expect(createdEnvironment.Namespace).To(Equal(namespace))
+			// Create an environment in a specific namespace
+			It("creates an environment", func() {
+				env, err = fw.IntegrationController.CreateEnvironment(namespace)
+				Expect(err).ShouldNot(HaveOccurred())
 			})
 
 			for _, componentTest := range appTest.Components {
@@ -140,7 +131,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 				// TODO: In the future when HAS support creating private applications should push the containers from private repos to a private quay.io repo
 				if componentTest.Type == "private" {
-					It("Inject manually SPI token", func() {
+					It("injects manually SPI token", func() {
 						// Inject spi tokens to work with private components
 						if componentTest.ContainerSource != "" {
 							// More info about manual token upload for quay.io here: https://github.com/redhat-appstudio/service-provider-integration-operator/pull/115
@@ -158,14 +149,14 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 				// Components for now can be imported from gitUrl, container image or a devfile
 				if componentTest.ContainerSource != "" {
-					It(fmt.Sprintf("create component %s from %s container source", componentTest.Name, componentTest.Type), func() {
+					It(fmt.Sprintf("creates component %s from %s container source", componentTest.Name, componentTest.Type), func() {
 						component, err = fw.HasController.CreateComponent(application.Name, componentTest.Name, namespace, "", "", componentTest.ContainerSource, outputContainerImage, oauthSecretName, true)
 						Expect(err).NotTo(HaveOccurred())
 					})
 
 					// User can define a git url and a devfile at the same time if multiple devfile exists into a repo
 				} else if componentTest.GitSourceUrl != "" && componentTest.Devfilesource != "" {
-					It(fmt.Sprintf("create component %s from %s git source %s and devfile %s", componentTest.Name, componentTest.Type, componentTest.GitSourceUrl, componentTest.Devfilesource), func() {
+					It(fmt.Sprintf("creates component %s from %s git source %s and devfile %s", componentTest.Name, componentTest.Type, componentTest.GitSourceUrl, componentTest.Devfilesource), func() {
 						component, err = fw.HasController.CreateComponentFromDevfile(application.Name, componentTest.Name, namespace,
 							componentTest.GitSourceUrl, componentTest.Devfilesource, "", containerIMG, oauthSecretName)
 						Expect(err).NotTo(HaveOccurred())
@@ -173,7 +164,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 					// If component have only a git source application-service will start to fetch the devfile from the git root directory
 				} else if componentTest.GitSourceUrl != "" {
-					It(fmt.Sprintf("create component %s from %s git source %s", componentTest.Name, componentTest.Type, componentTest.GitSourceUrl), func() {
+					It(fmt.Sprintf("creates component %s from %s git source %s", componentTest.Name, componentTest.Type, componentTest.GitSourceUrl), func() {
 						component, err = fw.HasController.CreateComponent(application.Name, componentTest.Name, namespace,
 							componentTest.GitSourceUrl, "", "", containerIMG, oauthSecretName, true)
 						Expect(err).NotTo(HaveOccurred())
@@ -185,40 +176,46 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 				}
 
 				// Start to watch the pipeline until is finished
-				It(fmt.Sprintf("wait %s component %s pipeline to be finished", componentTest.Type, componentTest.Name), func() {
+				It(fmt.Sprintf("waits %s component %s pipeline to be finished", componentTest.Type, componentTest.Name), func() {
 					if componentTest.ContainerSource != "" {
 						Skip(fmt.Sprintf("component %s was imported from quay.io/docker.io source. Skipping pipelinerun check.", componentTest.Name))
 					}
 					Expect(fw.HasController.WaitForComponentPipelineToBeFinished(component.Name, application.Name, namespace)).To(Succeed(), "Failed component pipeline %v", err)
 				})
 
-				// Obtain a snapshot for the SnapshotEnvironmentBinding
-				if componentTest.ContainerSource != "" {
-					It("create snapshot for component imported from quay.io/docker.io source", func() {
-						snapshotName := SnapshotName + "-" + util.GenerateRandomString(4)
-						snapshotComponents := []appservice.SnapshotComponent{
-							{Name: component.Name, ContainerImage: component.Spec.ContainerImage},
+				It("finds the snapshot and checks if it is marked as successful", func() {
+					timeout = time.Second * 600
+					interval = time.Second * 10
+
+					snapshot, err = fw.IntegrationController.GetApplicationSnapshot("", application.Name, namespace, component.Name)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					Eventually(func() bool {
+						if fw.IntegrationController.HaveHACBSTestsSucceeded(snapshot) {
+							return true
 						}
-						snapshot, err = fw.ReleaseController.CreateSnapshot(snapshotName, namespace, application.Name, snapshotComponents)
-						Expect(err).NotTo(HaveOccurred())
-					})
-				} else {
-					It("check if the component's snapshot is created when the pipelinerun is targeted", func() {
-						// snapshotName is sent as empty since it is unknown at this stage
+						return false
+					}, timeout, interval).Should(BeTrue(), "time out when trying to check if the snapshot is marked as successful")
+				})
+
+				It("checks if a snapshot environment binding is created successfully", func() {
+					Eventually(func() bool {
+						if fw.IntegrationController.HaveHACBSTestsSucceeded(snapshot) {
+							envbinding, err := fw.IntegrationController.GetSnapshotEnvironmentBinding(application.Name, namespace, env)
+							Expect(err).ShouldNot(HaveOccurred())
+							Expect(envbinding != nil).To(BeTrue())
+							GinkgoWriter.Printf("The EnvironmentBinding %s is created\n", envbinding.Name)
+							return true
+						}
+
 						snapshot, err = fw.IntegrationController.GetApplicationSnapshot("", application.Name, namespace, component.Name)
 						Expect(err).ShouldNot(HaveOccurred())
-					})
-				}
-
-				// Create snapshotEnvironmentBinding to cause an application (and its components) to be deployed
-				It("snapshotEnvironmentBinding is created", func() {
-					snapshotEnvBindingName := SnapshotEnvironmentBindingName + "-" + util.GenerateRandomString(4)
-					_, err = fw.HasController.CreateSnapshotEnvironmentBinding(snapshotEnvBindingName, namespace, application.Name, snapshot.Name, EnvironmentName, component)
-					Expect(err).NotTo(HaveOccurred())
+						return false
+					}, timeout, interval).Should(BeTrue(), "time out when waiting for release created")
 				})
 
 				// Deploy the component using gitops and check for the health
-				It(fmt.Sprintf("deploy component %s using gitops", componentTest.Name), func() {
+				It(fmt.Sprintf("deploys component %s using gitops", componentTest.Name), func() {
 					var deployment *appsv1.Deployment
 					Eventually(func() bool {
 						deployment, err = fw.CommonController.GetAppDeploymentByName(componentTest.Name, namespace)
@@ -235,7 +232,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 					Expect(err).NotTo(HaveOccurred())
 				})
 
-				It(fmt.Sprintf("check component %s health", componentTest.Name), func() {
+				It(fmt.Sprintf("checks if component %s health", componentTest.Name), func() {
 					Eventually(func() bool {
 						gitOpsRoute, err := fw.CommonController.GetOpenshiftRoute(componentTest.Name, namespace)
 						Expect(err).NotTo(HaveOccurred())
@@ -248,7 +245,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 				})
 
 				if componentTest.K8sSpec != (config.K8sSpec{}) && *componentTest.K8sSpec.Replicas > 1 {
-					It(fmt.Sprintf("scale component %s replicas", componentTest.Name), Pending, func() {
+					It(fmt.Sprintf("scales component %s replicas", componentTest.Name), Pending, func() {
 						component, err := fw.HasController.GetHasComponent(componentTest.Name, namespace)
 						Expect(err).NotTo(HaveOccurred())
 						_, err = fw.HasController.ScaleComponentReplicas(component, int(*componentTest.K8sSpec.Replicas))

--- a/tests/e2e-demos/e2e-demo.go
+++ b/tests/e2e-demos/e2e-demo.go
@@ -191,10 +191,8 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					Eventually(func() bool {
-						if fw.IntegrationController.HaveHACBSTestsSucceeded(snapshot) {
-							return true
-						}
-						return false
+						return fw.IntegrationController.HaveHACBSTestsSucceeded(snapshot)
+
 					}, timeout, interval).Should(BeTrue(), "time out when trying to check if the snapshot is marked as successful")
 				})
 

--- a/tests/e2e-demos/multi-component.go
+++ b/tests/e2e-demos/multi-component.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/devfile/library/pkg/util"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,8 +28,6 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 	// Initialize the application struct
 	application := &appservice.Application{}
 	cdq := &appservice.ComponentDetectionQuery{}
-	snapshotGo := &appservice.Snapshot{}
-	snapshotNode := &appservice.Snapshot{}
 	componentGo := &appservice.Component{}
 	componentNode := &appservice.Component{}
 
@@ -85,14 +82,14 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 			}
 		})
 
-		It("Create Red Hat AppStudio Application", func() {
+		It("creates Red Hat AppStudio Application", func() {
 			createdApplication, err := fw.HasController.CreateHasApplication(testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(createdApplication.Spec.DisplayName).To(Equal(testSpecification.Tests[0].ApplicationName))
 			Expect(createdApplication.Namespace).To(Equal(AppStudioE2EApplicationsNamespace))
 		})
 
-		It("Check Red Hat AppStudio Application health", func() {
+		It("checks Red Hat AppStudio Application health", func() {
 			Eventually(func() string {
 				application, err = fw.HasController.GetHasApplication(testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)
 				Expect(err).NotTo(HaveOccurred())
@@ -108,20 +105,13 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 			}, 1*time.Minute, 1*time.Second).Should(BeTrue(), "Has controller didn't create gitops repository")
 		})
 
-		It("environment is created", func() {
-			createdEnvironment, err := fw.GitOpsController.CreateEnvironment(EnvironmentName, AppStudioE2EApplicationsNamespace)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(createdEnvironment.Spec.DisplayName).To(Equal(EnvironmentName))
-			Expect(createdEnvironment.Namespace).To(Equal(AppStudioE2EApplicationsNamespace))
-		})
-
-		It("Create Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
+		It("creates Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
 			cdq, err := fw.HasController.CreateComponentDetectionQuery(testSpecification.Tests[0].Components[0].Name, AppStudioE2EApplicationsNamespace, testSpecification.Tests[0].Components[0].GitSourceUrl, "", false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cdq.Name).To(Equal(testSpecification.Tests[0].Components[0].Name))
 		})
 
-		It("Check Red Hat AppStudio ComponentDetectionQuery status", func() {
+		It("checks Red Hat AppStudio ComponentDetectionQuery status", func() {
 			// Validate that the CDQ completes successfully
 			Eventually(func() bool {
 				// application info should be stored even after deleting the application in application variable
@@ -148,7 +138,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 			Expect(nodejs).To(BeTrue(), "Expect NodeJS component to be detected")
 		})
 
-		It("Create multiple components", func() {
+		It("creates multiple components", func() {
 			// Create Golang component from CDQ result
 			Expect(cdq.Status.ComponentDetected[compNameGo].DevfileFound).To(BeTrue(), "DevfileFound was not set to true")
 			componentDescription := cdq.Status.ComponentDetected[compNameGo]
@@ -167,7 +157,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 		})
 
 		// Start to watch the pipeline until is finished
-		It("Wait for all pipelines to be finished", func() {
+		It("waits for all pipelines to be finished", func() {
 			err := fw.HasController.WaitForComponentPipelineToBeFinished(compNameGo, testSpecification.Tests[0].ApplicationName, AppStudioE2EApplicationsNamespace)
 			if err != nil {
 				removeApplication = false
@@ -181,28 +171,8 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed component pipeline %v", err)
 		})
 
-		It(fmt.Sprintf("check if the %s and %s components snapshot is created when the pipelinerun is targeted", compNameNode, compNameNode), func() {
-			// snapshotName is sent as empty since it is unknown at this stage
-			snapshotGo, err = fw.IntegrationController.GetApplicationSnapshot("", application.Name, AppStudioE2EApplicationsNamespace, compNameGo)
-			Expect(err).ShouldNot(HaveOccurred())
-
-			// snapshotName is sent as empty since it is unknown at this stage
-			snapshotNode, err = fw.IntegrationController.GetApplicationSnapshot("", application.Name, AppStudioE2EApplicationsNamespace, compNameNode)
-			Expect(err).ShouldNot(HaveOccurred())
-		})
-
-		It(fmt.Sprintf("snapshotEnvironmentBinding for %s and %s are created", compNameGo, compNameNode), func() {
-			snapshotEnvBindingNameGo := SnapshotEnvironmentBindingName + "-" + util.GenerateRandomString(4)
-			_, err = fw.HasController.CreateSnapshotEnvironmentBinding(snapshotEnvBindingNameGo, AppStudioE2EApplicationsNamespace, application.Name, snapshotGo.Name, EnvironmentName, componentGo)
-			Expect(err).NotTo(HaveOccurred())
-
-			snapshotEnvBindingNameNode := SnapshotEnvironmentBindingName + "-" + util.GenerateRandomString(4)
-			_, err = fw.HasController.CreateSnapshotEnvironmentBinding(snapshotEnvBindingNameNode, AppStudioE2EApplicationsNamespace, application.Name, snapshotNode.Name, EnvironmentName, componentNode)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
 		// Check components are deployed
-		It("Check multiple components are deployed", func() {
+		It("checks if multiple components are deployed", Pending, func() {
 			Eventually(func() bool {
 				deploymentGo, err := fw.CommonController.GetAppDeploymentByName(compNameGo, AppStudioE2EApplicationsNamespace)
 				if err != nil && !errors.IsNotFound(err) {

--- a/tests/has/devfile_private_source.go
+++ b/tests/has/devfile_private_source.go
@@ -87,14 +87,14 @@ var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label(
 		}
 	})
 
-	It("Create Red Hat AppStudio Application", func() {
+	It("creates Red Hat AppStudio Application", func() {
 		createdApplication, err := framework.HasController.CreateHasApplication(applicationName, testNamespace)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createdApplication.Spec.DisplayName).To(Equal(applicationName))
 		Expect(createdApplication.Namespace).To(Equal(testNamespace))
 	})
 
-	It("Check Red Hat AppStudio Application health", func() {
+	It("checks Red Hat AppStudio Application health", func() {
 		Eventually(func() string {
 			application, err = framework.HasController.GetHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
@@ -111,20 +111,20 @@ var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label(
 	})
 
 	// Necessary for component pipeline
-	It("Check if 'git-clone' cluster tasks exists", func() {
+	It("checks if 'git-clone' cluster tasks exists", func() {
 		Eventually(func() bool {
 			return framework.CommonController.CheckIfClusterTaskExists("git-clone")
 		}, 5*time.Minute, 45*time.Second).Should(BeTrue(), "'git-clone' cluster task don't exist in cluster. Component cannot be created")
 	})
 
-	It("Create Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
+	It("creates Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
 		cdq, err := framework.HasController.CreateComponentDetectionQuery(componentName, testNamespace, QuarkusDevfileSource, "", false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cdq.Name).To(Equal(componentName))
 
 	})
 
-	It("Check Red Hat AppStudio ComponentDetectionQuery status", func() {
+	It("checks Red Hat AppStudio ComponentDetectionQuery status", func() {
 		// Validate that the CDQ completes successfully
 		Eventually(func() bool {
 			// application info should be stored even after deleting the application in application variable
@@ -143,7 +143,7 @@ var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label(
 		}
 	})
 
-	It("Create Red Hat AppStudio Quarkus component", func() {
+	It("creates Red Hat AppStudio Quarkus component", func() {
 		component, err := framework.HasController.CreateComponentFromStub(compDetected, componentName, testNamespace, oauthSecretName, applicationName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(component.Name).To(Equal(componentName))

--- a/tests/has/devfile_source.go
+++ b/tests/has/devfile_source.go
@@ -77,14 +77,14 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 		}
 	})
 
-	It("Create Red Hat AppStudio Application", func() {
+	It("creates Red Hat AppStudio Application", func() {
 		createdApplication, err := framework.HasController.CreateHasApplication(applicationName, testNamespace)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(createdApplication.Spec.DisplayName).To(Equal(applicationName))
 		Expect(createdApplication.Namespace).To(Equal(testNamespace))
 	})
 
-	It("Check Red Hat AppStudio Application health", func() {
+	It("checks Red Hat AppStudio Application health", func() {
 		Eventually(func() string {
 			application, err = framework.HasController.GetHasApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
@@ -101,20 +101,20 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 	})
 
 	// Necessary for component pipeline
-	It("Check if 'git-clone' cluster tasks exists", func() {
+	It("checks if 'git-clone' cluster tasks exists", func() {
 		Eventually(func() bool {
 			return framework.CommonController.CheckIfClusterTaskExists("git-clone")
 		}, 5*time.Minute, 45*time.Second).Should(BeTrue(), "'git-clone' cluster task don't exist in cluster. Component cannot be created")
 	})
 
-	It("Create Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
+	It("creates Red Hat AppStudio ComponentDetectionQuery for Component repository", func() {
 		cdq, err := framework.HasController.CreateComponentDetectionQuery(componentName, testNamespace, QuarkusDevfileSource, "", false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cdq.Name).To(Equal(componentName))
 
 	})
 
-	It("Check Red Hat AppStudio ComponentDetectionQuery status", func() {
+	It("checks Red Hat AppStudio ComponentDetectionQuery status", func() {
 		// Validate that the CDQ completes successfully
 		Eventually(func() bool {
 			// application info should be stored even after deleting the application in application variable
@@ -133,13 +133,13 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 		}
 	})
 
-	It("Create Red Hat AppStudio Quarkus component", func() {
+	It("creates Red Hat AppStudio Quarkus component", func() {
 		component, err := framework.HasController.CreateComponentFromStub(compDetected, componentName, testNamespace, "", applicationName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(component.Name).To(Equal(componentName))
 	})
 
-	It("Gitops Repository should not be deleted when component gets deleted", func() {
+	It("gitops Repository should not be deleted when component gets deleted", func() {
 		comp2Detected := appservice.ComponentDetectionDescription{}
 
 		for _, comp2Detected = range cdq.Status.ComponentDetected {
@@ -160,7 +160,7 @@ var _ = framework.HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source", Labe
 		}, 1*time.Minute, 100*time.Millisecond).Should(BeTrue(), "Gitops repository deleted after component was deleted")
 	})
 
-	It("Check a Component gets deleted when its application is deleted", func() {
+	It("checks a Component gets deleted when its application is deleted", func() {
 		err = framework.HasController.DeleteHasApplication(applicationName, testNamespace, false)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(func() bool {

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -23,8 +23,8 @@ const (
 	containerImageSource = "quay.io/redhat-appstudio-qe/busybox-loop:latest"
 	gitSourceRepoName    = "devfile-sample-python-basic"
 	gitSourceURL         = "https://github.com/redhat-appstudio-qe/" + gitSourceRepoName
-	bundleURL            = "quay.io/redhat-appstudio/example-tekton-bundle:integration-pipeline-pass"
-	inPipelineName       = "integration-pipeline-pass"
+	BundleURL            = "quay.io/redhat-appstudio/example-tekton-bundle:integration-pipeline-pass"
+	InPipelineName       = "integration-pipeline-pass"
 )
 
 var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests", Label("integration-service", "HACBS"), func() {
@@ -74,7 +74,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				}
 			}
 			_ = defaultBundleConfigMap.Data["default_build_bundle"]
-			_, err = f.IntegrationController.CreateIntegrationTestScenario(applicationName, appStudioE2EApplicationsNamespace, bundleURL, inPipelineName)
+			_, err = f.IntegrationController.CreateIntegrationTestScenario(applicationName, appStudioE2EApplicationsNamespace, BundleURL, InPipelineName)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -122,13 +122,13 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		})
 
 		When("the build pipelineRun run succeeded", func() {
-			It("check if the ApplicationSnapshot is created", func() {
+			It("checks if the ApplicationSnapshot is created", func() {
 				// snapshotName is sent as empty since it is unknown at this stage
 				applicationSnapshot, err = f.IntegrationController.GetApplicationSnapshot("", applicationName, appStudioE2EApplicationsNamespace, componentName)
 				Expect(err).ShouldNot(HaveOccurred())
 				GinkgoWriter.Printf("applicationSnapshot %s is found\n", applicationSnapshot.Name)
 			})
-			It("check if all of the integrationPipelineRuns passed", Label("slow"), func() {
+			It("checks if all of the integrationPipelineRuns passed", Label("slow"), func() {
 				integrationTestScenarios, err := f.IntegrationController.GetIntegrationTestScenarios(applicationName, appStudioE2EApplicationsNamespace)
 				Expect(err).ShouldNot(HaveOccurred())
 				for _, testScenario := range *integrationTestScenarios {
@@ -152,7 +152,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			})
 		})
 
-		It("create a ReleasePlan and an environment", func() {
+		It("creates a ReleasePlan and an environment", func() {
 			_, err = f.IntegrationController.CreateReleasePlan(applicationName, appStudioE2EApplicationsNamespace)
 			Expect(err).ShouldNot(HaveOccurred())
 			env, err = f.IntegrationController.CreateEnvironment(appStudioE2EApplicationsNamespace)
@@ -164,14 +164,15 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			}
 		})
 
-		It("create an applicationSnapshot of push event", func() {
-			applicationSnapshot_push, err = f.IntegrationController.CreateApplicationSnapshot(applicationName, appStudioE2EApplicationsNamespace, componentName)
+		It("creates an applicationSnapshot of push event", func() {
+			sample_image := "quay.io/redhat-appstudio/sample-image"
+			applicationSnapshot_push, err = f.IntegrationController.CreateApplicationSnapshot(applicationName, appStudioE2EApplicationsNamespace, componentName, sample_image)
 			Expect(err).ShouldNot(HaveOccurred())
 			GinkgoWriter.Printf("applicationSnapshot %s is found\n", applicationSnapshot_push.Name)
 		})
 
 		When("An applicationSnapshot of push event is created", func() {
-			It("check if all of the integrationPipelineRuns created by push event passed", Label("slow"), func() {
+			It("checks if all of the integrationPipelineRuns created by push event passed", Label("slow"), func() {
 				integrationTestScenarios, err := f.IntegrationController.GetIntegrationTestScenarios(applicationName, appStudioE2EApplicationsNamespace)
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -204,7 +205,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				}
 			})
 
-			It("check if the global candidate is updated after push event", func() {
+			It("checks if the global candidate is updated after push event", func() {
 				timeout = time.Second * 600
 				interval = time.Second * 10
 				Eventually(func() bool {
@@ -219,7 +220,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				}, timeout, interval).Should(BeTrue(), "time out when waiting for updating the global candidate")
 			})
 
-			It("check if a Release is created successfully", func() {
+			It("checks if a Release is created successfully", func() {
 				timeout = time.Second * 800
 				interval = time.Second * 10
 				Eventually(func() bool {
@@ -240,7 +241,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				}, timeout, interval).Should(BeTrue(), "time out when waiting for release created")
 			})
 
-			It("check if an EnvironmentBinding is created successfully", func() {
+			It("checks if an EnvironmentBinding is created successfully", func() {
 				timeout = time.Second * 600
 				interval = time.Second * 2
 				Eventually(func() bool {

--- a/tests/release/release.go
+++ b/tests/release/release.go
@@ -115,7 +115,7 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1108]test-release-service-happy-p
 
 	var _ = Describe("post-release verification.", func() {
 
-		It("make sure a PipelineRun should have been created in the managed namespace.", func() {
+		It("makes sure a PipelineRun should have been created in the managed namespace.", func() {
 			Eventually(func() bool {
 				prList, err := framework.TektonController.ListAllPipelineRuns(managedNamespace)
 				if err != nil || prList == nil || len(prList.Items) < 1 {


### PR DESCRIPTION
# Description

- Refactored `e2e-demos.go` to use integration service for Snapshot and SnapshotEnvironmentBinding creation (for `multi-component.go` is still on standby since multi components are not working as expected)

- Fixed typos

- Uniformed "It" block content. As said [here](https://github.com/redhat-appstudio/e2e-tests/pull/259#discussion_r1043130878), as good practice, 

> "It" block content should start in lower case and be conjugated in the 3rd person singular form

## Issue ticket number and link
[STONE-336](https://issues.redhat.com/browse/STONE-336)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
`make local/test/e2e`

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
