### PR TITLE
fix: Do not remove resources if specs failed for debuging

### DIFF
--- a/tests/e2e-demos/e2e-demo.go
+++ b/tests/e2e-demos/e2e-demo.go
@@ -89,12 +89,14 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 			})
 			// Remove all resources created by the tests
 			AfterAll(func() {
-				Expect(fw.HasController.DeleteAllComponentsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
-				Expect(fw.HasController.DeleteAllApplicationsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
-				Expect(fw.HasController.DeleteAllSnapshotEnvBindingsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
-				Expect(fw.ReleaseController.DeleteAllSnapshotsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
-				Expect(fw.GitOpsController.DeleteAllEnvironmentsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
-				Expect(fw.GitOpsController.DeleteAllGitOpsDeploymentInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
+				if !CurrentSpecReport().Failed() {
+					Expect(fw.HasController.DeleteAllComponentsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
+					Expect(fw.HasController.DeleteAllApplicationsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
+					Expect(fw.HasController.DeleteAllSnapshotEnvBindingsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
+					Expect(fw.ReleaseController.DeleteAllSnapshotsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
+					Expect(fw.GitOpsController.DeleteAllEnvironmentsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
+					Expect(fw.GitOpsController.DeleteAllGitOpsDeploymentInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
+				}
 			})
 
 			// Create an application in a specific namespace

--- a/tests/has/devfile_private_source.go
+++ b/tests/has/devfile_private_source.go
@@ -66,23 +66,25 @@ var _ = framework.HASSuiteDescribe("[test_id:02] private devfile source", Label(
 	})
 
 	AfterAll(func() {
-		err := framework.HasController.DeleteHasComponent(componentName, testNamespace, false)
-		Expect(err).NotTo(HaveOccurred())
+		if !CurrentSpecReport().Failed() {
+			err := framework.HasController.DeleteHasComponent(componentName, testNamespace, false)
+			Expect(err).NotTo(HaveOccurred())
 
-		err = framework.HasController.DeleteHasApplication(applicationName, testNamespace, false)
-		Expect(err).NotTo(HaveOccurred())
+			err = framework.HasController.DeleteHasApplication(applicationName, testNamespace, false)
+			Expect(err).NotTo(HaveOccurred())
 
-		err = framework.SPIController.DeleteAllBindingTokensInASpecificNamespace(testNamespace)
-		Expect(err).NotTo(HaveOccurred())
+			err = framework.SPIController.DeleteAllBindingTokensInASpecificNamespace(testNamespace)
+			Expect(err).NotTo(HaveOccurred())
 
-		Eventually(func() bool {
-			// application info should be stored even after deleting the application in application variable
-			gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
+			Eventually(func() bool {
+				// application info should be stored even after deleting the application in application variable
+				gitOpsRepository := utils.ObtainGitOpsRepositoryName(application.Status.Devfile)
 
-			return framework.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
-		}, 1*time.Minute, 100*time.Millisecond).Should(BeFalse(), "Has controller didn't remove Red Hat AppStudio application gitops repository")
+				return framework.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
+			}, 1*time.Minute, 100*time.Millisecond).Should(BeFalse(), "Has controller didn't remove Red Hat AppStudio application gitops repository")
 
-		Expect(framework.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
+			Expect(framework.CommonController.DeleteNamespace(testNamespace)).To(Succeed())
+		}
 	})
 
 	It("Create Red Hat AppStudio Application", func() {


### PR DESCRIPTION
# Description

e2e-demos fail on build pipelines and is not possible to collect logs because afterall remove all the resources from the cluster

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
