### PR TITLE
fix: update build-service PaC test

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -64,6 +64,7 @@ const (
 )
 
 var (
-	ComponentDefaultLabel      = map[string]string{"e2e-test": "true"}
-	ComponentDefaultAnnotation = map[string]string{"com.redhat.appstudio/component-initial-build-processed": "true"}
+	ComponentDefaultLabel         = map[string]string{"e2e-test": "true"}
+	ComponentDefaultAnnotation    = map[string]string{"appstudio.openshift.io/component-initial-build": "processed"}
+	ComponentPaCRequestAnnotation = map[string]string{"appstudio.openshift.io/pac-provision": "request"}
 )

--- a/pkg/utils/has/controller.go
+++ b/pkg/utils/has/controller.go
@@ -227,11 +227,9 @@ func (h *SuiteController) ComponentDeleted(component *appservice.Component) wait
 func (h *SuiteController) CreateComponentWithPaCEnabled(applicationName, componentName, namespace, gitSourceURL, baseBranch, outputContainerImage string) (*appservice.Component, error) {
 	component := &appservice.Component{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				"pipelinesascode": "1",
-			},
-			Name:      componentName,
-			Namespace: namespace,
+			Annotations: constants.ComponentPaCRequestAnnotation,
+			Name:        componentName,
+			Namespace:   namespace,
 		},
 		Spec: appservice.ComponentSpec{
 			ComponentName: componentName,


### PR DESCRIPTION
# Description

* Uses changes made by @psturc to pair tests update with https://github.com/redhat-appstudio/build-service/pull/103
* updated PR pairing process to allow pairing with infra-deployments PRs