### PR TITLE
test: STONE-438 change forked repos to original one in E2E suite

### DIFF
--- a/tests/e2e-demos/config/default.yaml
+++ b/tests/e2e-demos/config/default.yaml
@@ -15,7 +15,7 @@ tests:
     components:
       - name: "dotnet-component"
         type: "public"
-        gitSourceUrl: "https://github.com/redhat-appstudio-qe/devfile-sample-dotnet60-basic"
+        gitSourceUrl: "https://github.com/devfile-samples/devfile-sample-dotnet60-basic"
         language: "dotNet"
         healthz: "/"
   - name: "RHDP-478: create an application with multiple components from private and public repositories"
@@ -23,7 +23,7 @@ tests:
     components:
       - name: "component-python"
         type: "public"
-        gitSourceUrl: "https://github.com/redhat-appstudio-qe/devfile-sample-python-basic"
+        gitSourceUrl: "https://github.com/devfile-samples/devfile-sample-python-basic"
         language: "python"
         healthz: "/"
       - name: "private-quarkus-component"


### PR DESCRIPTION
# Description

Change forked repos to the original one in E2E suite. 

I still did not delete the forked repos because I want to be sure that the PR is approved and the forked repos are unnecessary

## Issue ticket number and link
[STONE-438](https://issues.redhat.com/browse/STONE-438)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`make local/test/e2e`

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
