### PR TITLE
fix: STONE-442 Temporarily increase timeout for 'pipeline' SA creation.

### DIFF
--- a/pkg/utils/common/controller.go
+++ b/pkg/utils/common/controller.go
@@ -440,7 +440,8 @@ func (s *SuiteController) CreateTestNamespace(name string) (*corev1.Namespace, e
 	}
 
 	// "pipeline" service account needs to be present in the namespace before we start with creating tekton resources
-	if err := utils.WaitUntil(s.ServiceaccountPresent("pipeline", name), time.Second*30); err != nil {
+	// TODO: STONE-442 - decrease the timeout here back to 30 seconds once this issue is resolved.
+	if err := utils.WaitUntil(s.ServiceaccountPresent("pipeline", name), time.Second*60); err != nil {
 		return nil, fmt.Errorf("'pipeline' service account wasn't created in %s namespace: %+v", name, err)
 	}
 

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -464,7 +464,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			gitUrl := gitUrl
 
 			It(fmt.Sprintf("should eventually finish successfully for component with source URL %s", gitUrl), Label(buildTemplatesTestLabel), func() {
-				timeout := time.Second * 900
+				timeout := time.Second * 1200
 				interval := time.Second * 10
 				Eventually(func() bool {
 					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false, "")

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -103,7 +103,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				}
 				return pipelineRun.HasStarted()
 			}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
-			timeout = time.Second * 600
+			timeout = time.Second * 1200
 			interval = time.Second * 10
 			Eventually(func() bool {
 				pipelineRun, err := f.IntegrationController.GetBuildPipelineRun(componentName, applicationName, appStudioE2EApplicationsNamespace, false, "")


### PR DESCRIPTION
# Description
[STONE-442](https://issues.redhat.com//browse/STONE-442) - Recently we've seen too many failures in CI related to this issue. 
Given the issue is tracked in upstream and given the rate of flakiness of this issue I'm proposing to temporarliy increase the timeout to 1 minute from original 30 seconds. 
## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

It hasn't :-D

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
