### PR TITLE
fix: increase timeout for waiting on build pipelinerun

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -176,7 +176,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			})
 
 			It("the PipelineRun should eventually finish successfully", func() {
-				timeout = time.Minute * 15
+				timeout = time.Minute * 30
 				interval = time.Second * 10
 				Eventually(func() bool {
 
@@ -254,7 +254,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
 			})
 			It("PipelineRun should eventually finish", func() {
-				timeout = time.Minute * 10
+				timeout = time.Minute * 20
 				interval = time.Second * 10
 
 				Eventually(func() bool {
@@ -330,7 +330,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
 			})
 			It("pipelineRun should eventually finish", func() {
-				timeout = time.Minute * 10
+				timeout = time.Minute * 20
 				interval = time.Second * 10
 
 				Eventually(func() bool {


### PR DESCRIPTION
Quay is being slow these days which is reported as incident. Increasing timeouts in build tests.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
