### PR TITLE
fix: bump timeout for chains pipelinerun tests

### DIFF
--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -66,7 +66,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 		var imageWithDigest string
 		serviceAccountName := "pipeline"
 
-		pipelineRunTimeout := 600
+		pipelineRunTimeout := int(time.Duration(20) * time.Minute)
 		attestationTimeout := time.Duration(60) * time.Second
 
 		var kubeController tekton.KubeController


### PR DESCRIPTION
# Description

The environment is taking longer than expected to fully execute a PipelineRun. A previous run exceeded the old 10 minute timeout by about 30 seconds. This change doubles the timeout to avoid such instability in tests.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
