### PR TITLE
test: STONEBLD-27: use build-templates-e2e

### DIFF
--- a/magefiles/installation/install.go
+++ b/magefiles/installation/install.go
@@ -25,7 +25,7 @@ const (
 	DEFAULT_LOCAL_FORK_NAME             = "qe"
 	DEFAULT_LOCAL_FORK_ORGANIZATION     = "redhat-appstudio-qe"
 	DEFAULT_E2E_APPLICATIONS_NAMEPSPACE = "appstudio-e2e-test"
-	DEFAULT_SHARED_SECRETS_NAMESPACE    = "build-templates"
+	DEFAULT_SHARED_SECRETS_NAMESPACE    = "build-templates-e2e"
 	DEFAULT_SHARED_SECRET_NAME          = "redhat-appstudio-user-workload"
 	DEFAULT_E2E_QUAY_ORG                = "redhat-appstudio-qe"
 )
@@ -141,7 +141,7 @@ func (i *InstallAppStudio) cloneInfraDeployments() (*git.Remote, error) {
 	return repo.CreateRemote(&config.RemoteConfig{Name: i.LocalForkName, URLs: []string{fmt.Sprintf("https://github.com/%s/infra-deployments.git", i.LocalGithubForkOrganization)}})
 }
 
-// createSharedSecret make sure that redhat-appstudio-user-workload secret is created in the build-templates namespace for build purposes
+// createSharedSecret make sure that redhat-appstudio-user-workload secret is created in the build-templates-e2e namespace for build purposes
 func (i *InstallAppStudio) createSharedSecret() error {
 	quayToken := os.Getenv("QUAY_TOKEN")
 	if quayToken == "" {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -42,8 +42,6 @@ const (
 	ArgoCDLabelKey   string = "argocd.argoproj.io/managed-by"
 	ArgoCDLabelValue string = "gitops-service-argocd"
 
-	BuildPipelinesConfigMapDefaultNamespace = "build-templates"
-
 	HostOperatorNamespace   string = "toolchain-host-operator"
 	MemberOperatorNamespace string = "toolchain-member-operator"
 
@@ -59,7 +57,7 @@ const (
 	RegistryAuthSecretName = "redhat-appstudio-registry-pull-secret"
 
 	SharedPullSecretName      = "redhat-appstudio-user-workload"
-	SharedPullSecretNamespace = "build-templates"
+	SharedPullSecretNamespace = "build-templates-e2e"
 
 	JVMBuildImageSecretName = "jvm-build-image-secrets"
 	JBSConfigName           = "jvm-build-config"


### PR DESCRIPTION
components/build-templates is removed along with the build-pipelines-defaults configmap from infra-deployments.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
