### PR TITLE
test: adding label 'pipeline' to identify the tests that are used for Pipeline Service tests

### DIFF
--- a/docs/LabelsNaming.md
+++ b/docs/LabelsNaming.md
@@ -19,6 +19,7 @@ has | HAS related tests
 build | Build related tests
 cluster-registration | cluster registration related tests
 e2e-demos | e2e-demos related tests
+pipeline | Pipeline Service related tests
 
 ### Test Types Labels
 

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -48,7 +48,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 	f, err := framework.NewFramework()
 	Expect(err).NotTo(HaveOccurred())
 
-	Describe("the component with git source (GitHub) is created", Ordered, Label("github-webhook"), func() {
+	Describe("the component with git source (GitHub) is created", Ordered, Label("github-webhook", "pipeline"), func() {
 		var applicationName, componentName, componentBaseBranchName, pacBranchName, testNamespace, outputContainerImage, pacControllerHost string
 
 		var timeout, interval time.Duration

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -29,7 +29,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Context("infrastructure is running", func() {
+	Context("infrastructure is running", Label("pipeline"), func() {
 		It("verifies if the chains controller is running", func() {
 			err := fwk.CommonController.WaitForPodSelector(fwk.CommonController.IsPodRunning, constants.TEKTON_CHAINS_NS, "app", "tekton-chains-controller", 60, 100)
 			Expect(err).NotTo(HaveOccurred())
@@ -56,7 +56,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 		})
 	})
 
-	Context("test creating and signing an image and task", func() {
+	Context("test creating and signing an image and task", Label("pipeline"), func() {
 		// Make the PipelineRun name and namespace predictable. For convenience, the name of the
 		// PipelineRun that builds an image, is the same as the repository where the image is
 		// pushed to.


### PR DESCRIPTION
# Description

This PR is to add label "pipeline" to mark existing tests as part of Pipeline Service tests. 

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
