### PR TITLE
fix: checking pipelines running in parallel

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -444,6 +444,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		})
 
 		for i, gitUrl := range componentUrls {
+			i := i
 			gitUrl := gitUrl
 			It(fmt.Sprintf("triggers PipelineRun for component with source URL %s", gitUrl), Label(buildTemplatesTestLabel), func() {
 				timeout := time.Minute * 25
@@ -461,6 +462,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		}
 
 		for i, gitUrl := range componentUrls {
+			i := i
 			gitUrl := gitUrl
 
 			It(fmt.Sprintf("should eventually finish successfully for component with source URL %s", gitUrl), Label(buildTemplatesTestLabel), func() {


### PR DESCRIPTION
# Description

when `export COMPONENT_REPO_URLS=<repo-url-1>,<repo-url-2>,...` is specified, the check for validating that pipeline finishes successfully is not working correctly due to missing assignment of the loop variable `i` to the local variable

[(Link to a detailed explanation in ginkgo docs)](https://onsi.github.io/ginkgo/#dynamically-generating-specs)

This PR fixes it. Verified on my cluster:

```
[build-service-suite Build service E2E tests] HACBS pipelines should eventually finish successfully for component with source URL https://github.com/redhat-appstudio-qe/devfile-sample-python-basic [build, HACBS, build-templates-e2e]
/Users/psturc/work/redhat-appstudio/e2e-tests/tests/build/build.go:468
  PipelineRun test-component-gfcp-8d7kr Status.Conditions.Reason: Running
...
  PipelineRun test-component-gfcp-8d7kr Status.Conditions.Reason: Completed
...
[build-service-suite Build service E2E tests] HACBS pipelines should eventually finish successfully for component with source URL https://github.com/redhat-appstudio-qe/retrodep [build, HACBS, build-templates-e2e]
/Users/psturc/work/redhat-appstudio/e2e-tests/tests/build/build.go:468
  PipelineRun test-component-jlww-9ldxs Status.Conditions.Reason: Succeeded
```
Note the **different pipelinerun names in the log** (indicating that the issue is fixed) ^

## Issue ticket number and link
N/A
but related to https://github.com/redhat-appstudio/build-definitions/pull/275
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

locally
```
ginkgo --focus "HACBS pipelines" --v ./cmd/ -- --config-suites=$PWD/tests/e2e-demos/config/default.yaml
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
