### PR TITLE
fix: increase build and release timeouts to avoid quay.io incident of…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/redhat-appstudio/e2e-tests
 go 1.18
 
 require (
-	github.com/avast/retry-go/v4 v4.3.2
 	github.com/codeready-toolchain/api v0.0.0-20220511141428-1adfed7d17b0
 	github.com/codeready-toolchain/toolchain-e2e v0.0.0-20220525131508-60876bfb99d3
 	github.com/devfile/library v1.2.1-0.20211104222135-49d635cb492f
@@ -33,7 +32,6 @@ require (
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.1
 	github.com/tektoncd/pipeline v0.42.0
-	golang.org/x/crypto v0.2.0
 	golang.org/x/oauth2 v0.2.0
 	golang.org/x/text v0.5.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -210,6 +208,7 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.23.0 // indirect
+	golang.org/x/crypto v0.2.0 // indirect
 	golang.org/x/mod v0.6.0 // indirect
 	golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10 // indirect
 	golang.org/x/sync v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/avast/retry-go/v4 v4.3.2 h1:x4sTEu3jSwr7zNjya8NTdIN+U88u/jtO/q3OupBoDtM=
-github.com/avast/retry-go/v4 v4.3.2/go.mod h1:rg6XFaiuFYII0Xu3RDbZQkxCofFwruZKW8oEF1jpWiU=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.38.49 h1:E31vxjCe6a5I+mJLmUGaZobiWmg9KdWaud9IfceYeYQ=
 github.com/aws/aws-sdk-go v1.38.49/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -142,7 +142,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		})
 
 		It("triggers a PipelineRun", func() {
-			timeout = time.Second * 120
+			timeout = time.Second * 600
 			interval = time.Second * 1
 			Eventually(func() bool {
 				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, true, "")
@@ -156,7 +156,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 		When("the PipelineRun has started", func() {
 			It("should lead to a PaC init PR creation", func() {
-				timeout = time.Second * 60
+				timeout = time.Second * 300
 				interval = time.Second * 1
 
 				Eventually(func() bool {
@@ -176,7 +176,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			})
 
 			It("the PipelineRun should eventually finish successfully", func() {
-				timeout = time.Minute * 30
+				timeout = time.Minute * 60
 				interval = time.Second * 10
 				Eventually(func() bool {
 
@@ -209,7 +209,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 			It("eventually leads to a creation of a PR comment with the PipelineRun status report", func() {
 				var comments []*github.IssueComment
-				timeout = time.Minute * 5
+				timeout = time.Minute * 15
 				interval = time.Second * 10
 
 				Eventually(func() bool {
@@ -241,7 +241,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			})
 
 			It("eventually leads to triggering another PipelineRun", func() {
-				timeout = time.Minute * 2
+				timeout = time.Minute * 7
 				interval = time.Second * 1
 
 				Eventually(func() bool {
@@ -254,7 +254,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
 			})
 			It("PipelineRun should eventually finish", func() {
-				timeout = time.Minute * 20
+				timeout = time.Minute * 50
 				interval = time.Second * 10
 
 				Eventually(func() bool {
@@ -285,7 +285,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			It("eventually leads to another update of a PR with a comment about the PipelineRun status report", func() {
 				var comments []*github.IssueComment
 
-				timeout = time.Minute * 5
+				timeout = time.Minute * 20
 				interval = time.Second * 5
 
 				Eventually(func() bool {
@@ -317,7 +317,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			})
 
 			It("eventually leads to triggering another PipelineRun", func() {
-				timeout = time.Minute * 2
+				timeout = time.Minute * 10
 				interval = time.Second * 1
 
 				Eventually(func() bool {
@@ -330,7 +330,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the PipelineRun to start")
 			})
 			It("pipelineRun should eventually finish", func() {
-				timeout = time.Minute * 20
+				timeout = time.Minute * 50
 				interval = time.Second * 10
 
 				Eventually(func() bool {
@@ -372,7 +372,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			})
 
 			It("should no longer lead to a creation of a PaC PR", func() {
-				timeout = time.Second * 10
+				timeout = time.Second * 40
 				interval = time.Second * 2
 				Consistently(func() bool {
 					prs, err := f.CommonController.Github.ListPullRequests(helloWorldComponentGitSourceRepoName)
@@ -446,7 +446,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		for i, gitUrl := range componentUrls {
 			gitUrl := gitUrl
 			It(fmt.Sprintf("triggers PipelineRun for component with source URL %s", gitUrl), Label(buildTemplatesTestLabel), func() {
-				timeout := time.Minute * 5
+				timeout := time.Minute * 25
 				interval := time.Second * 1
 
 				Eventually(func() bool {
@@ -464,7 +464,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			gitUrl := gitUrl
 
 			It(fmt.Sprintf("should eventually finish successfully for component with source URL %s", gitUrl), Label(buildTemplatesTestLabel), func() {
-				timeout := time.Second * 1200
+				timeout := time.Second * 1800
 				interval := time.Second * 10
 				Eventually(func() bool {
 					pipelineRun, err := f.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, false, "")
@@ -587,7 +587,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 			componentName = fmt.Sprintf("build-suite-test-component-image-source-%s", util.GenerateRandomString(4))
 			outputContainerImage := ""
-			timeout = time.Second * 180
+			timeout = time.Second * 500
 			interval = time.Second * 1
 			// Create a component with containerImageSource being defined
 			_, err = f.HasController.CreateComponent(applicationName, componentName, testNamespace, "", "", containerImageSource, outputContainerImage, "", true)
@@ -658,7 +658,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
 
-			timeout = time.Second * 360
+			timeout = time.Second * 600
 			interval = time.Second * 1
 
 		})
@@ -745,7 +745,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			)
 			DeferCleanup(f.HasController.DeleteHasApplication, applicationName, testNamespace, false)
 
-			timeout = time.Minute * 5
+			timeout = time.Minute * 20
 			interval = time.Second * 1
 
 			dummySecret := &v1.Secret{
@@ -783,7 +783,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		})
 
 		It("should not be possible to push to quay.io repo (PipelineRun should fail)", func() {
-			timeout = time.Minute * 10
+			timeout = time.Minute * 30
 			interval = time.Second * 5
 			Eventually(func() bool {
 				pipelineRun, err := f.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")

--- a/tests/release/const.go
+++ b/tests/release/const.go
@@ -42,18 +42,18 @@ const (
 	releasePipelineBundleDefault         string = "quay.io/hacbs-release/pipeline-release:main"
 	roleName                             string = "role-release-service-account"
 
-	namespaceCreationTimeout              = 1 * time.Minute
-	namespaceDeletionTimeout              = 1 * time.Minute
-	snapshotCreationTimeout               = 1 * time.Minute
-	releaseStrategyCreationTimeout        = 1 * time.Minute
-	releasePlanCreationTimeout            = 1 * time.Minute
-	EnterpriseContractPolicyTimeout       = 1 * time.Minute
-	releasePlanAdmissionCreationTimeout   = 1 * time.Minute
-	releaseCreationTimeout                = 1 * time.Minute
-	releasePipelineRunCreationTimeout     = 5 * time.Minute
-	releasePipelineRunCompletionTimeout   = 20 * time.Minute
-	avgControllerQueryTimeout             = 1 * time.Minute
-	pipelineServiceAccountCreationTimeout = 3 * time.Minute
+	namespaceCreationTimeout              = 5 * time.Minute
+	namespaceDeletionTimeout              = 5 * time.Minute
+	snapshotCreationTimeout               = 5 * time.Minute
+	releaseStrategyCreationTimeout        = 5 * time.Minute
+	releasePlanCreationTimeout            = 5 * time.Minute
+	EnterpriseContractPolicyTimeout       = 5 * time.Minute
+	releasePlanAdmissionCreationTimeout   = 5 * time.Minute
+	releaseCreationTimeout                = 5 * time.Minute
+	releasePipelineRunCreationTimeout     = 25 * time.Minute
+	releasePipelineRunCompletionTimeout   = 40 * time.Minute
+	avgControllerQueryTimeout             = 5 * time.Minute
+	pipelineServiceAccountCreationTimeout = 7 * time.Minute
 
 	defaultInterval = 100 * time.Millisecond
 )


### PR DESCRIPTION
… slowness

# Description
We see e2e-test failing on CI and it's related to the quay.io incident of slowness, thus we increased timeouts of build and release tests trying to avoid this issue.  

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
