### PR TITLE
test: STONE-503 improve error message in e2e-demos-suite

### DIFF
--- a/tests/e2e-demos/e2e-demo.go
+++ b/tests/e2e-demos/e2e-demo.go
@@ -194,7 +194,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 					Eventually(func() bool {
 						return fw.IntegrationController.HaveHACBSTestsSucceeded(snapshot)
 
-					}, timeout, interval).Should(BeTrue(), "time out when trying to check if the snapshot is marked as successful")
+					}, timeout, interval).Should(BeTrue(), fmt.Sprintf("time out when trying to check if the snapshot %s is marked as successful", snapshot.Name))
 				})
 
 				It("checks if a snapshot environment binding is created successfully", func() {
@@ -203,14 +203,14 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 							envbinding, err := fw.IntegrationController.GetSnapshotEnvironmentBinding(application.Name, namespace, env)
 							Expect(err).ShouldNot(HaveOccurred())
 							Expect(envbinding != nil).To(BeTrue())
-							GinkgoWriter.Printf("The EnvironmentBinding %s is created\n", envbinding.Name)
+							GinkgoWriter.Printf("The SnapshotEnvironmentBinding %s is created\n", envbinding.Name)
 							return true
 						}
 
 						snapshot, err = fw.IntegrationController.GetApplicationSnapshot("", application.Name, namespace, component.Name)
 						Expect(err).ShouldNot(HaveOccurred())
 						return false
-					}, timeout, interval).Should(BeTrue(), "time out when waiting for release created")
+					}, timeout, interval).Should(BeTrue(), "time out when trying to check if SnapshotEnvironmentBinding is created")
 				})
 
 				// Deploy the component using gitops and check for the health


### PR DESCRIPTION
# Description

- Improve error msg in e2e-demos-suite to specify the snapshot in `time out when trying to check if the snapshot is marked as successful` error

## Issue ticket number and link
[STONE-503](https://issues.redhat.com/browse/STONE-503)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] DEVHAS-62 devfile source") 
- [ ] I have updated labels (if needed)
