### PR TITLE
fix: override default JBS cache resource requests

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -698,7 +698,6 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=

--- a/pkg/utils/jvmbuildservice/controller.go
+++ b/pkg/utils/jvmbuildservice/controller.go
@@ -67,7 +67,11 @@ func (s *SuiteController) CreateJBSConfig(name, namespace, imageRegistryOwner st
 				Repository: "test-images",
 				PrependTag: strconv.FormatInt(time.Now().UnixMilli(), 10),
 			},
-			CacheSettings: v1alpha1.CacheSettings{},
+			CacheSettings: v1alpha1.CacheSettings{
+				RequestMemory: "256Mi",
+				RequestCPU:    "100m",
+				Storage:       "1Gi",
+			},
 			BuildSettings: v1alpha1.BuildSettings{},
 			RelocationPatterns: []v1alpha1.RelocationPatternElement{
 				{


### PR DESCRIPTION
# Description

We've seen issues with jvm build service tests that failed on deploying the JBS cache

After looking at the real resource usage by JBS cache during test I decided to lower the default resource requests (including the PVC size - we're currently using up to ~200 MB)

![Screenshot 2023-02-13 at 16 39 26](https://user-images.githubusercontent.com/4881144/218504621-73acc4fc-ee30-4aa0-8c54-730d273ce1f7.png)

## Issue ticket number and link
Addresses https://issues.redhat.com/browse/STONEBLD-718

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

locally
```
ginkgo --focus "JVM Build" --v ./cmd/ -- --config-suites=$PWD/tests/e2e-demos/config/default.yaml
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
