### PR TITLE
fix: STONE-530 check nil pointer in "finds the snapshot and checks if it is marked as successful"

### DIFF
--- a/pkg/utils/integration/controller.go
+++ b/pkg/utils/integration/controller.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	appstudioApi "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	kubeCl "github.com/redhat-appstudio/e2e-tests/pkg/apis/kubernetes"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	integrationv1alpha1 "github.com/redhat-appstudio/integration-service/api/v1alpha1"
 	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -77,7 +78,11 @@ func (h *SuiteController) GetApplicationSnapshot(snapshotName, applicationName, 
 		}
 	}
 
-	return nil, nil
+	additionalInfo := utils.GetAdditionalInfo(applicationName, namespace)
+	if componentName != "" {
+		return &appstudioApi.Snapshot{}, fmt.Errorf("no snapshot found for component %s %s", componentName, additionalInfo)
+	}
+	return &appstudioApi.Snapshot{}, fmt.Errorf("no snapshot '%s' found %s", snapshotName, additionalInfo)
 }
 
 func (h *SuiteController) GetComponent(applicationName, namespace string) (*appstudioApi.Component, error) {
@@ -95,7 +100,7 @@ func (h *SuiteController) GetComponent(applicationName, namespace string) (*apps
 		}
 	}
 
-	return nil, nil
+	return &appstudioApi.Component{}, fmt.Errorf("no component found %s", utils.GetAdditionalInfo(applicationName, namespace))
 }
 
 func (h *SuiteController) GetReleasesWithApplicationSnapshot(applicationSnapshot *appstudioApi.Snapshot, namespace string) (*[]releasev1alpha1.Release, error) {
@@ -335,7 +340,7 @@ func (h *SuiteController) GetBuildPipelineRun(componentName, applicationName, na
 		return &list.Items[0], nil
 	}
 
-	return &tektonv1beta1.PipelineRun{}, fmt.Errorf("no pipelinerun found for component %s", componentName)
+	return &tektonv1beta1.PipelineRun{}, fmt.Errorf("no pipelinerun found for component %s %s", componentName, utils.GetAdditionalInfo(applicationName, namespace))
 }
 
 // GetComponentPipeline returns the pipeline for a given component labels
@@ -361,7 +366,7 @@ func (h *SuiteController) GetIntegrationPipelineRun(integrationTestScenarioName 
 		return &list.Items[0], nil
 	}
 
-	return &tektonv1beta1.PipelineRun{}, fmt.Errorf("no pipelinerun found for integrationTestScenario %s", integrationTestScenarioName)
+	return &tektonv1beta1.PipelineRun{}, fmt.Errorf("no pipelinerun found for integrationTestScenario %s (snapshot: %s, namespace: %s)", integrationTestScenarioName, applicationSnapshotName, namespace)
 }
 
 // GetComponentPipeline returns the pipeline for a given component labels
@@ -382,5 +387,5 @@ func (h *SuiteController) GetSnapshotEnvironmentBinding(applicationName string, 
 		}
 	}
 
-	return nil, nil
+	return &appstudioApi.SnapshotEnvironmentBinding{}, fmt.Errorf("no SnapshotEnvironmentBinding found in environment %s %s", environment.Name, utils.GetAdditionalInfo(applicationName, namespace))
 }

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -184,3 +184,8 @@ func ToPrettyJSONString(v interface{}) string {
 	s, _ := json.MarshalIndent(v, "", "  ")
 	return string(s)
 }
+
+// GetAdditionalInfo adds information regarding the application name and namespace of the test
+func GetAdditionalInfo(applicationName, namespace string) string {
+	return fmt.Sprintf("(application: %s, namespace: %s)", applicationName, namespace)
+}

--- a/tests/e2e-demos/e2e-demo.go
+++ b/tests/e2e-demos/e2e-demo.go
@@ -199,7 +199,10 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 					Expect(err).ShouldNot(HaveOccurred())
 
 					Eventually(func() bool {
-						return fw.IntegrationController.HaveHACBSTestsSucceeded(snapshot)
+						if snapshot != nil {
+							return fw.IntegrationController.HaveHACBSTestsSucceeded(snapshot)
+						}
+						return false
 
 					}, timeout, interval).Should(BeTrue(), fmt.Sprintf("time out when trying to check if the snapshot %s is marked as successful", snapshot.Name))
 				})

--- a/tests/e2e-demos/e2e-demo.go
+++ b/tests/e2e-demos/e2e-demo.go
@@ -195,16 +195,13 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 					timeout = time.Second * 600
 					interval = time.Second * 10
 
-					snapshot, err = fw.IntegrationController.GetApplicationSnapshot("", application.Name, namespace, component.Name)
-					Expect(err).ShouldNot(HaveOccurred())
-
 					Eventually(func() bool {
-						if snapshot != nil {
-							return fw.IntegrationController.HaveHACBSTestsSucceeded(snapshot)
+						snapshot, err = fw.IntegrationController.GetApplicationSnapshot("", application.Name, namespace, component.Name)
+						if err != nil {
+							GinkgoWriter.Println("snapshot has not been found yet")
+							return false
 						}
-						snapshot, _ = fw.IntegrationController.GetApplicationSnapshot("", application.Name, namespace, component.Name)
-						Expect(err).ShouldNot(HaveOccurred())
-						return false
+						return fw.IntegrationController.HaveHACBSTestsSucceeded(snapshot)
 
 					}, timeout, interval).Should(BeTrue(), fmt.Sprintf("time out when trying to check if the snapshot %s is marked as successful", snapshot.Name))
 				})
@@ -213,14 +210,13 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 					Eventually(func() bool {
 						if fw.IntegrationController.HaveHACBSTestsSucceeded(snapshot) {
 							envbinding, err := fw.IntegrationController.GetSnapshotEnvironmentBinding(application.Name, namespace, env)
-							Expect(err).ShouldNot(HaveOccurred())
-							Expect(envbinding != nil).To(BeTrue())
+							if err != nil {
+								GinkgoWriter.Println("SnapshotEnvironmentBinding has not been found yet")
+								return false
+							}
 							GinkgoWriter.Printf("The SnapshotEnvironmentBinding %s is created\n", envbinding.Name)
 							return true
 						}
-
-						snapshot, err = fw.IntegrationController.GetApplicationSnapshot("", application.Name, namespace, component.Name)
-						Expect(err).ShouldNot(HaveOccurred())
 						return false
 					}, timeout, interval).Should(BeTrue(), fmt.Sprintf("time out when trying to check if SnapshotEnvironmentBinding is created (snapshot: %s, env: %s)", snapshot.Name, env.Name))
 				})

--- a/tests/e2e-demos/e2e-demo.go
+++ b/tests/e2e-demos/e2e-demo.go
@@ -202,6 +202,8 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 						if snapshot != nil {
 							return fw.IntegrationController.HaveHACBSTestsSucceeded(snapshot)
 						}
+						snapshot, _ = fw.IntegrationController.GetApplicationSnapshot("", application.Name, namespace, component.Name)
+						Expect(err).ShouldNot(HaveOccurred())
 						return false
 
 					}, timeout, interval).Should(BeTrue(), fmt.Sprintf("time out when trying to check if the snapshot %s is marked as successful", snapshot.Name))

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -198,12 +198,20 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				interval = time.Second * 10
 				Eventually(func() bool {
 					if f.IntegrationController.HaveHACBSTestsSucceeded(applicationSnapshot_push) {
-						component, _ := f.IntegrationController.GetComponent(applicationName, appStudioE2EApplicationsNamespace)
+						component, err := f.IntegrationController.GetComponent(applicationName, appStudioE2EApplicationsNamespace)
+						if err != nil {
+							GinkgoWriter.Println("component has not been found yet")
+							return false
+						}
 						Expect(component.Spec.ContainerImage != "").To(BeTrue())
 						GinkgoWriter.Printf("Global candidate is updated\n")
 						return true
 					}
 					applicationSnapshot_push, err = f.IntegrationController.GetApplicationSnapshot(applicationSnapshot_push.Name, "", appStudioE2EApplicationsNamespace, "")
+					if err != nil {
+						GinkgoWriter.Printf("snapshot %s has not been found yet\n", applicationSnapshot_push.Name)
+						return false
+					}
 					return false
 				}, timeout, interval).Should(BeTrue(), "time out when waiting for updating the global candidate")
 			})
@@ -225,6 +233,10 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 						return true
 					}
 					applicationSnapshot_push, err = f.IntegrationController.GetApplicationSnapshot(applicationSnapshot_push.Name, "", appStudioE2EApplicationsNamespace, "")
+					if err != nil {
+						GinkgoWriter.Printf("snapshot %s has not been found yet\n", applicationSnapshot_push.Name)
+						return false
+					}
 					return false
 				}, timeout, interval).Should(BeTrue(), "time out when waiting for release created")
 			})
@@ -241,6 +253,10 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 						return true
 					}
 					applicationSnapshot_push, err = f.IntegrationController.GetApplicationSnapshot(applicationSnapshot_push.Name, "", appStudioE2EApplicationsNamespace, "")
+					if err != nil {
+						GinkgoWriter.Printf("snapshot %s has not been found yet\n", applicationSnapshot_push.Name)
+						return false
+					}
 					return false
 				}, timeout, interval).Should(BeTrue(), "time out when waiting for release created")
 			})

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -210,7 +210,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 					applicationSnapshot_push, err = f.IntegrationController.GetApplicationSnapshot(applicationSnapshot_push.Name, "", appStudioE2EApplicationsNamespace, "")
 					if err != nil {
 						GinkgoWriter.Printf("snapshot %s has not been found yet\n", applicationSnapshot_push.Name)
-						return false
 					}
 					return false
 				}, timeout, interval).Should(BeTrue(), "time out when waiting for updating the global candidate")
@@ -235,7 +234,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 					applicationSnapshot_push, err = f.IntegrationController.GetApplicationSnapshot(applicationSnapshot_push.Name, "", appStudioE2EApplicationsNamespace, "")
 					if err != nil {
 						GinkgoWriter.Printf("snapshot %s has not been found yet\n", applicationSnapshot_push.Name)
-						return false
 					}
 					return false
 				}, timeout, interval).Should(BeTrue(), "time out when waiting for release created")
@@ -255,7 +253,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 					applicationSnapshot_push, err = f.IntegrationController.GetApplicationSnapshot(applicationSnapshot_push.Name, "", appStudioE2EApplicationsNamespace, "")
 					if err != nil {
 						GinkgoWriter.Printf("snapshot %s has not been found yet\n", applicationSnapshot_push.Name)
-						return false
 					}
 					return false
 				}, timeout, interval).Should(BeTrue(), "time out when waiting for release created")


### PR DESCRIPTION
# Description
- Improved `It` `finds the snapshot and checks if it is marked as successful` and `It` `checks if a snapshot environment binding is created successfully`
- Added error (in case of not finding the resource) in `GetComponent`, `GetApplicationSnapshot`, and `GetSnapshotEnvironmentBinding`
- Improved error in `GetBuildPipelineRun` and `GetIntegrationPipelineRun`

## Issue ticket number and link
[STONE-530](https://issues.redhat.com/browse/STONE-530)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
`make local/test/e2e `

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
