### PR TITLE
feat(HACBS-1669): add case for running release-service PR check

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/devfile/library/pkg/util"
-	"k8s.io/apimachinery/pkg/runtime"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/devfile/library/pkg/util"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -270,6 +271,10 @@ func (ci CI) setRequiredEnvVars() error {
 				envVarPrefix = "JVM_BUILD_SERVICE"
 				imageTagSuffix = "jvm-build-service-image"
 				testSuiteLabel = "jvm-build"
+			case strings.Contains(jobName, "release-service"):
+				envVarPrefix = "RELEASE_SERVICE"
+				imageTagSuffix = "release-service-image"
+				testSuiteLabel = "release"
 
 				// Since CI requires to have default values for dependency images
 				// (https://github.com/openshift/release/blob/master/ci-operator/step-registry/redhat-appstudio/e2e/redhat-appstudio-e2e-ref.yaml#L15)


### PR DESCRIPTION
# Description

This is needed in order to be able to execute only the release tests when e2e tests are triggered from release-service repo.

## Issue ticket number and link

https://issues.redhat.com/browse/HACBS-1669

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

No testing. But I verified that the label string is the one the tests in `tests/release` set.

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [X] I have updated labels (if needed)
