### PR TITLE
fix: release-service CI config

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -267,15 +267,14 @@ func (ci CI) setRequiredEnvVars() error {
 				envVarPrefix = "HAS"
 				imageTagSuffix = "has-image"
 				testSuiteLabel = "has,e2e-demo"
-			case strings.Contains(jobName, "jvm-build-service"):
-				envVarPrefix = "JVM_BUILD_SERVICE"
-				imageTagSuffix = "jvm-build-service-image"
-				testSuiteLabel = "jvm-build"
 			case strings.Contains(jobName, "release-service"):
 				envVarPrefix = "RELEASE_SERVICE"
 				imageTagSuffix = "release-service-image"
 				testSuiteLabel = "release"
-
+			case strings.Contains(jobName, "jvm-build-service"):
+				envVarPrefix = "JVM_BUILD_SERVICE"
+				imageTagSuffix = "jvm-build-service-image"
+				testSuiteLabel = "jvm-build"
 				// Since CI requires to have default values for dependency images
 				// (https://github.com/openshift/release/blob/master/ci-operator/step-registry/redhat-appstudio/e2e/redhat-appstudio-e2e-ref.yaml#L15)
 				// we cannot let these env vars to have identical names in CI as those env vars used in tests


### PR DESCRIPTION
# Description

jvm-build-service CI config was accidentally broken by a [config for another service](https://github.com/redhat-appstudio/e2e-tests/pull/353/files)
This PR fixes it

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
