### PR TITLE
fix: Fixes pipelinerun retrigger

### DIFF
--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -16,16 +16,6 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
 )
 
-type UserControllerHub struct {
-	HasController             *has.SuiteController
-	CommonController          *common.SuiteController
-	GitOpsController          *gitops.SuiteController
-	SPIController             *spi.SuiteController
-	IntegrationController     *integration.SuiteController
-	TektonController          *tekton.SuiteController
-	JvmbuildserviceController *jvmbuildservice.SuiteController
-}
-
 type ControllerHub struct {
 	HasController             *has.SuiteController
 	CommonController          *common.SuiteController


### PR DESCRIPTION
# Description

We are removing pipelineruns without checking if the pipelinerun failed. Im changing the flow to use `CurrentSpecReport().NumAttempts` to retrigger a pipelinerun.

## Issue ticket number and link
https://issues.redhat.com/browse/STONEBLD-754
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
