### PR TITLE
test: STONE-604 increase timeout and improve GetIntegrationTestScenarios to consider application

### DIFF
--- a/pkg/utils/integration/controller.go
+++ b/pkg/utils/integration/controller.go
@@ -133,7 +133,14 @@ func (h *SuiteController) GetIntegrationTestScenarios(applicationName, namespace
 	if err != nil {
 		return nil, err
 	}
-	return &integrationTestScenarioList.Items, nil
+
+	items := make([]integrationv1alpha1.IntegrationTestScenario, 0)
+	for _, t := range integrationTestScenarioList.Items {
+		if t.Spec.Application == applicationName {
+			items = append(items, t)
+		}
+	}
+	return &items, nil
 }
 
 func (h *SuiteController) CreateEnvironment(namespace string, environmenName string) (*appstudioApi.Environment, error) {

--- a/pkg/utils/integration/controller.go
+++ b/pkg/utils/integration/controller.go
@@ -244,7 +244,7 @@ func (h *SuiteController) CreateReleasePlan(applicationName, namespace string) (
 	return testReleasePlan, err
 }
 
-func (h *SuiteController) CreateIntegrationPipelineRun(applicationSnapshotName, namespace, componentName string) (*tektonv1beta1.PipelineRun, error) {
+func (h *SuiteController) CreateIntegrationPipelineRun(applicationSnapshotName, namespace, componentName, integrationTestScenarioName string) (*tektonv1beta1.PipelineRun, error) {
 	testpipelineRun := &tektonv1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "component-pipelinerun" + "-",
@@ -254,7 +254,7 @@ func (h *SuiteController) CreateIntegrationPipelineRun(applicationSnapshotName, 
 				"appstudio.openshift.io/component":      componentName,
 				"pipelines.appstudio.openshift.io/type": "test",
 				"appstudio.openshift.io/snapshot":       applicationSnapshotName,
-				"test.appstudio.openshift.io/scenario":  "example-pass",
+				"test.appstudio.openshift.io/scenario":  integrationTestScenarioName,
 			},
 		},
 		Spec: tektonv1beta1.PipelineRunSpec{
@@ -283,7 +283,7 @@ func (h *SuiteController) CreateIntegrationPipelineRun(applicationSnapshotName, 
 func (h *SuiteController) CreateIntegrationTestScenario(applicationName, namespace, bundleURL, pipelineName string) (*integrationv1alpha1.IntegrationTestScenario, error) {
 	integrationTestScenario := &integrationv1alpha1.IntegrationTestScenario{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-pass",
+			Name:      "example-pass-" + util.GenerateRandomString(4),
 			Namespace: namespace,
 			Labels: map[string]string{
 				"test.appstudio.openshift.io/optional": "false",

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -51,7 +51,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			Expect(utils.WaitUntil(f.AsKubeAdmin.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 			)
-			DeferCleanup(f.AsKubeAdmin.HasController.DeleteHasApplication, applicationName, appStudioE2EApplicationsNamespace, false)
+			//	DeferCleanup(f.AsKubeAdmin.HasController.DeleteHasApplication, applicationName, appStudioE2EApplicationsNamespace, false)
 
 			componentName = fmt.Sprintf("integration-suite-test-component-git-source-%s", util.GenerateRandomString(4))
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
@@ -60,7 +60,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			// Create a component with Git Source URL being defined
 			_, err = f.AsKubeAdmin.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, gitSourceURL, "", "", outputContainerImage, "", true)
 			Expect(err).ShouldNot(HaveOccurred())
-			DeferCleanup(f.AsKubeAdmin.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace, false)
+			//	DeferCleanup(f.AsKubeAdmin.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace, false)
 
 			_, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario(applicationName, appStudioE2EApplicationsNamespace, BundleURL, InPipelineName)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -171,7 +171,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				Expect(err).ShouldNot(HaveOccurred())
 
 				for _, testScenario := range *integrationTestScenarios {
-					timeout = time.Second * 60
+					timeout = time.Minute * 5
 					interval = time.Second * 2
 					Eventually(func() bool {
 						pipelineRun, err := f.AsKubeAdmin.IntegrationController.GetIntegrationPipelineRun(testScenario.Name, applicationSnapshot_push.Name, appStudioE2EApplicationsNamespace)

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -51,7 +51,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			Expect(utils.WaitUntil(f.AsKubeAdmin.CommonController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
 				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
 			)
-			//	DeferCleanup(f.AsKubeAdmin.HasController.DeleteHasApplication, applicationName, appStudioE2EApplicationsNamespace, false)
 
 			componentName = fmt.Sprintf("integration-suite-test-component-git-source-%s", util.GenerateRandomString(4))
 			outputContainerImage = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), strings.Replace(uuid.New().String(), "-", "", -1))
@@ -60,7 +59,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			// Create a component with Git Source URL being defined
 			_, err = f.AsKubeAdmin.HasController.CreateComponent(applicationName, componentName, appStudioE2EApplicationsNamespace, gitSourceURL, "", "", outputContainerImage, "", true)
 			Expect(err).ShouldNot(HaveOccurred())
-			//	DeferCleanup(f.AsKubeAdmin.HasController.DeleteHasComponent, componentName, appStudioE2EApplicationsNamespace, false)
 
 			_, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario(applicationName, appStudioE2EApplicationsNamespace, BundleURL, InPipelineName)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -126,7 +126,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				integrationTestScenarios, err := f.AsKubeAdmin.IntegrationController.GetIntegrationTestScenarios(applicationName, appStudioE2EApplicationsNamespace)
 				Expect(err).ShouldNot(HaveOccurred())
 				for _, testScenario := range *integrationTestScenarios {
-					timeout = time.Minute * 2
+					timeout = time.Minute * 5
 					interval = time.Second * 2
 					Eventually(func() bool {
 						pipelineRun, err := f.AsKubeAdmin.IntegrationController.GetIntegrationPipelineRun(testScenario.Name, applicationSnapshot.Name, appStudioE2EApplicationsNamespace)

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -126,7 +126,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				integrationTestScenarios, err := f.AsKubeAdmin.IntegrationController.GetIntegrationTestScenarios(applicationName, appStudioE2EApplicationsNamespace)
 				Expect(err).ShouldNot(HaveOccurred())
 				for _, testScenario := range *integrationTestScenarios {
-					timeout = time.Second * 60
+					timeout = time.Minute * 2
 					interval = time.Second * 2
 					Eventually(func() bool {
 						pipelineRun, err := f.AsKubeAdmin.IntegrationController.GetIntegrationPipelineRun(testScenario.Name, applicationSnapshot.Name, appStudioE2EApplicationsNamespace)


### PR DESCRIPTION
# Description
- Deleted DeferCleanup in IntegrationServiceSuite
- Integration test scenario name random in order to avoid error related to "example-pass already exists" when running locally
- Updated CreateIntegrationPipelineRun (that is not being used. maybe we could delete it)
- Increased timeout from 60s to 5min
- Improved GetIntegrationTestScenarios to consider application

## Issue ticket number and link
[STONE-604](https://issues.redhat.com/browse/STONE-604)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
