### PR TITLE
fix: update e2e issue reporting section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Parameters:
 | `project-id` | string | Polarion project ID  | `AppStudio`  |
 
 # Reporting issues
-For reporting issues with e2e tests please use [RHDP JIRA project](https://issues.redhat.com/projects/RHDP) - please use labels `appstudio` and `quality`. If the issues is also relevant to CI - for example it is blocking PRs, the also use label `appstudio-e2e-tests-known-issues`.
+For reporting issues with e2e tests please use [STONE Jira project](https://issues.redhat.com/browse/STONE) - please use labels `ci-fail` and `quality`. For existing issues, see [this Jira query](https://issues.redhat.com/issues/?jql=labels%20%3D%20%22ci-fail%22%20and%20labels%20%3D%20%22quality%22%20and%20resolution%20%3D%20unresolved).
 
 # Debugging tests
 ## In vscode


### PR DESCRIPTION
# Description

It turns out different labels are used nowadays.

## Issue ticket number and link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

N/A

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [X] I have updated labels (if needed)
