### PR TITLE
fix: CI setup for PRs from upstream branch

### DIFF
--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -62,17 +62,18 @@ func sendHttpRequestAndParseResponse(url, method string, v interface{}) error {
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("token %s", os.Getenv("GITHUB_TOKEN")))
 	res, err := http.DefaultClient.Do(req)
-	klog.Infof("response status code: '%d'", res.StatusCode)
-
 	if err != nil {
 		return fmt.Errorf("error when sending request to '%s': %+v", url, err)
 	}
 	defer res.Body.Close()
 	body, err := io.ReadAll(res.Body)
-
 	if err != nil {
 		return fmt.Errorf("error when reading the response body from URL '%s': %+v", url, err)
 	}
+	if res.StatusCode > 299 {
+		return fmt.Errorf("unexpected status code: %d, response body: %s", res.StatusCode, string(body))
+	}
+
 	if err := json.Unmarshal(body, v); err != nil {
 		return fmt.Errorf("error when unmarshalling the response body from URL '%s': %+v", url, err)
 	}


### PR DESCRIPTION
# Description

* should handle issues caused by PRs created from upstream branches (not forks), for example [PRs created by dependabot](https://github.com/redhat-appstudio/e2e-tests/pull/364)
* handle reponse statuscode >299 as error (and print the response body) during PR pairing

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
TBD

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
