### PR TITLE
test: added e2e test that verifies if rebuild uses cached dependencies

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -80,10 +80,12 @@ const (
 	DefaultImagePushRepo = "quay.io/redhat-appstudio-qe/test-images"
 
 	BuildTaskRunName = "build-container"
+
+	ComponentInitialBuildAnnotationKey = "appstudio.openshift.io/component-initial-build"
 )
 
 var (
 	ComponentDefaultLabel         = map[string]string{"e2e-test": "true"}
-	ComponentDefaultAnnotation    = map[string]string{"appstudio.openshift.io/component-initial-build": "processed"}
+	ComponentDefaultAnnotation    = map[string]string{ComponentInitialBuildAnnotationKey: "processed"}
 	ComponentPaCRequestAnnotation = map[string]string{"appstudio.openshift.io/pac-provision": "request"}
 )

--- a/pkg/utils/tekton/controller.go
+++ b/pkg/utils/tekton/controller.go
@@ -9,6 +9,7 @@ import (
 
 	buildservice "github.com/redhat-appstudio/build-service/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 
@@ -105,6 +106,10 @@ func (s *SuiteController) NewBundles() (*Bundles, error) {
 
 func (s *SuiteController) GetPipelineRun(pipelineRunName, namespace string) (*v1beta1.PipelineRun, error) {
 	return s.PipelineClient().TektonV1beta1().PipelineRuns(namespace).Get(context.TODO(), pipelineRunName, metav1.GetOptions{})
+}
+
+func (s *SuiteController) WatchPipelineRun(ctx context.Context, namespace string) (watch.Interface, error) {
+	return s.PipelineClient().TektonV1beta1().PipelineRuns(namespace).Watch(ctx, metav1.ListOptions{})
 }
 
 func (s *SuiteController) fetchContainerLog(podName, containerName, namespace string) (string, error) {

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/devfile/library/pkg/util"
 	"github.com/google/uuid"
@@ -356,6 +357,136 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 				} else {
 					doCollectLogs = true
 					Skip("SKIPPING: unstable feature: timed-out when waiting for some artifactbuilds and dependencybuilds complete")
+				}
+			}
+		})
+
+		It("all artifactbuild and dependencybuilds complete", func() {
+			err = wait.PollImmediate(interval, 2*timeout, func() (done bool, err error) {
+				abList, err := f.AsKubeAdmin.JvmbuildserviceController.ListArtifactBuilds(testNamespace)
+				Expect(err).ShouldNot(HaveOccurred(), "error in listing artifact builds")
+				// we want to make sure there is more than one ab and that they are all complete
+				abComplete := len(abList.Items) > 0
+				GinkgoWriter.Printf("number of artifactbuilds: %d", len(abList.Items))
+				for _, ab := range abList.Items {
+					if ab.Status.State != v1alpha1.ArtifactBuildStateComplete {
+						GinkgoWriter.Printf("artifactbuild %s not complete", ab.Spec.GAV)
+						abComplete = false
+						break
+					}
+				}
+				dbList, err := f.AsKubeAdmin.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
+				Expect(err).ShouldNot(HaveOccurred(), "error in listing dependency builds")
+				dbComplete := len(dbList.Items) > 0
+				GinkgoWriter.Printf("number of dependencybuilds: %d", len(dbList.Items))
+				for _, db := range dbList.Items {
+					if db.Status.State != v1alpha1.DependencyBuildStateComplete {
+						GinkgoWriter.Printf("dependencybuild %s not complete", db.Spec.ScmInfo.SCMURL)
+						dbComplete = false
+						break
+					} else if db.Status.State == v1alpha1.DependencyBuildStateFailed {
+						Fail(fmt.Sprintf("dependencybuild %s FAILED", db.Spec.ScmInfo.SCMURL))
+					}
+				}
+				if abComplete && dbComplete {
+					return true, nil
+				}
+				return false, nil
+			})
+			if err != nil {
+				Fail("timed out waiting for some artifactbuilds and dependencybuilds to complete")
+			}
+		})
+
+		It("does rebuild use cached dependencies", func() {
+			prun := &v1beta1.PipelineRun{}
+
+			component, err := f.AsKubeAdmin.HasController.GetHasComponent(componentName, testNamespace)
+			Expect(err).ShouldNot(HaveOccurred(), "could not get component")
+
+			annotations := component.GetAnnotations()
+			delete(annotations, constants.ComponentInitialBuildAnnotationKey)
+			component.SetAnnotations(annotations)
+			Expect(f.AsKubeAdmin.CommonController.KubeRest().Update(context.TODO(), component, &client.UpdateOptions{})).To(Succeed())
+
+			Eventually(func() bool {
+				prun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			ctx := context.TODO()
+
+			watch, err := f.AsKubeAdmin.TektonController.WatchPipelineRun(ctx, testNamespace)
+			Expect(err).ShouldNot(HaveOccurred(), "watch pipelinerun failed")
+
+			exitForLoop := false
+
+			for {
+				select {
+				case <-time.After(15 * time.Minute):
+					Fail("timed out waiting for second build to complete")
+				case event := <-watch.ResultChan():
+					if event.Object == nil {
+						continue
+					}
+					pr, ok := event.Object.(*v1beta1.PipelineRun)
+					if !ok {
+						continue
+					}
+					if prun.Name != pr.Name {
+						if pr.IsDone() {
+							GinkgoWriter.Printf("got event for pipelinerun %s in a terminal state", pr.Name)
+							continue
+						}
+						Fail("another non-completed pipeline run was generated when it should not")
+					}
+					GinkgoWriter.Printf("done processing event for pr %s", pr.Name)
+					if pr.IsDone() {
+						GinkgoWriter.Println("pr is done")
+
+						podClient := f.AsKubeAdmin.CommonController.KubeInterface().CoreV1().Pods(testNamespace)
+						listOptions := metav1.ListOptions{
+							LabelSelector: fmt.Sprintf("tekton.dev/pipelineRun=%s", pr.Name),
+						}
+						podList, err := podClient.List(context.TODO(), listOptions)
+						Expect(err).ShouldNot(HaveOccurred(), "error listing pr pods")
+
+						pods := podList.Items
+
+						if len(pods) == 0 {
+							Fail("pod for pipeline run unexpectedly missing")
+						}
+
+						containers := []corev1.Container{}
+						containers = append(containers, pods[0].Spec.InitContainers...)
+						containers = append(containers, pods[0].Spec.Containers...)
+
+						for _, container := range containers {
+							if !strings.Contains(container.Name, "analyse-dependecies") {
+								continue
+							}
+							cLog, err := f.AsKubeAdmin.CommonController.GetContainerLogs(pods[0].Name, container.Name, testNamespace)
+							Expect(err).ShouldNot(HaveOccurred(), "getting container logs failed")
+							if strings.Contains(cLog, "\"publisher\" : \"central\"") {
+								Fail(fmt.Sprintf("pipelinerun %s has container %s with dep analysis still pointing to central %s", pr.Name, container.Name, cLog))
+							}
+							if !strings.Contains(cLog, "\"publisher\" : \"rebuilt\"") {
+								Fail(fmt.Sprintf("pipelinerun %s has container %s with dep analysis that does not access rebuilt %s", pr.Name, container.Name, cLog))
+							}
+							if !strings.Contains(cLog, "\"java:scm-uri\" : \"https://github.com/stuartwdouglas/hacbs-test-simple-jdk8.git\"") {
+								Fail(fmt.Sprintf("pipelinerun %s has container %s with dep analysis did not include java:scm-uri %s", pr.Name, container.Name, cLog))
+							}
+							if !strings.Contains(cLog, "\"java:scm-commit\" : \"") {
+								Fail(fmt.Sprintf("pipelinerun %s has container %s with dep analysis did not include java:scm-commit %s", pr.Name, container.Name, cLog))
+							}
+							break
+						}
+						GinkgoWriter.Println("pr is done and has correct analyse-dependecies output, exiting")
+						exitForLoop = true
+					}
+				}
+				if exitForLoop {
+					break
 				}
 			}
 		})

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -410,7 +410,7 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 			Expect(f.AsKubeAdmin.CommonController.KubeRest().Update(context.TODO(), component, &client.UpdateOptions{})).To(Succeed())
 
 			Eventually(func() bool {
-				prun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, false, "")
+				prun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -367,10 +367,10 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 				Expect(err).ShouldNot(HaveOccurred(), "error in listing artifact builds")
 				// we want to make sure there is more than one ab and that they are all complete
 				abComplete := len(abList.Items) > 0
-				GinkgoWriter.Printf("number of artifactbuilds: %d", len(abList.Items))
+				GinkgoWriter.Printf("number of artifactbuilds: %d\n", len(abList.Items))
 				for _, ab := range abList.Items {
 					if ab.Status.State != v1alpha1.ArtifactBuildStateComplete {
-						GinkgoWriter.Printf("artifactbuild %s not complete", ab.Spec.GAV)
+						GinkgoWriter.Printf("artifactbuild %s not complete\n", ab.Spec.GAV)
 						abComplete = false
 						break
 					}
@@ -378,10 +378,10 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 				dbList, err := f.AsKubeAdmin.JvmbuildserviceController.ListDependencyBuilds(testNamespace)
 				Expect(err).ShouldNot(HaveOccurred(), "error in listing dependency builds")
 				dbComplete := len(dbList.Items) > 0
-				GinkgoWriter.Printf("number of dependencybuilds: %d", len(dbList.Items))
+				GinkgoWriter.Printf("number of dependencybuilds: %d\n", len(dbList.Items))
 				for _, db := range dbList.Items {
 					if db.Status.State != v1alpha1.DependencyBuildStateComplete {
-						GinkgoWriter.Printf("dependencybuild %s not complete", db.Spec.ScmInfo.SCMURL)
+						GinkgoWriter.Printf("dependencybuild %s not complete\n", db.Spec.ScmInfo.SCMURL)
 						dbComplete = false
 						break
 					} else if db.Status.State == v1alpha1.DependencyBuildStateFailed {
@@ -435,12 +435,12 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 					}
 					if prun.Name != pr.Name {
 						if pr.IsDone() {
-							GinkgoWriter.Printf("got event for pipelinerun %s in a terminal state", pr.Name)
+							GinkgoWriter.Printf("got event for pipelinerun %s in a terminal state\n", pr.Name)
 							continue
 						}
 						Fail("another non-completed pipeline run was generated when it should not")
 					}
-					GinkgoWriter.Printf("done processing event for pr %s", pr.Name)
+					GinkgoWriter.Printf("done processing event for pr %s\n", pr.Name)
 					if pr.IsDone() {
 						GinkgoWriter.Println("pr is done")
 

--- a/tests/e2e-demos/e2e-demo.go
+++ b/tests/e2e-demos/e2e-demo.go
@@ -30,8 +30,6 @@ const (
 
 	// Environment name used for e2e-tests demos
 	SPIQuaySecretName string = "e2e-quay-secret"
-
-	InitialBuildAnnotationName = "appstudio.openshift.io/component-initial-build"
 )
 
 var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
@@ -195,7 +193,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 						err = fw.AsKubeAdmin.TektonController.DeletePipelineRun(pipelineRun.Name, namespace)
 						Expect(err).ShouldNot(HaveOccurred(), "failed to delete pipelinerun when retriger: %v", err)
 
-						delete(component.Annotations, InitialBuildAnnotationName)
+						delete(component.Annotations, constants.ComponentInitialBuildAnnotationKey)
 						err = fw.AsKubeDeveloper.HasController.KubeRest().Update(context.Background(), component)
 						Expect(err).ShouldNot(HaveOccurred(), "failed to update component to trigger another pipeline build: %v", err)
 					}


### PR DESCRIPTION
# Description

Added an e2e-test that verifies that a rebuild of the same component uses cached dependencies from [jvm-build-service](https://github.com/redhat-appstudio/jvm-build-service/pull/199/files#diff-a298302321bbcd7e01a1f88bc21771a734b8c31b3a05c26cc70070afbba083fbR272).

I also had to add a test that checks if all artifactbuild and dependencybuilds are complete and I added a `ComponentInitialBuildAnnotationKey` constant and edited files that use it.

## Issue ticket number and link

https://issues.redhat.com/browse/STONEBLD-61

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
ginkgo -v --label-filter "jvm-build" ./cmd -- --config-suites="$PWD/tests/e2e-demos/config/default.yaml"
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
