### PR TITLE
fix: cleanup repositories when using github org seperate from redhat-appstudio-qe

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -133,7 +133,8 @@ func (Local) CleanupGithubOrg() error {
 	}
 
 	// Get all repos
-	ghClient := github.NewGithubClient(githubToken, "redhat-appstudio-qe")
+	githubOrgName := utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe")
+	ghClient := github.NewGithubClient(githubToken, githubOrgName)
 	repos, err := ghClient.GetAllRepositories()
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

When using MY_GITHUB_ORG env value different from redhat-appstudio-qe, it was creating repositories on my local github organization, so to clean up the repositories in my github org, we have to use the same MY_GITHUB_ORG environment when set.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I have tested it with setting my github org.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
