### PR TITLE
fix: update mvp-demo "untrusted" build template

### DIFF
--- a/tests/mvp-demo/mvp-demo.go
+++ b/tests/mvp-demo/mvp-demo.go
@@ -41,7 +41,7 @@ const (
 	// This pipeline contains an image that comes from "not allowed" container image registry repo
 	// https://github.com/hacbs-contract/ec-policies/blob/de8afa912e7a80d02abb82358ce7b23cf9a286c8/data/rule_data.yml#L9-L12
 	// It is required in order to test that the release of the image failed based on a failed check in EC
-	untrustedPipelineBundle = "quay.io/psturc/pipeline-docker-build:2023-02-17-162546@sha256:470155be2886a81fd03afae53b559beec038d449d712aa54b93788c7a719f50a"
+	untrustedPipelineBundle = "quay.io/psturc/pipeline-docker-build:2023-03-07-104058@sha256:7e64d34d73b185df301ffd96271196cd547f2c1148471865d1d16d915ddf4e74"
 )
 
 var sampleRepoURL = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), sampleRepoName)


### PR DESCRIPTION
# Description

the "untrusted" docker-build pipeline bundle had to be updated due to [latest changes in build-definitions](https://github.com/redhat-appstudio/build-definitions/pull/337)

This is just a hot fix to make e2e in https://github.com/redhat-appstudio/infra-deployments/pull/1441 pass. There will be a follow-up fix to add a functionality for building the "untrusted" bundle from the latest build templates at the beginning of the test, so the bundle is always up-to-date

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
```
ginkgo --label-filter="mvp-demo" --v ./cmd -- --config-suites=$PWD/tests/e2e-demos/config/default.yaml
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
