### PR TITLE
fix: PR and TR status checks

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -78,6 +78,8 @@ const (
 	BuildPipelineSelectorYamlURL = "https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/build-service/base/build-pipeline-selector.yaml"
 
 	DefaultImagePushRepo = "quay.io/redhat-appstudio-qe/test-images"
+
+	BuildTaskRunName = "build-container"
 )
 
 var (


### PR DESCRIPTION
# Description

* workaround an issue with checking the pipelinerun status in openshift pipelines 1.9
  * issue in OSP reported [here](https://issues.redhat.com/browse/SRVKP-2880)
  * the issue in the test mentioned [here](https://github.com/redhat-appstudio/infra-deployments/pull/1441#issuecomment-1458165050)
* updated `WaitForComponentPipelineToBeFinished` method to use [pr.IsDone()](https://pkg.go.dev/github.com/tektoncd/pipeline@v0.45.0/pkg/apis/pipeline/v1beta1#CustomRun.IsDone) method instead of checking the `condition.Reason` field, which could lead to issues (similar to what's mentioned above) when we move to OSP 1.9

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
in CI

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
