### PR TITLE
feat: Add pipeline for syncing frontend-configs to public github.

### DIFF
--- a/pipelines/sync-hac-frontend-configs/README.md
+++ b/pipelines/sync-hac-frontend-configs/README.md
@@ -1,0 +1,24 @@
+# Pipeline for syncing private frontend-configs repo to public github repo
+### Why?
+Private frontend-configs repo (hosted on internal gitlab instance) is the last thing
+preventing us from being able to deploy ephemeral HAC from public internet (openshift-ci).
+
+### What?
+This pipeline just clones private gitlab repo, adds remote for public github and pushes it there.
+
+In case of any failure, this pipeline sends message to Stonesoup QE Slack Channel
+
+## Installation
+* Create secrets for 
+  * ssh access to gitlab ([documentation](https://tekton.dev/vault/pipelines-v0.15.2/auth/#ssh-authentication-git))
+  * basic-auth for github ([documentation](https://tekton.dev/vault/pipelines-v0.15.2/auth/#basic-authentication-git))
+  * slack token used for posting the messages to slack named `slack-token` (key is `token`)
+* Link the git access secrets to `pipeline` service account:
+    ```
+    $ oc secrets link gitlab-ssh
+    $ oc secrets link github-basic
+    ```
+* Apply all resources from this folder
+    ```
+    $ oc apply -f .
+    ```

--- a/pipelines/sync-hac-frontend-configs/README.md
+++ b/pipelines/sync-hac-frontend-configs/README.md
@@ -15,8 +15,8 @@ In case of any failure, this pipeline sends message to Stonesoup QE Slack Channe
   * slack token used for posting the messages to slack named `slack-token` (key is `token`)
 * Link the git access secrets to `pipeline` service account:
     ```
-    $ oc secrets link gitlab-ssh
-    $ oc secrets link github-basic
+    $ oc secrets link pipeline gitlab-ssh
+    $ oc secrets link pipeline github-basic
     ```
 * Apply all resources from this folder
     ```

--- a/pipelines/sync-hac-frontend-configs/cronjob.yaml
+++ b/pipelines/sync-hac-frontend-configs/cronjob.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sync-frontend-configs
+  namespace: appstudio-qe
+spec:
+  schedule: "0 1 * * *" # Every day at 1AM
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger
+            image: curlimages/curl
+            args: ["curl", "-X", "POST", "--data", "{}", "el-sync-frontend-configs.appstudio-qe.svc.cluster.local:8080"]
+          restartPolicy: Never

--- a/pipelines/sync-hac-frontend-configs/eventlistener.yaml
+++ b/pipelines/sync-hac-frontend-configs/eventlistener.yaml
@@ -1,0 +1,11 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: sync-frontend-configs
+  namespace: appstudio-qe
+spec:
+  serviceAccountName: pipeline
+  triggers:
+    - name: cron-trig
+      template:
+        ref: sync-frontend-configs-template

--- a/pipelines/sync-hac-frontend-configs/pipeline.yaml
+++ b/pipelines/sync-hac-frontend-configs/pipeline.yaml
@@ -1,0 +1,30 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata: 
+  name: sync-frontend-configs
+  namespace: appstudio-qe
+spec:
+  finally:
+    - name: send-slack-message
+      params:
+        - name: token-secret
+          value: slack-token
+        - name: channel
+          value: C02FANRBZQD
+        - name: message
+          value: >-
+            :warning: sync-frontend-configs pipeline failed on ocp-c1 cluster.
+            Please take a look.
+      taskRef:
+        kind: Task
+        name: send-slack-message
+      when:
+        - input: $(tasks.sync-frontend-configs.status)
+          operator: notin
+          values:
+            - Succeeded
+  tasks:
+    - name: sync-frontend-configs
+      taskRef:
+        kind: Task
+        name: sync-frontend-configs

--- a/pipelines/sync-hac-frontend-configs/tasks.yaml
+++ b/pipelines/sync-hac-frontend-configs/tasks.yaml
@@ -1,0 +1,64 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata: 
+  name: sync-frontend-configs
+  namespace: appstudio-qe
+spec:
+  description: >-
+    This task updates redhat-appstudio-qe/frontend-configs with 
+    content from internal gitlab repo insights-platform/frontend-configs.
+  steps:
+    - image: quay.io/devfile/base-developer-image:latest
+      name: sync-frontend-configs
+      script: >
+        #!/bin/bash
+
+        git -c http.sslVerify=false clone 
+        https://gitlab.cee.redhat.com/insights-platform/frontend-configs.git 
+
+        cd frontend-configs 
+
+        git remote add redhat-appstudio-qe
+        https://github.com/redhat-appstudio-qe/frontend-configs.git
+
+        git push redhat-appstudio-qe main
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata: 
+  name: send-slack-message
+  namespace: appstudio-qe
+spec:
+  description: >-
+    This tasks post a simple message to a slack channel.
+
+    This task uses chat.postMessage slack REST api to send the message. There
+    are multiple ways to send a message to slack.
+  params:
+    - description: secret name of the slack app access token (key is token)
+      name: token-secret
+      type: string
+    - description: channel id or channel name
+      name: channel
+      type: string
+    - description: plain text message
+      name: message
+      type: string
+  steps:
+    - env:
+        - name: TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: $(params.token-secret)
+      image: >-
+        quay.io/devfile/base-developer-image:latest
+      name: post
+      resources: {}
+      script: >
+        #!/bin/sh
+
+        /usr/bin/curl -X POST -H 'Content-type: application/json' -H
+        'Authorization: Bearer '$TOKEN --data '{"channel":"$(params.channel)",
+        "text":"$(params.message)"}' https://slack.com/api/chat.postMessage

--- a/pipelines/sync-hac-frontend-configs/triggertemplate.yaml
+++ b/pipelines/sync-hac-frontend-configs/triggertemplate.yaml
@@ -1,0 +1,14 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: sync-frontend-configs-template
+  namespace: appstudio-qe
+spec:
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: PipelineRun
+    metadata:
+      generateName: sync-frontend-configs-
+    spec:
+      pipelineRef:
+        name: sync-frontend-configs


### PR DESCRIPTION
# Description

This adds pipeline that's intended to be deployed on internal ocp-c1 cluster.
This pipeline will run every day at 1AM. In case of failure it will send a message to #forum-stonesoup-qe slack channel.
The mirroring from private to public repo is done with approval from the internal repo owners.

## Issue ticket number and link
https://issues.redhat.com/browse/STONE-524

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
I've created the pipeline in ocp-c1 cluster and tested different scenarios.
* public repo is out of date - job correctly updated this public repo
* public repo is in sync - job did nothing
* public repo has conflict - job correctly failed and sent a message to slack channel asking for human intervention.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("[test_id:01] [DEVHAS-62](https://issues.redhat.com//browse/DEVHAS-62) devfile source") 
- [ ] I have updated labels (if needed)
