### PR TITLE
docs: Mention docker token env variable in the readme for avoiding pull limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The following environment variables are used to launch the Red Hat AppStudio ins
 | `PRIVATE_DEVFILE_SAMPLE` | no | The name of the private git repository used in HAS E2E tests. Your GITHUB_TOKEN should be able to read from it. | `https://github.com/redhat-appstudio-qe/private-quarkus-devfile-sample` |
 | `QUAY_OAUTH_USER` | no | A valid quay robot account username to make quay oauth | '' |
 | `QUAY_OAUTH_TOKEN` | no | A valid quay quay robot account token to make oauth against quay.io. | '' |
+| `DOCKER_IO_AUTH` | no | A valid docker.io token to avoid pull limits in the format: username:access_token, eg. `export DOCKER_IO_AUTH=susdas:43228532-b374-11ec-989b-98fa9b70b97d` | '' |
 | `INFRA_DEPLOYMENTS_ORG` | no | A specific github organization from where to download infra-deployments repository | `redhat-appstudio` |
 | `INFRA_DEPLOYMENTS_BRANCH` | no | A valid infra-deployments branch. | `main` |
 | `E2E_TEST_SUITE_LABEL` | no | Run only test suites with the given Giknkgo label | '' |


### PR DESCRIPTION
# Description

Updated readme to avoid pull limits when doing docker pull during the cluster installation. When I was not using DOCKER_IO_AUTH token while running `make local/cluster/prepare` got this error `Failed to pull image "docker.io/minio/mc:RELEASE.2023-01-28T20-29-38Z": rpc error: code = Unknown desc = reading manifest RELEASE.2023-01-28T20-29-38Z in docker.io/minio/mc: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit`

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tried again after setting the DOCKER_IO_AUTH and the installation was successful.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
