### PR TITLE
fix: out-of-date load test

### DIFF
--- a/docs/LoadTests.md
+++ b/docs/LoadTests.md
@@ -10,9 +10,9 @@ This Test Section Provides Load Testing Scripts for Red Hat AppStudio
 
 ## Running the script
 1. Change your directory to `tests/load-tests` 
-2. Open `run.sh` and add your encoded docker config json:
+2. Set `DOCKER_CONFIG_JSON` environment variable with your encoded docker config json:
 ```bash
-  DOCKER_CONFIG_JSON=<PLEASE_ENTER_BASE64_ENCODED_CONFIG>
+  export DOCKER_CONFIG_JSON=<PLEASE_ENTER_BASE64_ENCODED_CONFIG>
 ```
 3. Run the bash script
 ```

--- a/tests/load-tests/.gitignore
+++ b/tests/load-tests/.gitignore
@@ -1,0 +1,1 @@
+load-tests.log

--- a/tests/load-tests/clear.sh
+++ b/tests/load-tests/clear.sh
@@ -1,12 +1,26 @@
-#!/bin/bash -x
-USER_PREFIX=${1:-testuser}
-REPO_LIST=$(curl -s https://api.github.com/users/${MY_GITHUB_ORG}/repos\?per_page\=1000 | jq -r '.[]|select(.name | startswith("'${USER_PREFIX}'"))' | jq --raw-output '.name')
+#!/bin/bash
 
-for REPO in $REPO_LIST
-do
-	curl \
-    -X DELETE \
-    -H "Accept: application/vnd.github.v3+json" \
-    -H "Authorization: token $GITHUB_TOKEN" \
-    https://api.github.com/repos/${MY_GITHUB_ORG}/${REPO}
+set -xe
+set -o pipefail
+
+USER_PREFIX=${1:-testuser}
+COUNTER=0
+
+while true; do
+    REPO_LIST=$( curl --fail -s https://api.github.com/users/${MY_GITHUB_ORG}/repos\?per_page\=100 | jq -r '.[]|select(.name | startswith("'${USER_PREFIX}'"))' | jq --raw-output '.name' )
+
+    if [[ ${#REPO_LIST} == 0 ]]; then
+        break
+    fi
+
+    for REPO in $REPO_LIST; do
+        curl --fail-with-body \
+            -X DELETE \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            https://api.github.com/repos/${MY_GITHUB_ORG}/${REPO}
+        let COUNTER+=1
+    done
 done
+
+echo "Deleted $COUNTER repos"

--- a/tests/load-tests/clear.sh
+++ b/tests/load-tests/clear.sh
@@ -1,4 +1,6 @@
-REPO_LIST=$(curl -s https://api.github.com/users/app-studio-test/repos\?per_page\=1000 | jq -r '.[]|select(.name | startswith("testuser"))' | jq --raw-output '.name')
+#!/bin/bash -x
+USER_PREFIX=${1:-testuser}
+REPO_LIST=$(curl -s https://api.github.com/users/${MY_GITHUB_ORG}/repos\?per_page\=1000 | jq -r '.[]|select(.name | startswith("'${USER_PREFIX}'"))' | jq --raw-output '.name')
 
 for REPO in $REPO_LIST
 do
@@ -6,5 +8,5 @@ do
     -X DELETE \
     -H "Accept: application/vnd.github.v3+json" \
     -H "Authorization: token $GITHUB_TOKEN" \
-    https://api.github.com/repos/app-studio-test/${REPO}
+    https://api.github.com/repos/${MY_GITHUB_ORG}/${REPO}
 done

--- a/tests/load-tests/loadtest.go
+++ b/tests/load-tests/loadtest.go
@@ -3,5 +3,5 @@ package main
 import "github.com/redhat-appstudio/e2e-tests/cmd"
 
 func main() {
-	cmd.Execute()
+	cmd.ExecuteLoadTest()
 }

--- a/tests/load-tests/run.sh
+++ b/tests/load-tests/run.sh
@@ -1,7 +1,6 @@
-export DOCKER_CONFIG_JSON=
+export DOCKER_CONFIG_JSON=${DOCKER_CONFIG_JSON:-}
 
 if [ -z ${DOCKER_CONFIG_JSON+x} ]; then echo "env DOCKER_CONFIG_JSON need to be defined"; exit 1;  else echo "DOCKER_CONFIG_JSON is set"; fi
 
-go run loadtest.go --username testuser --users 50 --batch 10 -w && ./clear.sh
-
-
+USER_PREFIX=${USER_PREFIX:-testuser}
+go run loadtest.go --username $USER_PREFIX --users ${USERS:-50} --batch ${USERS_BATCH:-10} -w $@ && ./clear.sh $USER_PREFIX


### PR DESCRIPTION
# Description

When deleting repositories created by load test, we need to iterate until there are none - maximum for per_page is 100 only.

This depends on #396 so should be merged after that one.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran it on the organization with 556 repos:

```
$ ./clear.sh load
[...]
+ REPO_LIST=
+ [[ 0 == 0 ]]
+ break
+ echo 'Deleted 556 repos'
Deleted 556 repos
```

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
