### PR TITLE
[STONEBUGS-108] Add function for getting route associated with Component

### DIFF
--- a/tests/e2e-demos/e2e-demo.go
+++ b/tests/e2e-demos/e2e-demo.go
@@ -254,7 +254,7 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 				It(fmt.Sprintf("checks if component %s health", component.Name), func() {
 					Eventually(func() bool {
-						gitOpsRoute, err := fw.AsKubeDeveloper.CommonController.GetOpenshiftRoute(component.Name, namespace)
+						gitOpsRoute, err := fw.AsKubeDeveloper.CommonController.GetOpenshiftRouteByComponentName(component.Name, namespace)
 						Expect(err).NotTo(HaveOccurred())
 						err = fw.AsKubeDeveloper.GitOpsController.CheckGitOpsEndpoint(gitOpsRoute, componentTest.HealthEndpoint)
 						if err != nil {


### PR DESCRIPTION
# Description

Paired with https://github.com/redhat-appstudio/application-service/pull/292

This PR updates the e2e tests to add a function to get Component routes by label.

Since HAS will truncate Component route names that are > 30 characters (and adds 4 random characters), it's important for the tests to get the Component route by label, rather than by name

## Issue ticket number and link
https://issues.redhat.com/browse/STONEBUGS-108

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
