### PR TITLE
fix: Enabling sbom check in the build-templates-e2e tests

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -299,7 +299,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 						tekton.MatchTaskRunResultWithJSONPathValue("HACBS_TEST_OUTPUT", "{$.result}", `["SUCCESS"]`),
 					))
 				})
-				It("contains non-empty sbom files", func() {
+				It("contains non-empty sbom files", Label(buildTemplatesTestLabel), func() {
 
 					purl, cyclonedx, err := build.GetParsedSbomFilesContentFromImage(outputImage)
 					Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
# Description

Enabling sbom check in the build-templates-e2e tests

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested in the build-definitions repo PR https://github.com/redhat-appstudio/build-definitions/pull/364 enabling this in the custom image

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
