### PR TITLE
fix: RHTAPBUGS-34 return the error instead of fatal log it

### DIFF
--- a/pkg/utils/pipeline/results.go
+++ b/pkg/utils/pipeline/results.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"time"
 )
@@ -35,7 +34,7 @@ func (c *ResultClient) sendRequest(path string) (body []byte, err error) {
 	requestURL := fmt.Sprintf("%s/%s", c.BaseURL, path)
 	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	req.Header.Set("Accept", "application/json; charset=utf-8")
@@ -60,7 +59,7 @@ func (c *ResultClient) GetRecords(namespace, resultId string) (*Records, error) 
 
 	body, err := c.sendRequest(path)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	var records *Records
 	err = json.Unmarshal(body, &records)
@@ -75,7 +74,7 @@ func (c *ResultClient) GetLogs(namespace, resultId string) (*Logs, error) {
 
 	body, err := c.sendRequest(path)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	var logs *Logs


### PR DESCRIPTION
# Description

After adding ginkgo flag `--output-interceptor-mode=none`, another test failed with this error on Apr 06 [643988124960821248](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/redhat-appstudio_e2e-tests/434/pull-ci-redhat-appstudio-e2e-tests-main-redhat-appstudio-e2e/1643988124960821248/build-log.txt).

From the `--output-interceptor-mode=none` logs, we can see that it fails on the function [sendRequest](https://github.com/redhat-appstudio/e2e-tests/blob/main/pkg/utils/pipeline/results.go#L50):

```
[1mOutput from proc 13:[0m
    "level"=0 "msg"="Starting Red Hat App Studio e2e tests...\n"2023/04/06 15:19:08 failed to access Tekton Result Service with status code: 401 and
  body: {"code":16,"message":"permission denied","details":[]}
```

I think it is the `log.Fatal(err)` that is causing it

## Issue ticket number and link
[RHTAPBUGS-34](https://issues.redhat.com/browse/RHTAPBUGS-34)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
