### PR TITLE
fix: build: add container image field to PaC comp

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -111,7 +111,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 		When("a new component without specified branch is created", Label("pac-custom-default-branch"), func() {
 			BeforeAll(func() {
-				_, err = f.AsKubeDeveloper.HasController.CreateComponentWithPaCEnabled(applicationName, defaultBranchTestComponentName, testNamespace, helloWorldComponentGitSourceURL, "", "")
+				_, err = f.AsKubeDeveloper.HasController.CreateComponentWithPaCEnabled(applicationName, defaultBranchTestComponentName, testNamespace, helloWorldComponentGitSourceURL, "", outputContainerImage)
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 


### PR DESCRIPTION
# Description

blocker for https://github.com/redhat-appstudio-qe/devfile-sample-hello-world/pull/6156

with changes made in https://github.com/redhat-appstudio-qe/devfile-sample-hello-world/pull/6156 a component requires the `containerImage` field specified

## Issue ticket number and link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
ginkgo --label-filter="github-webhook" --focus "Build service E2E tests" --v ./cmd/ -- --config-suites=$PWD/tests/e2e-demos/config/default.yaml
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
