### PR TITLE
chore: changes AutoReleaseLabel import package to metadata

### DIFF
--- a/pkg/utils/integration/controller.go
+++ b/pkg/utils/integration/controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
 	integrationv1alpha1 "github.com/redhat-appstudio/integration-service/api/v1alpha1"
 	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
+	releasemetadata "github.com/redhat-appstudio/release-service/metadata"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -262,7 +263,7 @@ func (h *SuiteController) CreateReleasePlan(applicationName, namespace string) (
 			GenerateName: "test-releaseplan-",
 			Namespace:    namespace,
 			Labels: map[string]string{
-				releasev1alpha1.AutoReleaseLabel: "true",
+				releasemetadata.AutoReleaseLabel: "true",
 			},
 		},
 		Spec: releasev1alpha1.ReleasePlanSpec{

--- a/pkg/utils/release/controller.go
+++ b/pkg/utils/release/controller.go
@@ -9,6 +9,7 @@ import (
 	kubeCl "github.com/redhat-appstudio/e2e-tests/pkg/apis/kubernetes"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	releaseApi "github.com/redhat-appstudio/release-service/api/v1alpha1"
+	releaseMetadata "github.com/redhat-appstudio/release-service/metadata"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -203,7 +204,7 @@ func (s *SuiteController) CreateReleasePlan(name, namespace, application, target
 			Name:         name,
 			Namespace:    namespace,
 			Labels: map[string]string{
-				releaseApi.AutoReleaseLabel: autoReleaseLabel,
+				releaseMetadata.AutoReleaseLabel: autoReleaseLabel,
 			},
 		},
 		Spec: releaseApi.ReleasePlanSpec{
@@ -213,9 +214,9 @@ func (s *SuiteController) CreateReleasePlan(name, namespace, application, target
 		},
 	}
 	if autoReleaseLabel == "" || autoReleaseLabel == "true" {
-		releasePlan.ObjectMeta.Labels[releaseApi.AutoReleaseLabel] = "true"
+		releasePlan.ObjectMeta.Labels[releaseMetadata.AutoReleaseLabel] = "true"
 	} else {
-		releasePlan.ObjectMeta.Labels[releaseApi.AutoReleaseLabel] = "false"
+		releasePlan.ObjectMeta.Labels[releaseMetadata.AutoReleaseLabel] = "false"
 	}
 
 	return releasePlan, s.KubeRest().Create(context.TODO(), releasePlan)
@@ -264,7 +265,7 @@ func (s *SuiteController) CreateReleasePlanAdmission(name, originNamespace, appl
 		},
 	}
 	if autoRelease != "" {
-		releasePlanAdmission.ObjectMeta.Labels[releaseApi.AutoReleaseLabel] = autoRelease
+		releasePlanAdmission.ObjectMeta.Labels[releaseMetadata.AutoReleaseLabel] = autoRelease
 	}
 	return releasePlanAdmission, s.KubeRest().Create(context.TODO(), releasePlanAdmission)
 }


### PR DESCRIPTION
# Description

HACBS-1032 changes the location of  Release's `AutoReleaseLabel` to its metadata package/directory so this adjust is necessary just after the merge on release-service side.

## Issue ticket number and link

https://issues.redhat.com/browse/HACBS-1032

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This change was tested manually on the release service side.

# Checklist:

- [x ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
