### PR TITLE
feat: Make SPI service providers configurable from env variables

### DIFF
--- a/scripts/spi-e2e-setup.sh
+++ b/scripts/spi-e2e-setup.sh
@@ -14,8 +14,10 @@ export OAUTH_URL='spi-oauth-route-spi-system.'$( oc get ingresses.config/cluster
 export tmpfile=$(mktemp -d)/config.yaml
 
 # We are injecting the token manually for the e2e. No need a real secret for now
-export SPI_GITHUB_CLIENT_ID="app-client-id"
-export SPI_GITHUB_CLIENT_SECRET="app-secret"
+export SPI_GITHUB_CLIENT_ID=${SPI_GITHUB_CLIENT_ID:-"app-client-id"}
+export SPI_GITHUB_CLIENT_SECRET=${SPI_GITHUB_CLIENT_SECRET:-"app-secret"}
+export SPI_QUAY_CLIENT_ID=${SPI_QUAY_CLIENT_ID:-"app-client-id"}
+export SPI_QUAY_CLIENT_SECRET=${SPI_QUAY_CLIENT_SECRET:-"app-secret"}
 
 # The legacy stuff can be removed once https://github.com/redhat-appstudio/infra-deployments/pull/638 is merged
 # in infra-deployments
@@ -26,8 +28,8 @@ serviceProviders:
     clientId: $SPI_GITHUB_CLIENT_ID
     clientSecret: $SPI_GITHUB_CLIENT_SECRET
   - type: Quay
-    clientId: $SPI_GITHUB_CLIENT_ID
-    clientSecret: $SPI_GITHUB_CLIENT_SECRET
+    clientId: $SPI_QUAY_CLIENT_ID
+    clientSecret: $SPI_QUAY_CLIENT_SECRET
 baseUrl: https://spi-oauth-route-spi-system.$( oc get ingresses.config/cluster -o jsonpath={.spec.domain})
 EOF
 )
@@ -39,8 +41,8 @@ serviceProviders:
     clientId: $SPI_GITHUB_CLIENT_ID
     clientSecret: $SPI_GITHUB_CLIENT_SECRET
   - type: Quay
-    clientId: $SPI_GITHUB_CLIENT_ID
-    clientSecret: $SPI_GITHUB_CLIENT_SECRET
+    clientId: $SPI_QUAY_CLIENT_ID
+    clientSecret: $SPI_QUAY_CLIENT_SECRET
 EOF
 )
 


### PR DESCRIPTION
# Description

Since the spi-e2e-setup script is being used in infra-deployments preview script, it would be nice to be able to have the SPI providers configured with actual values using environment variables.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
