### PR TITLE
feat: PLNSRVCE-1280- Verify the logs of failed pipeline are stored persistently

### DIFF
--- a/pkg/utils/common/rbac.go
+++ b/pkg/utils/common/rbac.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -119,4 +120,13 @@ func (s *SuiteController) CreateRoleBinding(roleBindingName, namespace, subjectK
 		return nil, err
 	}
 	return createdRoleBinding, nil
+}
+
+// DeleteRoleBinding deletes the role binding with the provided name and namespace
+func (s *SuiteController) DeleteRoleBinding(roleBindingName, namespace string, returnErrorOnNotFound bool) error {
+	err := s.KubeInterface().RbacV1().RoleBindings(namespace).Delete(context.TODO(), roleBindingName, metav1.DeleteOptions{})
+	if err != nil && errors.IsNotFound(err) && !returnErrorOnNotFound {
+		return nil // Ignore not found errors, if requested
+	}
+	return err
 }

--- a/pkg/utils/common/service_account.go
+++ b/pkg/utils/common/service_account.go
@@ -3,6 +3,8 @@ package common
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -38,4 +40,13 @@ func (s *SuiteController) CreateServiceAccount(name, namespace string, serviceAc
 // DeleteAllServiceAccountsInASpecificNamespace deletes all ServiceAccount from a given namespace
 func (h *SuiteController) DeleteAllServiceAccountsInASpecificNamespace(namespace string) error {
 	return h.KubeRest().DeleteAllOf(context.TODO(), &corev1.ServiceAccount{}, client.InNamespace(namespace))
+}
+
+// DeleteServiceAccount deletes a service account with the provided name and namespace
+func (s *SuiteController) DeleteServiceAccount(name, namespace string, returnErrorOnNotFound bool) error {
+	err := s.KubeInterface().CoreV1().ServiceAccounts(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil && errors.IsNotFound(err) && !returnErrorOnNotFound {
+		return nil // Ignore not found errors, if requested
+	}
+	return err
 }

--- a/pkg/utils/pipeline/results.go
+++ b/pkg/utils/pipeline/results.go
@@ -41,6 +41,9 @@ func (c *ResultClient) sendRequest(path string) (body []byte, err error) {
 	req.Header.Set("Accept", "application/json; charset=utf-8")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.Token))
 
+	//Debug
+	fmt.Printf("Request URL: %s\n", requestURL)
+	fmt.Printf("Request Token: %s\n", c.Token)
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/pkg/utils/pipeline/results.go
+++ b/pkg/utils/pipeline/results.go
@@ -56,6 +56,8 @@ func (c *ResultClient) sendRequest(path string) (body []byte, err error) {
 
 	defer res.Body.Close()
 
+	//Debug:
+	fmt.Printf("Response Body: %s\n", string(body))
 	return body, err
 }
 


### PR DESCRIPTION
# Description

This PR added one more result test for verifying if the logs of failed pipeline are stored persistently.  This PR will require PR [#441](https://github.com/redhat-appstudio/e2e-tests/pull/441) to be merged first

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
