### PR TITLE
feat: add CleanupQuayTags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,6 @@ clean-github-webhooks:
 
 clean-quay-repos-and-robots:
 	./mage -v local:cleanupQuayReposAndRobots
+
+clean-quay-tags:
+	./mage -v local:cleanupQuayTags

--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,5 @@ clean-gitops-repositories:
 clean-github-webhooks:
 	./mage -v cleanWebHooks
 
-clean-quay:
-	./mage -v local:cleanupQuay
+clean-quay-repos-and-robots:
+	./mage -v local:cleanupQuayReposAndRobots

--- a/go.mod
+++ b/go.mod
@@ -24,14 +24,14 @@ require (
 	github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c
 	github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc
 	github.com/openshift/oc v0.0.0-alpha.0.0.20220614012638-35c7eeb5274e
-	github.com/redhat-appstudio/application-api v0.0.0-20230405183341-7a48b1d4c860
+	github.com/redhat-appstudio/application-api v0.0.0-20230427114540-a91722251e0a
 	github.com/redhat-appstudio/build-service v0.0.0-20230113121706-a9f10055dbc4
 	github.com/redhat-appstudio/image-controller v0.0.0-20230424143941-3da9b4925e36
 	github.com/redhat-appstudio/integration-service v0.0.0-20230427084439-306b4611389b
 	github.com/redhat-appstudio/jvm-build-service v0.0.0-20230125042419-efd0d0342a2c
 	github.com/redhat-appstudio/managed-gitops/backend v0.0.0-20220506042230-3a79f373a001
 	github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0
-	github.com/redhat-appstudio/release-service v0.0.0-20230314103738-21edb2dadc4e
+	github.com/redhat-appstudio/release-service v0.0.0-20230501180319-d9907b54776b
 	github.com/redhat-appstudio/service-provider-integration-operator v0.9.1-0.20230412095305-101be612c01e
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -26,12 +26,12 @@ require (
 	github.com/openshift/oc v0.0.0-alpha.0.0.20220614012638-35c7eeb5274e
 	github.com/redhat-appstudio/application-api v0.0.0-20230405183341-7a48b1d4c860
 	github.com/redhat-appstudio/build-service v0.0.0-20230113121706-a9f10055dbc4
-	github.com/redhat-appstudio/image-controller v0.0.0-20230413111635-7e9bc2f236ee
+	github.com/redhat-appstudio/image-controller v0.0.0-20230424143941-3da9b4925e36
 	github.com/redhat-appstudio/integration-service v0.0.0-20230427084439-306b4611389b
 	github.com/redhat-appstudio/jvm-build-service v0.0.0-20230125042419-efd0d0342a2c
 	github.com/redhat-appstudio/managed-gitops/backend v0.0.0-20220506042230-3a79f373a001
 	github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0
-	github.com/redhat-appstudio/release-service v0.0.0-20230404140848-d2ad6f470f2e
+	github.com/redhat-appstudio/release-service v0.0.0-20230314103738-21edb2dadc4e
 	github.com/redhat-appstudio/service-provider-integration-operator v0.9.1-0.20230412095305-101be612c01e
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0
@@ -219,7 +219,7 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.8.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
-	google.golang.org/api v0.114.0 // indirect
+	google.golang.org/api v0.112.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/grpc v1.54.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1184,8 +1184,8 @@ github.com/redhat-appstudio/application-api v0.0.0-20230405183341-7a48b1d4c860 h
 github.com/redhat-appstudio/application-api v0.0.0-20230405183341-7a48b1d4c860/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
 github.com/redhat-appstudio/build-service v0.0.0-20230113121706-a9f10055dbc4 h1:Nc4qjZHxb8wnn5DW559GUyIVV5Z2HgYmGxQoWW02mWg=
 github.com/redhat-appstudio/build-service v0.0.0-20230113121706-a9f10055dbc4/go.mod h1:wgto41R9bV9wLVOp29llmx+O+voEb0r/hy7Yw+MkKxQ=
-github.com/redhat-appstudio/image-controller v0.0.0-20230413111635-7e9bc2f236ee h1:3ZgAsp1ncL/veRndRyxwailsGVz2hcP9CScDpnGZZ6s=
-github.com/redhat-appstudio/image-controller v0.0.0-20230413111635-7e9bc2f236ee/go.mod h1:6v+OpSt2oy3uuP16s4HUdShE9CR5HBSwwjL1fvbkKcg=
+github.com/redhat-appstudio/image-controller v0.0.0-20230424143941-3da9b4925e36 h1:vJcJsdTns+6tHfyI0Px//PUGlbAnsmky7BwRfjk58u0=
+github.com/redhat-appstudio/image-controller v0.0.0-20230424143941-3da9b4925e36/go.mod h1:6v+OpSt2oy3uuP16s4HUdShE9CR5HBSwwjL1fvbkKcg=
 github.com/redhat-appstudio/integration-service v0.0.0-20230427084439-306b4611389b h1:+9QZ6tcV3cddqE1E/N8zu3GJKe9bPtmLbN7cbY/9lQU=
 github.com/redhat-appstudio/integration-service v0.0.0-20230427084439-306b4611389b/go.mod h1:OVpNXkUNwAxJoJT3JwJfqNt2kAwixMxizcgzCQq4n8g=
 github.com/redhat-appstudio/jvm-build-service v0.0.0-20230125042419-efd0d0342a2c h1:3kgmn4uwlTjlzofcFU0zWBKsx+PthW5hBjR6LnEy/NA=
@@ -1194,8 +1194,8 @@ github.com/redhat-appstudio/managed-gitops/backend v0.0.0-20220506042230-3a79f37
 github.com/redhat-appstudio/managed-gitops/backend v0.0.0-20220506042230-3a79f373a001/go.mod h1:jqTuNQDL/xf+LsxWg1RuhJiMvMWnoRZcpcHRhX8Z12s=
 github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0-20220506042230-3a79f373a001 h1:xjO01dcMV7mv7b0GFeEN1uLhJiLOlzglgeEO57rfdNk=
 github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0-20220506042230-3a79f373a001/go.mod h1:5GV2vv5Eu8yiwTgQcnnvyk0TEE9URL3zSB0aGVfEnFk=
-github.com/redhat-appstudio/release-service v0.0.0-20230404140848-d2ad6f470f2e h1:gNxwQwyevFqMPN7UCc9nMPXqRXYX9/VstCe1fIILp9c=
-github.com/redhat-appstudio/release-service v0.0.0-20230404140848-d2ad6f470f2e/go.mod h1:QDzyFG8JEXQlKDJrsQ4IqoTa6vvRIXD7eh9CPg+b3FM=
+github.com/redhat-appstudio/release-service v0.0.0-20230314103738-21edb2dadc4e h1:h2q5Q+Wzdal1Xq1thHYsPTut7QfpU5ivBLqKGi5giBg=
+github.com/redhat-appstudio/release-service v0.0.0-20230314103738-21edb2dadc4e/go.mod h1:nbCcDcWgfJs9LhyKbsjJEolQsUfvL5nnoHlQebNeOEo=
 github.com/redhat-appstudio/service-provider-integration-operator v0.9.1-0.20230412095305-101be612c01e h1:jwnK3IbkpSwpvWVpYNdZhKjkMma9vf48sL3SZiVM1jk=
 github.com/redhat-appstudio/service-provider-integration-operator v0.9.1-0.20230412095305-101be612c01e/go.mod h1:dpeRolVrK0Ukt4jcfob2Wygwlp9sOBPp2A0Ra7eBQ3U=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf/go.mod h1:FfTyeSCu+e2VLgeMh/1RFG8TSkVjKRPEyR6EmDt0RIw=
@@ -1912,8 +1912,8 @@ google.golang.org/api v0.51.0/go.mod h1:t4HdrdoNgyN5cbEfm7Lum0lcLDLiise1F8qDKX00
 google.golang.org/api v0.54.0/go.mod h1:7C4bFFOvVDGXjfDTAsgGwDgAxRDeQ4X8NvUedIt6z3k=
 google.golang.org/api v0.55.0/go.mod h1:38yMfeP1kfjsl8isn0tliTjIb1rJXcQi4UXlbqivdVE=
 google.golang.org/api v0.57.0/go.mod h1:dVPlbZyBo2/OjBpmvNdpn2GRm6rPy75jyU7bmhdrMgI=
-google.golang.org/api v0.114.0 h1:1xQPji6cO2E2vLiI+C/XiFAnsn1WV3mjaEwGLhi3grE=
-google.golang.org/api v0.114.0/go.mod h1:ifYI2ZsFK6/uGddGfAD5BMxlnkBqCmqHSDUVi45N5Yg=
+google.golang.org/api v0.112.0 h1:iDmzvZ4C086R3+en4nSyIf07HlQKMOX1Xx2dmia/+KQ=
+google.golang.org/api v0.112.0/go.mod h1:737UfWHNsOq4F3REUTmb+GN9pugkgNLCayLTfoIKpPc=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/go.sum
+++ b/go.sum
@@ -1180,8 +1180,8 @@ github.com/prometheus/statsd_exporter v0.22.7/go.mod h1:N/TevpjkIh9ccs6nuzY3jQn9
 github.com/prometheus/statsd_exporter v0.23.0 h1:GEkriUCmARYh1gSA0gzpvmTg/oHMc5MfDFNlS/che4E=
 github.com/prometheus/statsd_exporter v0.23.0/go.mod h1:1itCY9XMa2p5pjO5HseGjs5cnaIA5qxLCYmn3OUna58=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/redhat-appstudio/application-api v0.0.0-20230405183341-7a48b1d4c860 h1:/12iN8Zft+v1hTrUN/Z06nYQ8rDUP2wKM4aAyc9cRhs=
-github.com/redhat-appstudio/application-api v0.0.0-20230405183341-7a48b1d4c860/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
+github.com/redhat-appstudio/application-api v0.0.0-20230427114540-a91722251e0a h1:3fLezk9GHkAez0a94EywNVI9bWHAviddjEH8EKj9gRs=
+github.com/redhat-appstudio/application-api v0.0.0-20230427114540-a91722251e0a/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
 github.com/redhat-appstudio/build-service v0.0.0-20230113121706-a9f10055dbc4 h1:Nc4qjZHxb8wnn5DW559GUyIVV5Z2HgYmGxQoWW02mWg=
 github.com/redhat-appstudio/build-service v0.0.0-20230113121706-a9f10055dbc4/go.mod h1:wgto41R9bV9wLVOp29llmx+O+voEb0r/hy7Yw+MkKxQ=
 github.com/redhat-appstudio/image-controller v0.0.0-20230424143941-3da9b4925e36 h1:vJcJsdTns+6tHfyI0Px//PUGlbAnsmky7BwRfjk58u0=
@@ -1194,8 +1194,8 @@ github.com/redhat-appstudio/managed-gitops/backend v0.0.0-20220506042230-3a79f37
 github.com/redhat-appstudio/managed-gitops/backend v0.0.0-20220506042230-3a79f373a001/go.mod h1:jqTuNQDL/xf+LsxWg1RuhJiMvMWnoRZcpcHRhX8Z12s=
 github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0-20220506042230-3a79f373a001 h1:xjO01dcMV7mv7b0GFeEN1uLhJiLOlzglgeEO57rfdNk=
 github.com/redhat-appstudio/managed-gitops/backend-shared v0.0.0-20220506042230-3a79f373a001/go.mod h1:5GV2vv5Eu8yiwTgQcnnvyk0TEE9URL3zSB0aGVfEnFk=
-github.com/redhat-appstudio/release-service v0.0.0-20230314103738-21edb2dadc4e h1:h2q5Q+Wzdal1Xq1thHYsPTut7QfpU5ivBLqKGi5giBg=
-github.com/redhat-appstudio/release-service v0.0.0-20230314103738-21edb2dadc4e/go.mod h1:nbCcDcWgfJs9LhyKbsjJEolQsUfvL5nnoHlQebNeOEo=
+github.com/redhat-appstudio/release-service v0.0.0-20230501180319-d9907b54776b h1:MXD8a3aFbTuQ82+NBCHR3KnFT04uxVrBSDtnjcSOw5Q=
+github.com/redhat-appstudio/release-service v0.0.0-20230501180319-d9907b54776b/go.mod h1:6vJ+iIj6bY1PIxvdPOI+WpQvvmShVK6+1aX0MmNA8tY=
 github.com/redhat-appstudio/service-provider-integration-operator v0.9.1-0.20230412095305-101be612c01e h1:jwnK3IbkpSwpvWVpYNdZhKjkMma9vf48sL3SZiVM1jk=
 github.com/redhat-appstudio/service-provider-integration-operator v0.9.1-0.20230412095305-101be612c01e/go.mod h1:dpeRolVrK0Ukt4jcfob2Wygwlp9sOBPp2A0Ra7eBQ3U=
 github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf/go.mod h1:FfTyeSCu+e2VLgeMh/1RFG8TSkVjKRPEyR6EmDt0RIw=

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -181,7 +181,7 @@ func (Local) CleanupGithubOrg() error {
 }
 
 // Deletes Quay repos and robot accounts older than 24 hours with prefixes `has-e2e` and `e2e-demos`, uses env vars DEFAULT_QUAY_ORG and DEFAULT_QUAY_ORG_TOKEN
-func (Local) CleanupQuay() error {
+func (Local) CleanupQuayReposAndRobots() error {
 	quayOrgToken := os.Getenv("DEFAULT_QUAY_ORG_TOKEN")
 	if quayOrgToken == "" {
 		return fmt.Errorf("DEFAULT_QUAY_ORG_TOKEN env var was not found")
@@ -189,7 +189,7 @@ func (Local) CleanupQuay() error {
 	quayOrg := utils.GetEnv("DEFAULT_QUAY_ORG", "redhat-appstudio-qe")
 
 	quayClient := quay.NewQuayClient(&http.Client{Transport: &http.Transport{}}, quayOrgToken, "https://quay.io/api/v1")
-	return cleanupQuay(&quayClient, quayOrg)
+	return cleanupQuayReposAndRobots(&quayClient, quayOrg)
 }
 
 // Deletes Quay Tags older than 7 days in `test-images` repository

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -192,6 +192,18 @@ func (Local) CleanupQuay() error {
 	return cleanupQuay(&quayClient, quayOrg)
 }
 
+// Deletes Quay Tags older than 7 days in `test-images` repository
+func (Local) CleanupQuayTags() error {
+	quayOrgToken := os.Getenv("DEFAULT_QUAY_ORG_TOKEN")
+	if quayOrgToken == "" {
+		return fmt.Errorf("DEFAULT_QUAY_ORG_TOKEN env var was not found")
+	}
+	quayOrg := utils.GetEnv("DEFAULT_QUAY_ORG", "redhat-appstudio-qe")
+
+	quayClient := quay.NewQuayClient(&http.Client{Transport: &http.Transport{}}, quayOrgToken, "https://quay.io/api/v1")
+	return cleanupQuayTags(&quayClient, quayOrg, "test-images")
+}
+
 func (ci CI) TestE2E() error {
 	var testFailure bool
 

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -236,34 +236,33 @@ func cleanupQuayTags(quayService quay.QuayService, organization, repository stri
 	workerCount := 10
 	var wg sync.WaitGroup
 
-	allTagsChan := make(chan quay.Tag)
+  var allTags []quay.Tag
 	errChan := make(chan error)
 
-	go func() {
-		page := 1
-		for {
-			tags, hasAdditional, err := quayService.GetTagsFromPage(organization, repository, page)
-			if err != nil {
-				errChan <- fmt.Errorf("error getting tags of `%s` repository of `%s` organization on page `%d`, error: %s", repository, organization, page, err)
-				continue
-			}
-			for _, tag := range tags {
-				allTagsChan <- tag
-			}
-			if !hasAdditional {
-				break
-			}
-			page++
-		}
-		close(allTagsChan)
-	}()
+  page := 1
+  for {
+    tags, hasAdditional, err := quayService.GetTagsFromPage(organization, repository, page)
+    if err != nil {
+      errChan <- fmt.Errorf("error getting tags of `%s` repository of `%s` organization on page `%d`, error: %s", repository, organization, page, err)
+      continue
+    }
+    allTags = append(allTags, tags...)
+    if !hasAdditional {
+      break
+    }
+    page++
+  }
 
 	wg.Add(workerCount)
 
+  var allTagsMutex sync.Mutex
 	for i := 0; i < workerCount; i++ {
-		go func(tagsChan <-chan quay.Tag, errChan chan<- error, wg *sync.WaitGroup) {
+		go func(startIdx int, allTags []quay.Tag, allTagsMutex sync.Mutex, errChan chan<- error, wg *sync.WaitGroup) {
 			defer wg.Done()
-			for tag := range tagsChan {
+      for idx := startIdx; idx < len(allTags); idx += workerCount {
+        allTagsMutex.Lock()
+        tag := allTags[idx]
+        allTagsMutex.Unlock()
 				if time.Unix(tag.StartTS, 0).Before(time.Now().AddDate(0, 0, -7)) {
 					deleted, err := quayService.DeleteTag(organization, repository, tag.Name)
 					if err != nil {
@@ -273,7 +272,7 @@ func cleanupQuayTags(quayService quay.QuayService, organization, repository stri
 					}
 				}
 			}
-		}(allTagsChan, errChan, &wg)
+		}(i, allTags, allTagsMutex, errChan, &wg)
 	}
 
 	wg.Wait()

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -277,6 +277,7 @@ func cleanupQuayTags(quayService quay.QuayService, organization, repository stri
 	}
 
 	wg.Wait()
+  close(errChan)
 
 	if len(errChan) == 0 {
 		return nil

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -160,7 +160,7 @@ func renderTemplate(destination, templatePath string, templateData interface{}, 
 	return nil
 }
 
-func cleanupQuay(quayService quay.QuayService, quayOrg string) error {
+func cleanupQuayReposAndRobots(quayService quay.QuayService, quayOrg string) error {
 	r, err := regexp.Compile(fmt.Sprintf(`^(%s)`, quayPrefixesToDeleteRegexp))
 	if err != nil {
 		return err

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -277,7 +277,7 @@ func cleanupQuayTags(quayService quay.QuayService, organization, repository stri
 	}
 
 	wg.Wait()
-  close(errChan)
+	close(errChan)
 
 	if len(errChan) == 0 {
 		return nil

--- a/magefiles/utils_test.go
+++ b/magefiles/utils_test.go
@@ -78,7 +78,7 @@ func (m *QuayClientMock) CreateRobotAccount(organization string, robotName strin
 	return nil, nil
 }
 
-func TestCleanupQuay(t *testing.T) {
+func TestCleanupQuayReposAndRobots(t *testing.T) {
 	timeFormat := "Mon, 02 Jan 2006 15:04:05 -0700"
 
 	deletedRepos := []quay.Repository{
@@ -107,7 +107,7 @@ func TestCleanupQuay(t *testing.T) {
 		DeleteRepositoryCalls:   make(map[string]bool),
 		DeleteRobotAccountCalls: make(map[string]bool),
 	}
-	err := cleanupQuay(&quayClientMock, "test-org")
+	err := cleanupQuayReposAndRobots(&quayClientMock, "test-org")
 	if err != nil {
 		t.Errorf("error during quay cleanup, error: %s", err)
 	}

--- a/magefiles/utils_test.go
+++ b/magefiles/utils_test.go
@@ -212,5 +212,8 @@ func BenchmarkCleanupQuayTags(b *testing.B) {
 		TagPages:       tagPages,
 		Benchmark:      true,
 	}
-	cleanupQuayTags(&quayClientMock, testOrg, testRepo)
+	err := cleanupQuayTags(&quayClientMock, testOrg, testRepo)
+	if err != nil {
+		b.Errorf("error during quay tag cleanup, error: %s", err)
+	}
 }


### PR DESCRIPTION
# Description

Is depending on https://github.com/redhat-appstudio/image-controller/pull/22. (merged)

Added mage target CleanupQuayTags which deletes all tags older than 7 days in the `test-images` repo.


## Issue ticket number and link
https://issues.redhat.com/browse/STONEBLD-1193

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Covered by unit tests and tested in my own quay organization on mock tags.
Be advised that this will delete all the tags older than 7 days in the repository.
In order to reproduce, create some tags that you don't mind getting deleted in a repository and either:

- change your `$DEFAULT_QUAY_ORG` and `$DEFAULT_QUAY_ORG_TOKEN`
- change values of `quayOrg` and `quayOrgToken` in the [mage target](https://github.com/tnevrlka/e2e-tests/blob/tag-cleanup/magefiles/magefile.go#L197-L201)
 
Don't forget to change the repository in the [return statement](https://github.com/tnevrlka/e2e-tests/blob/tag-cleanup/magefiles/magefile.go#L204)!

Run `/mage -v local:cleanupQuayTags`. Since the new tags won't be more than 7 days old, none should get deleted. Next comment out [this if](https://github.com/tnevrlka/e2e-tests/blob/tag-cleanup/magefiles/utils.go#L247) and run it again. All the tags should be deleted.

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
