### PR TITLE
fix(RHTAPBUGS-197): enable pyxis tests again

### DIFF
--- a/tests/release/e2e-test-push-image-to-pyxis.go
+++ b/tests/release/e2e-test-push-image-to-pyxis.go
@@ -30,7 +30,6 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1571]test-release-e2e-push-image-
 	var devNamespace, managedNamespace string
 
 	BeforeAll(func() {
-		Skip("skip tests until: https://issues.redhat.com/browse/RHTAPBUGS-197")
 		fw, err = framework.NewFramework("release-e2e-pyxis")
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
# Description

The issue in the release pyxis test was caused
by bugs in a tekton task that is part
of the push-to-external-registry pipeline.

It was fixed here:
- https://github.com/redhat-appstudio/release-service-bundles/pull/111
- https://github.com/redhat-appstudio/release-service-bundles/pull/112

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The test was disabled earlier today because it was failing: https://github.com/redhat-appstudio/e2e-tests/pull/477
If it passes as part of the e2e run of this PR, that should prove that it's fixed now.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
