### PR TITLE
fix: just check for end fail release, lose intermediate is progressing check

### DIFF
--- a/tests/mvp-demo/mvp-demo.go
+++ b/tests/mvp-demo/mvp-demo.go
@@ -263,17 +263,6 @@ var _ = framework.MvpDemoSuiteDescribe("MVP Demo tests", Label("mvp-demo"), func
 			}, pipelineRunStartedTimeout, defaultPollingInterval).Should(BeTrue())
 		})
 
-		It("Release status is updated", func() {
-			Eventually(func() bool {
-				release, err = f.AsKubeAdmin.ReleaseController.GetRelease(release.Name, "", userNamespace)
-				if err != nil {
-					GinkgoWriter.Printf("failed to get Release CR in '%s' namespace: %+v\n", managedNamespace, err)
-					return false
-				}
-				return release.IsReleasing()
-			}, customResourceUpdateTimeout, defaultPollingInterval).Should(BeTrue())
-		})
-
 		It("Release PipelineRun should eventually fail", func() {
 			Eventually(func() bool {
 				pipelineRun, err = f.AsKubeAdmin.ReleaseController.GetPipelineRunInNamespace(managedNamespace, release.Name, release.Namespace)


### PR DESCRIPTION
# Description

See https://redhat-internal.slack.com/archives/C02FANRBZQD/p1682614030044649 

bottom line: the Release only was progressing for short periods, per what we saw in the condition time stamps, and could sneak past the 2 second polling interval

let's just worry about the desired end state, not some short lived intermediate state

/assign @Dannyb48 
/assign @flacatus 

## Issue ticket number and link

## Type of change

- [/] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
