### PR TITLE
feat(RHTAP-668): Introduce CI scripts for load test

### DIFF
--- a/pkg/utils/has/controller.go
+++ b/pkg/utils/has/controller.go
@@ -348,6 +348,11 @@ func (h *SuiteController) DeleteHasComponentDetectionQuery(name string, namespac
 
 // CreateComponentDetectionQuery create a has componentdetectionquery from a given name, namespace, and git source
 func (h *SuiteController) CreateComponentDetectionQuery(cdqName, namespace, gitSourceURL, gitSourceRevision, gitSourceContext, secret string, isMultiComponent bool) (*appservice.ComponentDetectionQuery, error) {
+	return h.CreateComponentDetectionQueryWithTimeout(cdqName, namespace, gitSourceURL, gitSourceRevision, gitSourceContext, secret, isMultiComponent, 5*time.Minute)
+}
+
+// CreateComponentDetectionQueryWithTimeout create a has componentdetectionquery from a given name, namespace, and git source and waits for it to be read
+func (h *SuiteController) CreateComponentDetectionQueryWithTimeout(cdqName, namespace, gitSourceURL, gitSourceRevision, gitSourceContext, secret string, isMultiComponent bool, timeout time.Duration) (*appservice.ComponentDetectionQuery, error) {
 	componentDetectionQuery := &appservice.ComponentDetectionQuery{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cdqName,
@@ -378,7 +383,7 @@ func (h *SuiteController) CreateComponentDetectionQuery(cdqName, namespace, gitS
 			}
 		}
 		return false, nil
-	}, 5*time.Minute)
+	}, timeout)
 
 	if err != nil {
 		return nil, fmt.Errorf("error waiting for cdq to be ready: %v", err)

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -170,8 +170,12 @@ func GetGeneratedNamespace(name string) string {
 	return name + "-" + util.GenerateRandomString(4)
 }
 
+func WaitUntilWithInterval(cond wait.ConditionFunc, interval time.Duration, timeout time.Duration) error {
+	return wait.PollImmediate(interval, timeout, cond)
+}
+
 func WaitUntil(cond wait.ConditionFunc, timeout time.Duration) error {
-	return wait.PollImmediate(time.Second, timeout, cond)
+	return WaitUntilWithInterval(cond, time.Second, timeout)
 }
 
 func ExecuteCommandInASpecificDirectory(command string, args []string, directory string) error {

--- a/tests/load-tests/ci-scripts/collect-results.sh
+++ b/tests/load-tests/ci-scripts/collect-results.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# shellcheck disable=SC1090
+source "/usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${1:-concurrent}"
+
+pushd "${2:-.}"
+
+echo "Collecting load test results"
+load_test_log=$ARTIFACT_DIR/load-tests.log
+cp -vf ./tests/load-tests/load-tests.log "$load_test_log"
+cp -vf ./tests/load-tests/load-tests.json "$ARTIFACT_DIR"
+cp -vf ./tests/load-tests/gh-rate-limits-remaining.csv "$ARTIFACT_DIR"
+
+application_timestamps=$ARTIFACT_DIR/applications.appstudio.redhat.com_timestamps
+application_timestamps_csv=${application_timestamps}.csv
+application_timestamps_txt=${application_timestamps}.txt
+componentdetectionquery_timestamps=$ARTIFACT_DIR/componentdetectionqueries.appstudio.redhat.com_timestamps.csv
+component_timestamps=$ARTIFACT_DIR/components.appstudio.redhat.com_timestamps.csv
+pipelinerun_timestamps=$ARTIFACT_DIR/pipelineruns.tekton.dev_timestamps.csv
+application_service_log=$ARTIFACT_DIR/application-service.log
+application_service_log_segments=$ARTIFACT_DIR/application-service-log-segments
+## Application timestamps
+echo "Collecting Application timestamps..."
+echo "Application;StatusSucceeded;StatusMessage;CreatedTimestamp;SucceededTimestamp" >"$application_timestamps_csv"
+oc get applications.appstudio.redhat.com -A -o json | jq -rc '.items[] | (.metadata.name) + ";" + (.status.conditions[0].status) + ";" + (.status.conditions[0].message) + ";" + (.metadata.creationTimestamp) + ";" + (.status.conditions[0].lastTransitionTime)' | sed -e 's,Z,,g' >>"$application_timestamps_csv"
+oc get applications.appstudio.redhat.com -A -o 'custom-columns=NAME:.metadata.name,CREATED:.metadata.creationTimestamp,LAST_UPDATED:.status.conditions[0].lastTransitionTime,STATUS:.status.conditions[0].reason,MESSAGE:.status.conditions[0].message' >"$application_timestamps_txt"
+## ComponentDetectionQuery timestamps
+echo "Collecting ComponentDetectionQuery timestamps..."
+echo "ComponentDetectionQuery;Namespace;CreationTimestamp;Completed;Completed.Reason;Completed.Mesasge" >"$componentdetectionquery_timestamps"
+oc get componentdetectionqueries.appstudio.redhat.com -A -o json | jq -rc '.items[] | (.metadata.name) + ";" + (.metadata.namespace) + ";" + (.metadata.creationTimestamp) + ";" + (.status.conditions[] | select(.type == "Completed") | .lastTransitionTime + ";" + .reason + ";" + .message + "")' | sed -e 's,Z,,g' >>"$componentdetectionquery_timestamps"
+## Component timestamps
+echo "Collecting Component timestamps..."
+echo "Component;Namespace;CreationTimestamp;Created;Created.Reason;Create.Mesasge;GitOpsResourcesGenerated;GitOpsResourcesGenerated.Reason;GitOpsResourcesGenerated.Message;Updated;Updated.Reason;Updated.Message" >"$component_timestamps"
+oc get components.appstudio.redhat.com -A -o json | jq -rc '.items[] | (.metadata.name) + ";" + (.metadata.namespace) + ";" + (.metadata.creationTimestamp) + ";" + (.status.conditions[] | select(.type == "Created") | .lastTransitionTime + ";" + .reason + ";" + (.message|split(";")|join("_"))) + ";" + (.status.conditions[] | select(.type == "GitOpsResourcesGenerated") | .lastTransitionTime + ";" + .reason + ";" + (.message|split(";")|join("_"))) + ";" + (.status.conditions[] | select(.type == "Updated") | .lastTransitionTime + ";" + .reason + ";" + (.message|split(";")|join("_")))' | sed -e 's,Z,,g' >>"$component_timestamps"
+## PipelineRun timestamps
+echo "Collecting PipelineRun timestamps..."
+echo "PipelineRun;Namespace;Succeeded;Reason;Message;Created;Started;FinallyStarted;Completed" >"$pipelinerun_timestamps"
+oc get pipelineruns.tekton.dev -A -o json | jq -r '.items[] | (.metadata.name) + ";" + (.metadata.namespace) + ";" + (.status.conditions[0].status) + ";" + (.status.conditions[0].reason) + ";" + (.status.conditions[0].message) + ";"  + (.metadata.creationTimestamp) + ";" + (.status.startTime) + ";" + (.status.finallyStartTime) + ";" + (.status.completionTime)' >>"$pipelinerun_timestamps"
+## Application service log segments per user app
+echo "Collecting application service log segments per user app..."
+oc logs -l "control-plane=controller-manager" --tail=-1 -n application-service >"$application_service_log"
+mkdir -p "$application_service_log_segments"
+for i in $(grep -Eo "${USER_PREFIX}-....-app" "$application_service_log" | sort | uniq); do grep "$i" "$application_service_log" >"$application_service_log_segments/$i.log"; done
+## Error summary
+echo "Number of errors occurred in load test log:"
+grep -Eo "Error #[0-9]+" "$load_test_log" | sort | uniq | while read -r i; do
+    echo -n " - $i: "
+    grep -c "$i" "$load_test_log"
+done | sort -V
+
+popd

--- a/tests/load-tests/ci-scripts/load-test.sh
+++ b/tests/load-tests/ci-scripts/load-test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# shellcheck disable=SC1090
+source "/usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${1:-concurrent}"
+
+pushd "${2:-./tests/load-tests}"
+
+export DOCKER_CONFIG_JSON=$QUAY_TOKEN
+
+rate_limits_csv=./gh-rate-limits-remaining.csv
+
+echo "Starting a watch for GH rate limits remainig"
+IFS="," read -ra kvs <<<"$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/github_accounts)"
+echo -n "Time" >"$rate_limits_csv"
+for kv in "${kvs[@]}"; do
+    IFS=":" read -ra name_token <<<"$kv"
+    echo -n ";${name_token[0]}" >>"$rate_limits_csv"
+done
+echo >>"$rate_limits_csv"
+
+while true; do
+    timestamp=$(printf "%s" "$(date -u +'%FT%T')")
+    echo -n "$timestamp" >>"$rate_limits_csv"
+    for kv in "${kvs[@]}"; do
+        IFS=":" read -ra name_token <<<"$kv"
+        rate=$(curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${name_token[1]}" -H "X-GitHub-Api-Version: 2022-11-28" 'https://api.github.com/rate_limit' | jq -rc '(.rate.remaining|tostring)')
+        echo -n ";$rate" >>"$rate_limits_csv"
+    done
+    echo >>"$rate_limits_csv"
+    sleep 10s
+done &
+
+rate_limit_exit=$!
+kill_rate_limits() {
+    echo "Stopping the watch for GH rate limits remainig"
+    kill $rate_limit_exit
+}
+trap kill_rate_limits EXIT
+
+./run.sh
+
+popd

--- a/tests/load-tests/ci-scripts/setup-cluster.sh
+++ b/tests/load-tests/ci-scripts/setup-cluster.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# shellcheck disable=SC1090
+source "/usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${1:-concurrent}"
+
+pushd "${2:-.}"
+
+# Install app-studio and tweak cluster configuration
+echo "Installing app-studio and tweaking cluster configuration"
+go mod tidy
+go mod vendor
+export MY_GITHUB_ORG QUAY_E2E_ORGANIZATION
+MY_GITHUB_ORG=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/github-org)
+QUAY_E2E_ORGANIZATION=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/quay-org)
+make local/cluster/prepare
+
+oc patch -n application-service secret has-github-token --type=json -p='[{"op": "add", "path": "/data/tokens", "value": "'"$(base64 -w0 </usr/local/ci-secrets/redhat-appstudio-load-test/github_accounts)"'"}]'
+oc patch -n application-service secret has-github-token -p '{"data": {"token": null}}'
+oc rollout restart deployment -n application-service
+oc rollout status deployment -n application-service -w
+
+popd

--- a/tests/load-tests/run.sh
+++ b/tests/load-tests/run.sh
@@ -7,5 +7,12 @@ if [ -z ${DOCKER_CONFIG_JSON+x} ]; then
 else echo "DOCKER_CONFIG_JSON is set"; fi
 
 USER_PREFIX=${USER_PREFIX:-testuser}
-go run loadtest.go --username "$USER_PREFIX" --users "${USERS_PER_THREAD:-50}" -w -l -t "${THREADS:-1}" --disable-metrics &&
-    DRY_RUN=false ./clear.sh "$USER_PREFIX"
+# Max length of compliant username is 20 characters. We add "-XXXX" suffix for the test users' name so max length of the prefix is 15.
+# See https://github.com/codeready-toolchain/toolchain-common/blob/master/pkg/usersignup/usersignup.go#L16
+if [ ${#USER_PREFIX} -gt 15 ]; then
+    echo "Maximal allowed length of user prefix is 15 characters. The '$USER_PREFIX' length of ${#USER_PREFIX} exceeds the limit."
+    exit 1
+else
+    go run loadtest.go --username "$USER_PREFIX" --users "${USERS_PER_THREAD:-50}" -w -l -t "${THREADS:-1}" --disable-metrics &&
+        DRY_RUN=false ./clear.sh "$USER_PREFIX"
+fi


### PR DESCRIPTION
# Description

This PR:
* Introduces CI scripts for load test
* Fixes the component names for tenant users that are now generated by `ComponentDetectionQuery`s
* Modifies the check for existence gitops repo to not use the GH token to avoid token's primary rate limits being quickly spent.

## Issue ticket number and link

[RHTAP-668](https://issues.redhat.com/browse/RHTAP-668)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Part of [rehearsal tests](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/37577/rehearse-37577-periodic-ci-redhat-appstudio-e2e-tests-main-load-test-concurrent/1658147748395880448) of https://github.com/openshift/release/pull/37577

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
