### PR TITLE
test: (STONEINTG-398) Add Happy Path coverage for namespace-backed envs

### DIFF
--- a/pkg/utils/gitops/deploymenttargetclasses.go
+++ b/pkg/utils/gitops/deploymenttargetclasses.go
@@ -6,6 +6,7 @@ import (
 
 	appservice "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // HaveAvailableDeploymentTargetClassExist attempts to find a DeploymentTargetClass with appstudioApi.Provisioner_Devsandbox as provisioner.
@@ -24,4 +25,37 @@ func (g *GitopsController) HaveAvailableDeploymentTargetClassExist() (*appservic
 	}
 
 	return nil, nil
+}
+
+// CreateDeploymentTargetClass creates a DeploymentTargetClass with a "appstudio.redhat.com/devsandbox" provisioner
+func (g *GitopsController) CreateDeploymentTargetClass() (*appservice.DeploymentTargetClass, error) {
+	dtcls := &appservice.DeploymentTargetClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-sandbox-class",
+			Annotations: map[string]string{},
+		},
+		Spec: appservice.DeploymentTargetClassSpec{
+			Provisioner:   appservice.Provisioner_Devsandbox,
+			ReclaimPolicy: "Retain",
+		},
+	}
+
+	err := g.KubeRest().Create(context.TODO(), dtcls)
+	if err != nil {
+		return nil, fmt.Errorf("error occurred when creating the DeploymentTargetClass: %+v", err)
+	}
+	return dtcls, nil
+}
+
+func (g *GitopsController) DeleteDeploymentTargetClass() (error) {
+	dtcls := appservice.DeploymentTargetClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-sandbox-class",
+		},
+	}
+	if err := g.KubeRest().Delete(context.TODO(), &dtcls); err != nil {
+		return fmt.Errorf("error occurred when deleting the DeploymentTargetClass: %+v", err)
+	}
+
+	return nil
 }

--- a/pkg/utils/gitops/environments.go
+++ b/pkg/utils/gitops/environments.go
@@ -10,6 +10,7 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/strings/slices"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -27,6 +28,29 @@ func (g *GitopsController) GetEnvironmentsList(namespace string) (*appservice.En
 	}
 
 	return environmentList, nil
+}
+
+// GetEphemeralEnvironment returns the Ephemeral Environment in the namespace and nil if it's not found
+// It will search for the Environment based on the Snapshot and Scneario name present in its labels,
+// and also look for environment containing the tag "ephemeral".
+func (g *GitopsController) GetEphemeralEnvironment(applicationName, snapshotName, integrationTestScenarioName, namespace string) (*appservice.Environment, error) {
+	opts := []client.ListOption{
+		client.InNamespace(namespace),
+	}
+
+	environmentList := &appservice.EnvironmentList{}
+	err := g.KubeRest().List(context.TODO(), environmentList, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("error occurred when listing the environments: %+v", err)
+	}
+
+	for _, environment := range environmentList.Items {
+		if environment.Labels["appstudio.openshift.io/snapshot"] == snapshotName && environment.Labels["test.appstudio.openshift.io/scenario"] == integrationTestScenarioName && slices.Contains(environment.Spec.Tags, "ephemeral") {
+			return &environment, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no matching ephemeral environment found %s", utils.GetAdditionalInfo(applicationName, namespace))
 }
 
 /*

--- a/pkg/utils/integration/pipelineruns.go
+++ b/pkg/utils/integration/pipelineruns.go
@@ -58,32 +58,42 @@ func (i *IntegrationController) CreateIntegrationPipelineRun(snapshotName, names
 
 // GetComponentPipeline returns the pipeline for a given component labels.
 func (i *IntegrationController) GetBuildPipelineRun(componentName, applicationName, namespace string, pacBuild bool, sha string) (*tektonv1beta1.PipelineRun, error) {
-	pipelineRunLabels := map[string]string{"appstudio.openshift.io/component": componentName, "appstudio.openshift.io/application": applicationName, "pipelines.appstudio.openshift.io/type": "build"}
-	opts := []client.ListOption{
-		client.InNamespace(namespace),
-		client.MatchingLabels{
-			"pipelines.appstudio.openshift.io/type": "build",
-			"appstudio.openshift.io/application":    applicationName,
-			"appstudio.openshift.io/component":      componentName,
-		},
-	}
+	var pipelineRun *tektonv1beta1.PipelineRun
 
-	if sha != "" {
-		pipelineRunLabels["pipelinesascode.tekton.dev/sha"] = sha
-	}
+	err := wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 20*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		pipelineRunLabels := map[string]string{"appstudio.openshift.io/component": componentName, "appstudio.openshift.io/application": applicationName, "pipelines.appstudio.openshift.io/type": "build"}
+		opts := []client.ListOption{
+			client.InNamespace(namespace),
+			client.MatchingLabels{
+				"pipelines.appstudio.openshift.io/type": "build",
+				"appstudio.openshift.io/application":    applicationName,
+				"appstudio.openshift.io/component":      componentName,
+			},
+		}
 
-	list := &tektonv1beta1.PipelineRunList{}
-	err := i.KubeRest().List(context.TODO(), list, opts...)
+        if sha != "" {
+			pipelineRunLabels["pipelinesascode.tekton.dev/sha"] = sha
+        }
 
-	if err != nil && !k8sErrors.IsNotFound(err) {
-		return nil, fmt.Errorf("error listing pipelineruns in %s namespace: %v", namespace, err)
-	}
+        list := &tektonv1beta1.PipelineRunList{}
+        err = i.KubeRest().List(context.TODO(), list, opts...)
 
-	if len(list.Items) > 0 {
-		return &list.Items[0], nil
-	}
+        if err != nil && !k8sErrors.IsNotFound(err) {
+            GinkgoWriter.Printf("error listing pipelineruns in %s namespace: %v", namespace, err)
+            return false, nil
+        }
 
-	return &tektonv1beta1.PipelineRun{}, fmt.Errorf("no pipelinerun found for component %s %s", componentName, utils.GetAdditionalInfo(applicationName, namespace))
+		if len(list.Items) > 0 {
+			pipelineRun = &list.Items[0]
+			return true, nil
+		}
+
+		pipelineRun = &tektonv1beta1.PipelineRun{}
+		GinkgoWriter.Printf("no pipelinerun found for component %s %s", componentName, utils.GetAdditionalInfo(applicationName, namespace))
+		return false, nil
+	})
+
+	return pipelineRun, err
 }
 
 // GetComponentPipeline returns the pipeline for a given component labels.
@@ -134,5 +144,66 @@ func (i *IntegrationController) WaitForIntegrationPipelineToBeFinished(testScena
 			}
 		}
 		return false, nil
+	})
+}
+
+// WaitForAllIntegrationPipelinesToBeFinished wait for all integration pipelines to finish.
+func (i *IntegrationController) WaitForAllIntegrationPipelinesToBeFinished(testNamespace, applicationName string, snapshot *appstudioApi.Snapshot) error {
+	integrationTestScenarios, err := i.GetIntegrationTestScenarios(applicationName, testNamespace)
+	if err != nil {
+		return fmt.Errorf("unable to get IntegrationTestScenarios for Application %s/%s. Error: %v", testNamespace, applicationName, err)
+	}
+
+	for _, testScenario := range *integrationTestScenarios {
+		GinkgoWriter.Printf("Integration test scenario %s is found\n", testScenario.Name)
+		err = i.WaitForIntegrationPipelineToBeFinished(&testScenario, snapshot, testNamespace)
+		if err != nil {
+			return fmt.Errorf("error occurred while waiting for Integration PLR (associated with IntegrationTestScenario: %s) to get finished in %s namespace. Error: %v", testScenario.Name, testNamespace, err)
+		}
+	}
+
+	return nil
+}
+
+// WaitForBuildPipelineRunToBeSigned waits for given build pipeline to get signed.
+func (i *IntegrationController) WaitForBuildPipelineRunToBeSigned(testNamespace, applicationName, componentName string) error {
+	return wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		pipelineRun, err := i.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+		if err != nil {
+			GinkgoWriter.Printf("pipelinerun for Component %s/%s can't be gotten successfully. Error: %v", testNamespace, componentName, err)
+			return false, nil
+		}
+		if pipelineRun.Annotations["chains.tekton.dev/signed"] != "true" {
+			GinkgoWriter.Printf("pipelinerun %s/%s hasn't been signed yet", pipelineRun.GetNamespace(), pipelineRun.GetName())
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+// GetAnnotationIfExists returns the value of a given annotation within a pipelinerun, if it exists.
+func (i *IntegrationController) GetAnnotationIfExists(testNamespace, applicationName, componentName, annotationKey string) (string, error) {
+	pipelineRun, err := i.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+	if err != nil {
+		return "", fmt.Errorf("pipelinerun for Component %s/%s can't be gotten successfully. Error: %v", testNamespace, componentName, err)
+	}
+	return pipelineRun.Annotations[annotationKey], nil
+}
+
+// WaitForBuildPipelineRunToGetAnnotated waits for given build pipeline to get annotated with a specific annotation.
+func (i *IntegrationController) WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, annotationKey string) error {
+	return wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+		pipelineRun, err := i.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+		if err != nil {
+			GinkgoWriter.Printf("pipelinerun for Component %s/%s can't be gotten successfully. Error: %v", testNamespace, componentName, err)
+			return false, nil
+		}
+
+		annotationValue, _ := i.GetAnnotationIfExists(testNamespace, applicationName, componentName, annotationKey)
+		if annotationValue == "" {
+			GinkgoWriter.Printf("build pipelinerun %s/%s doesn't contain annotation %s yet", testNamespace, pipelineRun.Name, annotationKey)
+			return false, nil
+		}
+		return true, nil
 	})
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@ Tests folder contains E2E related to several components divided in folders:
 | `cluster-registration` | https://github.com/stolostron/cluster-registration-operator | [README.md](/tests/cluster-registration/README.md)  |  |
 | `e2e-demos` | N/A | [README.md](/tests/e2e-demos/README.md) | |
 | `has` | https://github.com/redhat-appstudio/application-service | [README.md](/tests/has/README.md) | |
-| `integration-service` | https://github.com/redhat-appstudio/integration-service | N/A |  |
+| `integration-service` | https://github.com/redhat-appstudio/integration-service | [README.md](/tests/integration-service/README.md) |  |
 | `load-tests` | N/A | [LoadTests.md](/docs/LoadTests.md) |  |
-| `release` | https://github.com/redhat-appstudio/release-service | N/A |  |
+| `release` | https://github.com/redhat-appstudio/release-service | [README.md](/tests/release/README.md) |  |
 | `spi` | https://github.com/redhat-appstudio/service-provider-integration-operator | [README.md](/tests/spi/README.md) | |

--- a/tests/integration-service/README.md
+++ b/tests/integration-service/README.md
@@ -6,7 +6,7 @@ The Integration Service manages the lifecycle, deployment and integration testin
 ## Happy Path Tests
 
 Happy path testing describes tests that focus on the most common scenarios while assuming there are no exceptions or errors.
-### Basic E2E Tests:
+### Basic E2E Tests (within `integration.go`):
 
 - Testing for successful creation of applications and components.
 - Asserting the successful creation of a snapshot after a push event.
@@ -15,12 +15,23 @@ Happy path testing describes tests that focus on the most common scenarios while
 - Validating the successful creation of a SnapshotEnvironmentBinding.
 - Validating the successful creation of a Release.
 - Validating the Global Candidate is updated
-- Verifying that all integration pipeline runs finish successfully.
+- Verifying that all the Integration PipelineRuns finished successfully.
 - Checking that a snapshot gets successfully marked as 'passed' after all Integration pipeline runs finished.
+
+### E2E tests of Namespace-backed Environments (within `namespace-backed-environments.go`):
+
+- Testing for successful creation of applications, components, DeploymentTargetClass, Environment, and IntegrationTestScenario
+- Checking if the BuildPipelineRun is successfully triggered and completed.
+- Asserting the signing of BuildPipelineRun.
+- Validating the successful creation of a Snapshot, an Ephemeral environment, and an Integration PipelineRun.
+- Verifying that the Integration PipelineRun succeeded.
+- Asserting that the Snapshot was marked as Passed.
+- Verifying that the Epehemeral environment and related SnapshotEnvironmentBinding got deleted.
+
 
 ## Negative Test Cases
 
-### Failed IntegrationTestScenarios:
+### Failed IntegrationTestScenarios (within `integration.go`):
 
 - Creating an IntegrationTestScenario that is expected to fail.
 - Asserting that a snapshot is marked as failed.
@@ -28,7 +39,7 @@ Happy path testing describes tests that focus on the most common scenarios while
 - Checking that the global candidate does not get updated unexpectedly.
 
 
-### Failed Ephemeral Environment provisioning due to missing DeploymentTargetClass:
+### Failed Ephemeral Environment provisioning due to missing DeploymentTargetClass (within `namespace-backed-environments.go`):
 - Verifying that entities like deploymentTargetClass and GitOpsCR don't exist under certain conditions.
 - Asserting that no GitOpsCR is created for a non-existing deploymentTargetClass.
 - Checking that a snapshot doesn't get marked as 'passed' under specific conditions.

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -2,17 +2,14 @@ package integration
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/devfile/library/v2/pkg/util"
-	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 
 	appstudioApi "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	integrationv1alpha1 "github.com/redhat-appstudio/integration-service/api/v1alpha1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -43,6 +40,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 	var applicationName, componentName, testNamespace string
 	var timeout, interval time.Duration
 	var originalComponent *appstudioApi.Component
+	var pipelineRun *v1beta1.PipelineRun
 	var snapshot *appstudioApi.Snapshot
 	var snapshot_push *appstudioApi.Snapshot
 	var env *appstudioApi.Environment
@@ -52,10 +50,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 
 		createApp := func() {
 			applicationName = fmt.Sprintf("integ-app-%s", util.GenerateRandomString(4))
-			testNamespace = f.UserNamespace
-
-			_, err := f.AsKubeAdmin.CommonController.CreateTestNamespace(testNamespace)
-			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Error when creating/updating '%s' namespace: %v", testNamespace, err))
 
 			app, err := f.AsKubeAdmin.HasController.CreateApplication(applicationName, testNamespace)
 			Expect(err).NotTo(HaveOccurred())
@@ -66,8 +60,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 
 		createComponent := func() {
 			componentName = fmt.Sprintf("integration-suite-test-component-git-source-%s", util.GenerateRandomString(4))
-			timeout = time.Minute * 4
-			interval = time.Second * 1
 			// Create a component with Git Source URL being defined
 			// using cdq since git ref is not known
 			cdq, err := f.AsKubeAdmin.HasController.CreateComponentDetectionQuery(componentName, testNamespace, gitSourceURL, "", "", "", false)
@@ -96,86 +88,12 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			}
 		}
 
-		assertBuildPipelineRunFinished := func() {
-			var pipelineRun *v1beta1.PipelineRun
-			timeout = time.Minute * 10
-			Eventually(func() error {
-				pipelineRun, err = f.AsKubeAdmin.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
-				if err != nil {
-					GinkgoWriter.Printf("PipelineRun has not been created yet for Component %s/%s\n", testNamespace, componentName)
-					return err
-				}
-				if !pipelineRun.HasStarted() {
-					return fmt.Errorf("pipelinerun %s/%s hasn't started yet", pipelineRun.GetNamespace(), pipelineRun.GetName())
-				}
-				return nil
-			}, timeout, constants.PipelineRunPollingInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the PipelineRun to start for the component %s/%s", testNamespace, componentName))
-			Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", 2, f.AsKubeAdmin.TektonController)).To(Succeed())
-			Expect(pipelineRun.Annotations["appstudio.openshift.io/snapshot"]).To(Equal(""))
-		}
-
-		assertBuildPipelineRunSigned := func() {
-			Eventually(func() error {
-				pipelineRun, err := f.AsKubeAdmin.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
-				if err != nil {
-					GinkgoWriter.Printf("PipelineRun for Component %s/%s can't be gotten successfully\n", testNamespace, componentName)
-					return err
-				}
-				if pipelineRun.Annotations["chains.tekton.dev/signed"] != "true" {
-					return fmt.Errorf("pipelinerun %s/%s hasn't been signed yet", pipelineRun.GetNamespace(), pipelineRun.GetName())
-				}
-				return nil
-			}, timeout, constants.PipelineRunPollingInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the PipelineRun to be signed for component %s/%s", testNamespace, componentName))
-		}
-
-		assertSnapshotCreated := func() {
-			Eventually(func() error {
-				snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot("", "", componentName, testNamespace)
-				if err != nil {
-					GinkgoWriter.Printf("cannot get the Snapshot: %v\n", err)
-					return err
-				}
-				return nil
-			}, timeout, interval).Should(Succeed(), fmt.Sprintf("timed out when trying to check if the Snapshot for component %s/%s exists", testNamespace, componentName))
-			Eventually(func() error {
-				pipelineRun, err := f.AsKubeAdmin.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
-				if err != nil {
-					GinkgoWriter.Printf("PipelineRun for Component %s/%s can't be gotten successfully\n", testNamespace, componentName)
-					return err
-				}
-				if pipelineRun.Annotations["appstudio.openshift.io/snapshot"] != snapshot.GetName() {
-					return fmt.Errorf("build pipelinerun %s/%s hasn't been annotated with snapshot name", pipelineRun.GetNamespace(), pipelineRun.GetName())
-				}
-				return nil
-			}, timeout, interval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the buildPipelineRun annotated with Snapshot name %s", snapshot.GetName()))
-		}
-
-		assertIntegrationPipelineRunFinished := func() {
-			integrationTestScenarios, err := f.AsKubeAdmin.IntegrationController.GetIntegrationTestScenarios(applicationName, testNamespace)
-			Expect(err).ShouldNot(HaveOccurred())
-			for _, testScenario := range *integrationTestScenarios {
-				timeout = time.Minute * 5
-				Eventually(func() error {
-					pr, err := f.AsKubeAdmin.IntegrationController.GetIntegrationPipelineRun(testScenario.Name, snapshot.Name, testNamespace)
-					if err != nil {
-						GinkgoWriter.Printf("cannot get the Integration PipelineRun: %v\n", err)
-						return err
-					}
-					if !pr.HasStarted() {
-						return fmt.Errorf("pipelinerun %s/%s hasn't started yet", pr.GetNamespace(), pr.GetName())
-					}
-					return nil
-				}, timeout, constants.PipelineRunPollingInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the PipelineRun for test scenario %s and snapshot %s in %s namespace to start", testScenario.GetName(), snapshot.GetName(), snapshot.GetNamespace()))
-
-				Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(&testScenario, snapshot, testNamespace)).To(Succeed(), "Error when waiting for a integration pipeline to finish in %s namespace", testNamespace)
-			}
-		}
-
 		Describe("with happy path", Ordered, func() {
 			BeforeAll(func() {
 				// Initialize the tests controllers
 				f, err = framework.NewFramework(IntegrationServiceUser)
 				Expect(err).NotTo(HaveOccurred())
+				testNamespace = f.UserNamespace
 
 				createApp()
 				createComponent()
@@ -190,24 +108,32 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 					cleanup()
 
 					Expect(f.AsKubeAdmin.IntegrationController.DeleteSnapshot(snapshot_push, testNamespace)).To(Succeed())
+					Expect(f.AsKubeAdmin.GitOpsController.DeleteAllEnvironmentsInASpecificNamespace(EnvironmentName, time.Minute*5)).To(Succeed())
 				}
 			})
 
 			It("triggers a build PipelineRun", Label("integration-service"), func() {
-				assertBuildPipelineRunFinished()
+				pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+				Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", 2, f.AsKubeAdmin.TektonController)).To(Succeed())
+				Expect(pipelineRun.Annotations["appstudio.openshift.io/snapshot"]).To(Equal(""))
 			})
 
 			When("the build pipelineRun run succeeded", func() {
 				It("checks if the BuildPipelineRun is signed", func() {
-					assertBuildPipelineRunSigned()
+					Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToBeSigned(testNamespace, applicationName, componentName)).To(Succeed())
 				})
 
 				It("checks if the Snapshot is created", func() {
-					assertSnapshotCreated()
+					snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", componentName, testNamespace)
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+
+				It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
+					Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, "appstudio.openshift.io/snapshot")).To(Succeed())
 				})
 
 				It("checks if all of the integrationPipelineRuns passed", Label("slow"), func() {
-					assertIntegrationPipelineRunFinished()
+					Expect(f.AsKubeDeveloper.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, applicationName, snapshot)).To(Succeed())
 				})
 			})
 
@@ -231,26 +157,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 
 			When("An snapshot of push event is created", func() {
 				It("checks if all of the integrationPipelineRuns created by push event passed", Label("slow"), func() {
-					integrationTestScenarios, err := f.AsKubeAdmin.IntegrationController.GetIntegrationTestScenarios(applicationName, testNamespace)
-					Expect(err).ShouldNot(HaveOccurred())
-
-					for _, testScenario := range *integrationTestScenarios {
-						GinkgoWriter.Printf("Integration test scenario %s is found\n", testScenario.Name)
-						timeout = time.Minute * 5
-						Eventually(func() error {
-							pr, err := f.AsKubeAdmin.IntegrationController.GetIntegrationPipelineRun(testScenario.Name, snapshot_push.Name, testNamespace)
-							if err != nil {
-								GinkgoWriter.Printf("cannot get the Integration PipelineRun: %v\n", err)
-								return err
-							}
-							if !pr.HasStarted() {
-								return fmt.Errorf("pipelinerun %s/%s hasn't started yet", pr.GetNamespace(), pr.GetName())
-							}
-							return nil
-
-						}, timeout, constants.PipelineRunPollingInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the PipelineRun for test scenario %s and snapshot %s in %s namespace to start", testScenario.GetName(), snapshot_push.GetName(), snapshot_push.GetNamespace()))
-						Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(&testScenario, snapshot_push, testNamespace)).To(Succeed(), "Error when waiting for a integration pipeline to finish in %s namespace", testNamespace)
-					}
+					Expect(f.AsKubeAdmin.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, applicationName, snapshot_push)).To(Succeed(), "Error when waiting for one of the integration pipelines to finish in %s namespace", testNamespace)
 				})
 
 				It("checks if the global candidate is updated after push event", func() {
@@ -295,10 +202,13 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				// Initialize the tests controllers
 				f, err = framework.NewFramework(IntegrationServiceUser)
 				Expect(err).NotTo(HaveOccurred())
+				testNamespace = f.UserNamespace
 
 				createApp()
 				createComponent()
 
+				env, err = f.AsKubeAdmin.GitOpsController.CreatePocEnvironment(EnvironmentName, testNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
 				_, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario(applicationName, testNamespace, BundleURLFail, InPipelineNameFail)
 				Expect(err).ShouldNot(HaveOccurred())
 			})
@@ -306,39 +216,38 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			AfterAll(func() {
 				if !CurrentSpecReport().Failed() {
 					cleanup()
+
+					Expect(f.AsKubeAdmin.GitOpsController.DeleteAllEnvironmentsInASpecificNamespace(EnvironmentName, time.Minute*5)).To(Succeed())
 				}
 			})
 
 			It("triggers a build PipelineRun", Label("integration-service"), func() {
-				assertBuildPipelineRunFinished()
+				pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+				Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", 2, f.AsKubeAdmin.TektonController)).To(Succeed())
+				Expect(pipelineRun.Annotations["appstudio.openshift.io/snapshot"]).To(Equal(""))
 			})
 
 			It("checks if the BuildPipelineRun is signed", func() {
-				assertBuildPipelineRunSigned()
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToBeSigned(testNamespace, applicationName, componentName)).To(Succeed())
 			})
 
 			It("checks if the Snapshot is created", func() {
-				assertSnapshotCreated()
+				snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", pipelineRun.Name, componentName, testNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, "appstudio.openshift.io/snapshot")).To(Succeed())
 			})
 
 			It("checks if all of the integrationPipelineRuns finished", Label("slow"), func() {
-				assertIntegrationPipelineRunFinished()
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, applicationName, snapshot)).To(Succeed())
 			})
 
-			It("checks if snapshot is marked as failed", func() {
-				Eventually(func() error {
-					snapshot, err := f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
-					if err != nil {
-						GinkgoWriter.Printf("cannot get the Snapshot: %v\n", err)
-						return err
-					}
-					GinkgoWriter.Printf("snapshot %s is found\n", snapshot.Name)
-					if !f.AsKubeAdmin.CommonController.HaveTestsFinished(snapshot) {
-						return fmt.Errorf("tests haven't finished yet for snapshot %s/%s", snapshot.GetNamespace(), snapshot.GetName())
-					}
-					Expect(f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)).To(BeFalse(), "expected tests to fail for snapshot %s/%s", snapshot.GetNamespace(), snapshot.GetName())
-					return nil
-				}, timeout, interval).Should(Succeed(), fmt.Sprintf("time out when trying to check if either the Snapshot %s/%s exists or if the Snapshot is marked as failed", testNamespace, snapshot.GetName()))
+			It("checks if snapshot is marked as failed", FlakeAttempts(3), func() {
+				snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)).To(BeFalse(), "expected tests to fail for snapshot %s/%s", snapshot.GetNamespace(), snapshot.GetName())
 			})
 
 			It("creates an snapshot of push event", func() {
@@ -374,74 +283,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 
 					// global candidate is not updated
 					Expect(component.Spec.ContainerImage).To(Equal(originalComponent.Spec.ContainerImage))
-
-				})
-			})
-		})
-
-		Describe("valid dtcls doesn't exist", Ordered, func() {
-			var integrationTestScenario_alpha1 *integrationv1alpha1.IntegrationTestScenario
-			BeforeAll(func() {
-				// Initialize the tests controllers
-				f, err = framework.NewFramework(IntegrationServiceUser)
-				Expect(err).NotTo(HaveOccurred())
-
-				createApp()
-				createComponent()
-
-				integrationTestScenario_alpha1, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenarioWithEnvironment(applicationName, testNamespace, BundleURL, InPipelineName, EnvironmentName)
-				Expect(err).ShouldNot(HaveOccurred())
-				env, err = f.AsKubeAdmin.GitOpsController.CreatePocEnvironment(EnvironmentName, testNamespace)
-				Expect(err).ShouldNot(HaveOccurred())
-			})
-
-			AfterAll(func() {
-				if !CurrentSpecReport().Failed() {
-					cleanup()
-
-					Expect(f.AsKubeAdmin.GitOpsController.DeleteAllEnvironmentsInASpecificNamespace(testNamespace, 30*time.Second)).To(Succeed())
-					Expect(f.AsKubeAdmin.IntegrationController.DeleteSnapshot(snapshot_push, testNamespace)).To(Succeed())
-				}
-			})
-
-			It("valid deploymentTargetClass doesn't exist", func() {
-				validDTCLS, err := f.AsKubeAdmin.GitOpsController.HaveAvailableDeploymentTargetClassExist()
-				Expect(validDTCLS).To(BeNil())
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("creates a snapshot of push event", func() {
-				sampleImage := "quay.io/redhat-appstudio/sample-image@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
-				snapshot_push, err = f.AsKubeAdmin.IntegrationController.CreateSnapshotWithImage(componentName, applicationName, testNamespace, sampleImage)
-				Expect(err).ShouldNot(HaveOccurred())
-				GinkgoWriter.Printf("snapshot %s is found\n", snapshot_push.Name)
-			})
-
-			When("nonexisting valid deploymentTargetClass", func() {
-				It("check no GitOpsCR is created for the dtc with nonexisting deploymentTargetClass", func() {
-					spaceRequestList, err := f.AsKubeAdmin.GitOpsController.GetSpaceRequests(testNamespace)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(spaceRequestList.Items).To(BeEmpty())
-
-					deploymentTargetList, err := f.AsKubeAdmin.GitOpsController.GetDeploymentTargetsList(testNamespace)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(deploymentTargetList.Items).To(BeEmpty())
-
-					deploymentTargetClaimList, err := f.AsKubeAdmin.GitOpsController.GetDeploymentTargetClaimsList(testNamespace)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(deploymentTargetClaimList.Items).To(BeEmpty())
-
-					environmentList, err := f.AsKubeAdmin.GitOpsController.GetEnvironmentsList(testNamespace)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(len(environmentList.Items)).ToNot(BeNumerically(">", 1))
-
-					pipelineRun, err := f.AsKubeAdmin.IntegrationController.GetIntegrationPipelineRun(integrationTestScenario_alpha1.Name, snapshot_push.Name, testNamespace)
-					Expect(pipelineRun.Name == "" && strings.Contains(err.Error(), "no pipelinerun found")).To(BeTrue())
-				})
-				It("checks if snapshot is not marked as passed", func() {
-					snapshot, err := f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot_push.Name, "", "", testNamespace)
-					Expect(err).ShouldNot(HaveOccurred())
-					Expect(f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)).To(BeFalse())
 				})
 			})
 		})

--- a/tests/integration-service/namespace-backed-environments.go
+++ b/tests/integration-service/namespace-backed-environments.go
@@ -1,0 +1,260 @@
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/devfile/library/v2/pkg/util"
+	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+	appstudioApi "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	integrationv1beta1 "github.com/redhat-appstudio/integration-service/api/v1beta1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	componentRepoName = "hacbs-test-project"
+	componentRepoURL  = "https://github.com/redhat-appstudio-qe/" + componentRepoName
+	EnvNameForNBE     = "user-picked-environment"
+	gitURLForNBE      = "https://github.com/redhat-appstudio/integration-examples.git"
+	revisionForNBE    = "main"
+	pathInRepoForNBE  = "pipelines/integration_test_app.yaml"
+)
+
+var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment (NBE) E2E tests", Label("integration-service", "HACBS", "namespace-backed-envs"), func() {
+	defer GinkgoRecover()
+
+	var f *framework.Framework
+	var err error
+
+	var applicationName, componentName, testNamespace string
+	var pipelineRun, testPipelinerun *v1beta1.PipelineRun
+	var timeout, interval time.Duration
+	var originalComponent *appstudioApi.Component
+	var snapshot, snapshot_push *appstudioApi.Snapshot
+	var integrationTestScenario *integrationv1beta1.IntegrationTestScenario
+	var env, ephemeralEnvironment, userPickedEnvironment *appstudioApi.Environment
+	var snapshotEnvironmentBinding *appstudioApi.SnapshotEnvironmentBinding
+	AfterEach(framework.ReportFailure(&f))
+
+	Describe("the component with git source (GitHub) is created", Ordered, func() {
+
+		createApp := func() {
+			applicationName = fmt.Sprintf("integ-app-%s", util.GenerateRandomString(4))
+
+			app, err := f.AsKubeAdmin.HasController.CreateApplication(applicationName, testNamespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(utils.WaitUntil(f.AsKubeAdmin.HasController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
+				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
+			)
+		}
+
+		createComponent := func() {
+			componentName = fmt.Sprintf("integration-suite-test-component-git-source-%s", util.GenerateRandomString(4))
+			// Create a component with Git Source URL being defined
+			// using cdq since git ref is not known
+			cdq, err := f.AsKubeAdmin.HasController.CreateComponentDetectionQuery(componentName, testNamespace, componentRepoURL, "", "", "", false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cdq.Status.ComponentDetected).To(HaveLen(1), "Expected length of the detected Components was not 1")
+
+			for _, compDetected := range cdq.Status.ComponentDetected {
+				originalComponent, err = f.AsKubeAdmin.HasController.CreateComponent(compDetected.ComponentStub, testNamespace, "", "", applicationName, true, map[string]string{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(originalComponent).NotTo(BeNil())
+				componentName = originalComponent.Name
+			}
+		}
+
+		cleanup := func() {
+			if !CurrentSpecReport().Failed() {
+				Expect(f.AsKubeAdmin.HasController.DeleteApplication(applicationName, testNamespace, false)).To(Succeed())
+				Expect(f.AsKubeAdmin.HasController.DeleteComponent(componentName, testNamespace, false)).To(Succeed())
+				integrationTestScenarios, err := f.AsKubeAdmin.IntegrationController.GetIntegrationTestScenarios(applicationName, testNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				for _, testScenario := range *integrationTestScenarios {
+					Expect(f.AsKubeAdmin.IntegrationController.DeleteIntegrationTestScenario(&testScenario, testNamespace)).To(Succeed())
+				}
+				Expect(f.SandboxController.DeleteUserSignup(f.UserName)).To(BeTrue())
+			}
+		}
+
+		Describe("with happy path for Namespace-backed environments", Ordered, func() {
+			BeforeAll(func() {
+				// Initialize the tests controllers
+				f, err = framework.NewFramework(utils.GetGeneratedNamespace("nbe-e2e"))
+				Expect(err).NotTo(HaveOccurred())
+				testNamespace = f.UserNamespace
+
+				createApp()
+				createComponent()
+				
+				dtcls, err := f.AsKubeAdmin.GitOpsController.CreateDeploymentTargetClass()
+				Expect(dtcls).ToNot(BeNil())
+				Expect(err).ToNot(HaveOccurred())
+
+				userPickedEnvironment, err = f.AsKubeAdmin.GitOpsController.CreatePocEnvironment(EnvNameForNBE, testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+
+				integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenarioWithEnvironment(applicationName, testNamespace, gitURLForNBE, revisionForNBE, pathInRepoForNBE, userPickedEnvironment)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			AfterAll(func() {
+				if !CurrentSpecReport().Failed() {
+					cleanup()
+				}
+
+				Expect(f.AsKubeAdmin.GitOpsController.DeleteDeploymentTargetClass()).To(Succeed())
+			})
+
+			It("triggers a build PipelineRun", Label("integration-service"), func() {
+				pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+				Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", 2, f.AsKubeAdmin.TektonController)).To(Succeed())
+				Expect(pipelineRun.Annotations["appstudio.openshift.io/snapshot"]).To(Equal(""))
+			})
+
+			When("the build pipelineRun run succeeded", func() {
+				It("checks if the BuildPipelineRun is signed", func() {
+					Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToBeSigned(testNamespace, applicationName, componentName)).To(Succeed())
+				})
+
+				It("checks if the Snapshot is created", func() {
+					snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", componentName, testNamespace)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
+					Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, "appstudio.openshift.io/snapshot")).To(Succeed())
+				})
+			})
+
+			It("creates an Ephemeral Environment", func ()  {
+				ephemeralEnvironment, err = f.AsKubeAdmin.GitOpsController.GetEphemeralEnvironment(snapshot.Spec.Application, snapshot.Name, integrationTestScenario.Name, testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ephemeralEnvironment.Name).ToNot(BeEmpty())
+			})
+
+			It("should find the related Integration Test PipelineRun", func() {
+				timeout = time.Minute * 5
+				interval = time.Second * 2
+				Eventually(func() error {
+					testPipelinerun, err = f.AsKubeAdmin.IntegrationController.GetIntegrationPipelineRun(integrationTestScenario.Name, snapshot.Name, testNamespace)
+					if err != nil {
+						GinkgoWriter.Printf("failed to get Integration test PipelineRun for a snapshot '%s' in '%s' namespace: %+v\n", snapshot.Name, testNamespace, err)
+						return err
+					}
+					if !testPipelinerun.HasStarted() {
+						return fmt.Errorf("pipelinerun %s/%s hasn't started yet", testPipelinerun.GetNamespace(), testPipelinerun.GetName())
+					}
+					return nil
+				}, timeout, interval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the Integration PipelineRun to start for the IntegrationTestScenario/Snapshot : %s/%s", integrationTestScenario.Name, snapshot.Name))
+				Expect(testPipelinerun.Labels["appstudio.openshift.io/snapshot"]).To(ContainSubstring(snapshot.Name))
+				Expect(testPipelinerun.Labels["test.appstudio.openshift.io/scenario"]).To(ContainSubstring(integrationTestScenario.Name))
+				Expect(testPipelinerun.Labels["appstudio.openshift.io/environment"]).To(ContainSubstring(ephemeralEnvironment.Name))
+			})
+			
+
+			When("Integration Test PipelineRun is created", func() {
+				It("should eventually complete successfully", func() {
+					Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenario, snapshot, testNamespace)).To(Succeed(), fmt.Sprintf("Error when waiting for a integration pipeline for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
+				})
+			})
+
+			When("Integration Test PipelineRun completes successfully", func() {
+				It("should lead to Snapshot CR being marked as passed", FlakeAttempts(3), func() {
+					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot("", pipelineRun.Name, "", testNamespace)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)).To(BeTrue(), fmt.Sprintf("tests have not succeeded for snapshot %s/%s", snapshot.GetNamespace(), snapshot.GetName()))
+				})
+
+				It("should lead to SnapshotEnvironmentBinding getting deleted", func() {
+					Eventually(func() bool {
+						snapshotEnvironmentBinding, err = f.AsKubeAdmin.CommonController.GetSnapshotEnvironmentBinding(applicationName, testNamespace, ephemeralEnvironment)
+						return snapshotEnvironmentBinding == nil
+					}, time.Minute*3, time.Second*2).Should(BeTrue(), fmt.Sprintf("timed out when waiting for SnapshotEnvironmentBinding to be deleted for application %s/%s", testNamespace, applicationName))
+				})
+
+				It("should lead to ephemeral environment getting deleted", func() {
+					Eventually(func() bool {
+						ephemeralEnvironment, err = f.AsKubeAdmin.GitOpsController.GetEphemeralEnvironment(snapshot.Spec.Application, snapshot.Name, integrationTestScenario.Name, testNamespace)
+						return ephemeralEnvironment == nil
+					}, time.Minute*3, time.Second*1).Should(BeTrue(), fmt.Sprintf("timed out when waiting for the Ephemeral Environment %s to be deleted", ephemeralEnvironment.Name))
+				})
+			})
+		})
+
+		Describe("when valid DeploymentTargetClass doesn't exist", Ordered, func() {
+			var integrationTestScenario *integrationv1beta1.IntegrationTestScenario
+			BeforeAll(func() {
+				// Initialize the tests controllers
+				f, err = framework.NewFramework(utils.GetGeneratedNamespace("nbe-neg"))
+				Expect(err).NotTo(HaveOccurred())
+				testNamespace = f.UserNamespace
+
+				createApp()
+				createComponent()
+
+				env, err = f.AsKubeAdmin.GitOpsController.CreatePocEnvironment(EnvNameForNBE, testNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+				integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenarioWithEnvironment(applicationName, testNamespace, gitURLForNBE, revisionForNBE, pathInRepoForNBE, env)
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			AfterAll(func() {
+				if !CurrentSpecReport().Failed() {
+					cleanup()
+
+					Expect(f.AsKubeAdmin.GitOpsController.DeleteAllEnvironmentsInASpecificNamespace(testNamespace, 30*time.Second)).To(Succeed())
+					Expect(f.AsKubeAdmin.IntegrationController.DeleteSnapshot(snapshot_push, testNamespace)).To(Succeed())
+				}
+			})
+
+			It("valid deploymentTargetClass doesn't exist", func() {
+				validDTCLS, err := f.AsKubeAdmin.GitOpsController.HaveAvailableDeploymentTargetClassExist()
+				Expect(validDTCLS).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("creates a snapshot of push event", func() {
+				sampleImage := "quay.io/redhat-appstudio/sample-image@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
+				snapshot_push, err = f.AsKubeAdmin.IntegrationController.CreateSnapshotWithImage(componentName, applicationName, testNamespace, sampleImage)
+				Expect(err).ToNot(HaveOccurred())
+				GinkgoWriter.Printf("snapshot %s is found\n", snapshot_push.Name)
+			})
+
+			When("nonexisting valid deploymentTargetClass", func() {
+				It("check no GitOpsCR is created for the dtc with nonexisting deploymentTargetClass", func() {
+					spaceRequestList, err := f.AsKubeAdmin.GitOpsController.GetSpaceRequests(testNamespace)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(spaceRequestList.Items).To(BeEmpty())
+
+					deploymentTargetList, err := f.AsKubeAdmin.GitOpsController.GetDeploymentTargetsList(testNamespace)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(deploymentTargetList.Items).To(BeEmpty())
+
+					deploymentTargetClaimList, err := f.AsKubeAdmin.GitOpsController.GetDeploymentTargetClaimsList(testNamespace)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(deploymentTargetClaimList.Items).To(BeEmpty())
+
+					environmentList, err := f.AsKubeAdmin.GitOpsController.GetEnvironmentsList(testNamespace)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(len(environmentList.Items)).ToNot(BeNumerically(">", 2))
+
+					pipelineRun, err := f.AsKubeAdmin.IntegrationController.GetIntegrationPipelineRun(integrationTestScenario.Name, snapshot_push.Name, testNamespace)
+					Expect(pipelineRun.Name == "" && strings.Contains(err.Error(), "no pipelinerun found")).To(BeTrue())
+				})
+				It("checks if snapshot is not marked as passed", func() {
+					snapshot, err := f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot_push.Name, "", "", testNamespace)
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)).To(BeFalse())
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
# Description

This addition to the mvp-demo test suite's Chapter 2 deals with executing an IntegrationTestScenario on a Snapshot inside an ephemeral environment. The test makes sure that the snapshot passes the testing and gets marked as "passed".

## Issue ticket number and link
[STONEINTG-398](https://issues.redhat.com/browse/STONEINTG-398)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
