### PR TITLE
feat: ec validate can take mulitiple images as input

### DIFF
--- a/pkg/utils/tekton/pipelines.go
+++ b/pkg/utils/tekton/pipelines.go
@@ -1,6 +1,7 @@
 package tekton
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -8,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 
+	app "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/common"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -87,6 +89,23 @@ type VerifyEnterpriseContract struct {
 }
 
 func (p VerifyEnterpriseContract) Generate() *v1beta1.PipelineRun {
+	var snapshot app.SnapshotSpec
+	err := json.Unmarshal([]byte(p.Image), &snapshot)
+	if err != nil {
+		fmt.Printf("Application Snapshot doesn't exist: %s\n", err)
+	}
+
+	if len(snapshot.Components) == 0 {
+		p.Image = `{
+			"application": "` + p.ApplicationName + `",
+			"components": [
+			  {
+				"name": "` + p.ComponentName + `",
+				"containerImage": "` + p.Image + `"
+			  }
+			]
+		  }`
+	}
 	return &v1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-run-", p.Name),
@@ -105,16 +124,8 @@ func (p VerifyEnterpriseContract) Generate() *v1beta1.PipelineRun {
 							{
 								Name: "IMAGES",
 								Value: v1beta1.ArrayOrString{
-									Type: v1beta1.ParamTypeString,
-									StringVal: `{
-							"application": "` + p.ApplicationName + `",
-							"components": [
-							  {
-								"name": "` + p.ComponentName + `",
-								"containerImage": "` + p.Image + `"
-							  }
-							]
-						  }`,
+									Type:      v1beta1.ParamTypeString,
+									StringVal: p.Image,
 								},
 							},
 							{

--- a/tests/enterprise-contract/const.go
+++ b/tests/enterprise-contract/const.go
@@ -1,0 +1,5 @@
+package enterprisecontract
+
+const (
+	snapshotComponent = `{"components":[{"containerImage":"quay.io/redhat-appstudio/ec-golden-image:e2e-test-out-of-date-task"},{"containerImage":"quay.io/redhat-appstudio/ec-golden-image:e2e-test-unacceptable-task"}]}`
+)

--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -79,6 +79,38 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 			pipelineRunTimeout = int(time.Duration(5) * time.Minute)
 		})
 
+		It("verifies ec validate accepts a list of image references", func() {
+			policy := ecp.EnterpriseContractPolicySpec{
+				Sources: policySource,
+				Configuration: &ecp.EnterpriseContractPolicyConfiguration{
+					Include: []string{"minimal"},
+				},
+			}
+			Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
+
+			generator.Image = snapshotComponent
+			pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
+
+			pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			tr, err := kubeController.GetTaskRunStatus(fwk.AsKubeAdmin.CommonController.KubeRest(), pr, "verify-enterprise-contract")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(tr.Status.TaskRunResults).Should(Or(
+				// TODO: delete the first option after https://issues.redhat.com/browse/RHTAP-810 is completed
+				ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.OldTektonTaskTestOutputName, "{$.result}", `["SUCCESS"]`)),
+				ContainElements(tekton.MatchTaskRunResultWithJSONPathValue(constants.TektonTaskTestOutputName, "{$.result}", `["SUCCESS"]`)),
+			))
+			//Get container step-report log details from pod
+			reportLog, err := kubeController.Commonctrl.GetContainerLogs(tr.Status.PodName, "step-report", namespace)
+			GinkgoWriter.Printf("*** Logs from pod '%s', container '%s':\n----- START -----%s----- END -----\n", tr.Status.PodName, "step-report", reportLog)
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
 		It("verifies the release policy: Task bundle is not acceptable", func() {
 			policy := ecp.EnterpriseContractPolicySpec{
 				Sources: policySource,


### PR DESCRIPTION
# Description

add case of cmd 'ec-cli validate' accepts a list of image references to validate images, signature and attestationa

## Issue ticket number and link
https://issues.redhat.com/browse/HACBS-1837

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
$ ./bin/e2e-appstudio --ginkgo.focus-file tests/enterprise-contract/contract.go --ginkgo.vv
...
...
Ran 3 of 331 Specs in 36.731 seconds
SUCCESS! -- 3 Passed | 0 Failed | 5 Pending | 323 Skipped
PASS
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
