### PR TITLE
test: SVPI-473 collect SPI ResourceQuota metrics (temporary)

### DIFF
--- a/pkg/utils/common/resource_quota.go
+++ b/pkg/utils/common/resource_quota.go
@@ -1,0 +1,33 @@
+package common
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetResourceQuota returns the ResourceQuota object from a given namespace and ResourceQuota name
+func (s *SuiteController) GetResourceQuota(namespace, ResourceQuotaName string) (*corev1.ResourceQuota, error) {
+	return s.KubeInterface().CoreV1().ResourceQuotas(namespace).Get(context.TODO(), ResourceQuotaName, metav1.GetOptions{})
+}
+
+// GetSpiResourceQuotaInfo returns the available spi resources and its usage in a given test, namespace, and ResourceQuota name
+func (s *SuiteController) GetSpiResourceQuotaInfo(test, namespace, resourceQuotaName string) error {
+	rq, err := s.GetResourceQuota(namespace, resourceQuotaName)
+	if err != nil {
+		return err
+	}
+
+	available := rq.Status.Hard
+	used := rq.Status.Used
+
+	for resourceName, availableQuantity := range available {
+		if usedQuantity, ok := used[resourceName]; ok {
+			GinkgoWriter.Printf("test: %s, namespace: %s, resource: %s, available: %s, used: %s\n", test, namespace, resourceName, availableQuantity.String(), usedQuantity.String())
+		}
+	}
+
+	return nil
+}

--- a/tests/spi/get-file-content.go
+++ b/tests/spi/get-file-content.go
@@ -41,6 +41,10 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "get-file-content"), func(
 
 		// Clean up after running these tests and before the next tests block: can't have multiple AccessTokens in Injected phase
 		AfterAll(func() {
+			// collect SPI ResourceQuota metrics (temporary)
+			err := fw.AsKubeAdmin.CommonController.GetSpiResourceQuotaInfo("get-file-content", namespace, "appstudio-crds-spi")
+			Expect(err).NotTo(HaveOccurred())
+
 			if !CurrentSpecReport().Failed() {
 				Expect(fw.AsKubeAdmin.SPIController.DeleteAllBindingTokensInASpecificNamespace(namespace)).To(Succeed())
 				Expect(fw.AsKubeAdmin.SPIController.DeleteAllAccessTokensInASpecificNamespace(namespace)).To(Succeed())

--- a/tests/spi/link-secret-sa.go
+++ b/tests/spi/link-secret-sa.go
@@ -50,6 +50,10 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "link-secret-sa"), func() 
 
 			// Clean up after running these tests and before the next tests block: can't have multiple AccessTokens in Injected phase
 			AfterAll(func() {
+				// collect SPI ResourceQuota metrics (temporary)
+				err := fw.AsKubeAdmin.CommonController.GetSpiResourceQuotaInfo("link-secret-sa", namespace, "appstudio-crds-spi")
+				Expect(err).NotTo(HaveOccurred())
+
 				if !CurrentSpecReport().Failed() {
 					Expect(fw.AsKubeAdmin.SPIController.DeleteAllBindingTokensInASpecificNamespace(namespace)).To(Succeed())
 					Expect(fw.AsKubeAdmin.SPIController.DeleteAllAccessTokensInASpecificNamespace(namespace)).To(Succeed())

--- a/tests/spi/quay-imagepullsecret-usage.go
+++ b/tests/spi/quay-imagepullsecret-usage.go
@@ -63,6 +63,10 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "quay-imagepullsecret-usag
 
 		// Clean up after running these tests and before the next tests block: can't have multiple AccessTokens in Injected phase
 		AfterAll(func() {
+			// collect SPI ResourceQuota metrics (temporary)
+			err := fw.AsKubeAdmin.CommonController.GetSpiResourceQuotaInfo("quay-imagepullsecret-usage", namespace, "appstudio-crds-spi")
+			Expect(err).NotTo(HaveOccurred())
+
 			if !CurrentSpecReport().Failed() {
 				Expect(fw.AsKubeAdmin.SPIController.DeleteAllBindingTokensInASpecificNamespace(namespace)).To(Succeed())
 				Expect(fw.AsKubeAdmin.SPIController.DeleteAllAccessTokensInASpecificNamespace(namespace)).To(Succeed())

--- a/tests/spi/token-upload-k8s.go
+++ b/tests/spi/token-upload-k8s.go
@@ -137,6 +137,10 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "token-upload-k8s"), func(
 
 		// Clean up after running these tests and before the next tests block: can't have multiple AccessTokens in Injected phase
 		AfterAll(func() {
+			// collect SPI ResourceQuota metrics (temporary)
+			err := fw.AsKubeAdmin.CommonController.GetSpiResourceQuotaInfo("token-upload-k8s", namespace, "appstudio-crds-spi")
+			Expect(err).NotTo(HaveOccurred())
+
 			if !CurrentSpecReport().Failed() {
 				Expect(fw.AsKubeAdmin.SPIController.DeleteAllBindingTokensInASpecificNamespace(namespace)).To(Succeed())
 				Expect(fw.AsKubeAdmin.SPIController.DeleteAllAccessTokensInASpecificNamespace(namespace)).To(Succeed())

--- a/tests/spi/token-upload-rest-endpoint.go
+++ b/tests/spi/token-upload-rest-endpoint.go
@@ -51,6 +51,10 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "token-upload-rest-endpoin
 
 			// Clean up after running these tests and before the next tests block: can't have multiple AccessTokens in Injected phase
 			AfterAll(func() {
+				// collect SPI ResourceQuota metrics (temporary)
+				err := fw.AsKubeAdmin.CommonController.GetSpiResourceQuotaInfo("token-upload-rest-endpoint", namespace, "appstudio-crds-spi")
+				Expect(err).NotTo(HaveOccurred())
+
 				if !CurrentSpecReport().Failed() {
 					Expect(fw.AsKubeAdmin.SPIController.DeleteAllBindingTokensInASpecificNamespace(namespace)).To(Succeed())
 					Expect(fw.AsKubeAdmin.SPIController.DeleteAllAccessTokensInASpecificNamespace(namespace)).To(Succeed())


### PR DESCRIPTION
# Description

Unfortunately, we came across with `status unknown for quota error`. It seems that it is an isolated case, since it seems that it did not happen again. However, in order to mitigate this error in further failures, ResourceQuota metrics were added to the SPI tests.

## Issue ticket number and link
[SVPI-473](https://issues.redhat.com/browse/SVPI-473)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)