### PR TITLE
fix: refactored taskrun results validation

### DIFF
--- a/pkg/utils/build/task_results.go
+++ b/pkg/utils/build/task_results.go
@@ -4,17 +4,64 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
-	"strings"
 
-	. "github.com/onsi/ginkgo/v2"
+	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func FetchTaskRunResult(c crclient.Client, pr *v1beta1.PipelineRun, pipelineTaskName string, result string) (string, error) {
+var taskNames = []string{"clair-scan", "clamav-scan", "deprecated-base-image-check", "inspect-image", "label-check", "optional-label-check", "sbom-json-check"}
+
+type TestOutput struct {
+	Result    string `json:"result"`
+	Timestamp string `json:"timestamp"`
+	Note      string `json:"note"`
+	Namespace string `json:"namespace"`
+	Successes int    `json:"successes"`
+	Failures  int    `json:"failures"`
+	Warnings  int    `json:"warnings"`
+}
+
+type ClairScanResult struct {
+	Vulnerabilities Vulnerabilities `json:"vulnerabilities"`
+}
+
+type Vulnerabilities struct {
+	Critical int `json:"critical"`
+	High     int `json:"high"`
+	Medium   int `json:"medium"`
+	Low      int `json:"low"`
+}
+
+func ValidateBuildPipelineTestResults(pipelineRun *v1beta1.PipelineRun, c crclient.Client) error {
+	for _, taskName := range taskNames {
+		results, err := fetchTaskRunResults(c, pipelineRun, taskName)
+		if err != nil {
+			return err
+		}
+
+		resultsToValidate := []string{constants.TektonTaskTestOutputName}
+
+		switch taskName {
+		case "clair-scan":
+			resultsToValidate = append(resultsToValidate, "CLAIR_SCAN_RESULT")
+		case "deprecated-image-check":
+			resultsToValidate = append(resultsToValidate, "PYXIS_HTTP_CODE")
+		case "inspect-image":
+			resultsToValidate = append(resultsToValidate, "BASE_IMAGE", "BASE_IMAGE_REPOSITORY")
+		}
+
+		if err := validateTaskRunResult(results, resultsToValidate, taskName); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func fetchTaskRunResults(c crclient.Client, pr *v1beta1.PipelineRun, pipelineTaskName string) ([]v1beta1.TaskRunResult, error) {
 	for _, chr := range pr.Status.ChildReferences {
 		if chr.PipelineTaskName != pipelineTaskName {
 			continue
@@ -22,73 +69,49 @@ func FetchTaskRunResult(c crclient.Client, pr *v1beta1.PipelineRun, pipelineTask
 		taskRun := &v1beta1.TaskRun{}
 		taskRunKey := types.NamespacedName{Namespace: pr.Namespace, Name: chr.Name}
 		if err := c.Get(context.TODO(), taskRunKey, taskRun); err != nil {
-			return "", err
+			return nil, err
 		}
-		for _, trResult := range taskRun.Status.TaskRunResults {
-			if trResult.Name == result {
-				return strings.TrimSuffix(trResult.Value.StringVal, "\n"), nil
+		return taskRun.Status.TaskRunResults, nil
+	}
+	return nil, fmt.Errorf(
+		"pipelineTaskName %q not found in PipelineRun %s/%s", pipelineTaskName, pr.GetName(), pr.GetNamespace())
+}
+
+func validateTaskRunResult(trResults []v1beta1.TaskRunResult, expectedResultNames []string, taskName string) error {
+	for _, rn := range expectedResultNames {
+		found := false
+		for _, r := range trResults {
+			if rn == r.Name {
+				found = true
+				switch r.Name {
+				case constants.TektonTaskTestOutputName:
+					var testOutput = &TestOutput{}
+					err := json.Unmarshal([]byte(r.Value.StringVal), &testOutput)
+					if err != nil {
+						return fmt.Errorf("cannot parse %q result: %+v", constants.TektonTaskTestOutputName, err)
+					}
+					// If the test result isn't SUCCESS, the overall outcome is a failure
+					if taskName == "sbom-json-check" {
+						if testOutput.Result == "FAILURE" {
+							return fmt.Errorf("expected Result for Task name %q to be SUCCESS: %+v", taskName, testOutput)
+						}
+					}
+				case "CLAIR_SCAN_RESULT":
+					var testOutput = &ClairScanResult{}
+					err := json.Unmarshal([]byte(r.Value.StringVal), &testOutput)
+					if err != nil {
+						return fmt.Errorf("cannot parse CLAIR_SCAN_RESULT result: %+v", err)
+					}
+				case "PYXIS_HTTP_CODE", "BASE_IMAGE", "BASE_IMAGE_REPOSITORY":
+					if len(r.Value.StringVal) < 1 {
+						return fmt.Errorf("value of %q result is empty", r.Name)
+					}
+				}
 			}
 		}
-	}
-	return "", fmt.Errorf(
-		"result %q not found in TaskRuns of PipelineRun %s/%s for pipeline task name %s", result, pr.ObjectMeta.Namespace, pr.ObjectMeta.Name, pipelineTaskName)
-}
-
-func FetchImageTaskRunResult(c crclient.Client, pr *v1beta1.PipelineRun, pipelineTaskName string, result string) (string, error) {
-	for _, chr := range pr.Status.ChildReferences {
-		if chr.PipelineTaskName != pipelineTaskName {
-			continue
-		}
-		taskRun := &v1beta1.TaskRun{}
-		taskRunKey := types.NamespacedName{Namespace: pr.Namespace, Name: chr.Name}
-		if err := c.Get(context.TODO(), taskRunKey, taskRun); err != nil {
-			return "", err
-		}
-		for _, trResult := range taskRun.Status.TaskRunResults {
-
-			if trResult.Name == "BASE_IMAGE_REPOSITORY" || trResult.Name == result {
-				return trResult.Value.StringVal, nil
-			}
+		if !found {
+			return fmt.Errorf("expected result name %q not found in Task %q result", rn, taskName)
 		}
 	}
-	return "", fmt.Errorf(
-		"result %q not found in TaskRuns of PipelineRun %s/%s", result, pr.ObjectMeta.Namespace, pr.ObjectMeta.Name)
-}
-
-func ValidateImageTaskRunResults(taskname string, result string) bool {
-	var re = regexp.MustCompile(`devfile/python`)
-	if taskname == "inspect-image" {
-		if !(re.MatchString(result)) {
-			Fail(fmt.Sprintf("Expected Result for Taskrun '%s', failed with '%s'", taskname, result))
-		}
-	}
-	return true
-}
-
-func ValidateTaskRunResults(taskname string, result string) bool {
-	var testOutput map[string]interface{}
-	err := json.Unmarshal([]byte(result), &testOutput)
-	if err != nil {
-		Fail(fmt.Sprintf("Taskrun '%s' has failed with '%s'", taskname, err))
-	}
-	// conftest-clair taskruns are expected to FAIL
-	if taskname == "conftest-clair" {
-		if testOutput["result"] == "FAILURE" {
-			return true
-		}
-	}
-	// label-check taskruns are expected to FAIL
-	if taskname == "label-check" {
-		if testOutput["result"] == "FAILURE" {
-			return true
-		}
-	}
-	// If the test result isn't SUCCESS, the overall outcome is a failure
-	if taskname == "sbom-json-check" {
-		if testOutput["result"] == "FAILURE" {
-			Fail(fmt.Sprintf("Expected Result for Taskrun '%s' is SUCCESS, but '%d' test failed", taskname, testOutput["failures"]))
-		}
-		return true
-	}
-	return false
+	return nil
 }

--- a/pkg/utils/build/task_results.go
+++ b/pkg/utils/build/task_results.go
@@ -12,7 +12,7 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var taskNames = []string{"clair-scan", "clamav-scan", "deprecated-base-image-check", "inspect-image", "label-check", "optional-label-check", "sbom-json-check"}
+var taskNames = []string{"clair-scan", "clamav-scan", "deprecated-base-image-check", "inspect-image", "label-check", "sbom-json-check"}
 
 type TestOutput struct {
 	Result    string `json:"result"`

--- a/tests/mvp-demo/mvp-demo.go
+++ b/tests/mvp-demo/mvp-demo.go
@@ -426,7 +426,7 @@ var _ = framework.MvpDemoSuiteDescribe("MVP Demo tests", Label("mvp-demo"), func
 		})
 
 		It("resulting SBOM file can be downloaded", func() {
-			pipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, appName, userNamespace, "")
+			pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, appName, userNamespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			var outputImage string
@@ -440,6 +440,10 @@ var _ = framework.MvpDemoSuiteDescribe("MVP Demo tests", Label("mvp-demo"), func
 			_, _, err = build.GetParsedSbomFilesContentFromImage(outputImage)
 			Expect(err).NotTo(HaveOccurred())
 
+		})
+
+		It("validation of Tekton TaskRun test results completes successfully", func() {
+			Expect(build.ValidateBuildPipelineTestResults(pipelineRun, f.AsKubeAdmin.CommonController.KubeRest())).To(Succeed())
 		})
 
 		It("Snapshot is created", func() {

--- a/tests/mvp-demo/mvp-demo.go
+++ b/tests/mvp-demo/mvp-demo.go
@@ -426,9 +426,6 @@ var _ = framework.MvpDemoSuiteDescribe("MVP Demo tests", Label("mvp-demo"), func
 		})
 
 		It("resulting SBOM file can be downloaded", func() {
-			pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, appName, userNamespace, "")
-			Expect(err).ShouldNot(HaveOccurred())
-
 			var outputImage string
 			for _, p := range pipelineRun.Spec.Params {
 				if p.Name == "output-image" {
@@ -439,10 +436,11 @@ var _ = framework.MvpDemoSuiteDescribe("MVP Demo tests", Label("mvp-demo"), func
 
 			_, _, err = build.GetParsedSbomFilesContentFromImage(outputImage)
 			Expect(err).NotTo(HaveOccurred())
-
 		})
 
 		It("validation of Tekton TaskRun test results completes successfully", func() {
+			pipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, appName, userNamespace, mergeResultSha)
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(build.ValidateBuildPipelineTestResults(pipelineRun, f.AsKubeAdmin.CommonController.KubeRest())).To(Succeed())
 		})
 


### PR DESCRIPTION
# Description

+ included taskrun validation in build templates e2e and mvp-demo

## Issue ticket number and link
[RHTAPBUGS-207](https://issues.redhat.com//browse/RHTAPBUGS-207)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
ginkgo  --focus "HACBS pipelines" --v ./cmd/ -- --config-suites=$PWD/tests/e2e-demos/config/default.yaml
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
