### PR TITLE
fix: using specific data and policy for Release policy "out of date" test case

### DIFF
--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -28,7 +28,6 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 	publicSecretName := "cosign-public-key"
 
 	BeforeAll(func() {
-		Skip("Skip until: https://issues.redhat.com/browse/RHTAPBUGS-236 it is closed")
 		fwk, err = framework.NewFramework(constants.TEKTON_CHAINS_E2E_USER)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fwk.UserNamespace).NotTo(BeNil(), "failed to create sandbox user")
@@ -115,7 +114,16 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 
 		It("verifies the release policy: Task bundle is out of date", func() {
 			policy := ecp.EnterpriseContractPolicySpec{
-				Sources: policySource,
+				Sources: []ecp.Source{
+					{
+						Policy: []string{
+							"oci::quay.io/hacbs-contract/ec-release-policy:git-086f871@sha256:373a5c4c1d34123836cbfc11826f6bbf6fdf8f0dfae333a2686bbe941c4f79ef",
+						},
+						Data: []string{
+							"oci::quay.io/hacbs-contract/ec-policy-data:git-8629680@sha256:ee5708dda57216647f63032dd3e63375e70e2353cb1ad10c9ab5493b9236c23e",
+						},
+					},
+				},
 				Configuration: &ecp.EnterpriseContractPolicyConfiguration{
 					Include: []string{"attestation_task_bundle.task_ref_bundles_current"},
 				},


### PR DESCRIPTION
# Description

using specific data and policy configuration bundle  to ensure task 'build-container' bundle "'quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:c3712257615d206ef40013bf1c5c681670fc8f7fd6aac9fa4c86f7afeff627ef' always in the [acceptable bundle list.](https://github.com/enterprise-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml)

## Issue ticket number and link
https://issues.redhat.com/browse/RHTAPBUGS-236

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
