### PR TITLE
Increate the timeout to 5 mins to prevent CI failures

### DIFF
--- a/pkg/utils/has/controller.go
+++ b/pkg/utils/has/controller.go
@@ -378,7 +378,7 @@ func (h *SuiteController) CreateComponentDetectionQuery(cdqName, namespace, gitS
 			}
 		}
 		return false, nil
-	}, 3*time.Minute)
+	}, 5*time.Minute)
 
 	if err != nil {
 		return nil, fmt.Errorf("error waiting for cdq to be ready: %v", err)


### PR DESCRIPTION
## Description

This PR increases the timeout value (from 3 mins to 5 mins) for CDQ to get ready. I saw a PR fail due to the timeout, [here is the build-log.txt](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/redhat-appstudio_e2e-tests/512/pull-ci-redhat-appstudio-e2e-tests-main-redhat-appstudio-e2e/1656537260398481408/build-log.txt) of the failed CI run.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
