### PR TITLE
fix: RHTAP-912: fail Eventually ginkgo clauses on terminal failure states; all ginkgo 'Should' clauses should have debug info including keys

### DIFF
--- a/tests/mvp-demo/mvp-demo.go
+++ b/tests/mvp-demo/mvp-demo.go
@@ -25,6 +25,7 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/build"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
+	"github.com/redhat-appstudio/e2e-tests/tests"
 	"github.com/redhat-appstudio/jvm-build-service/pkg/apis/jvmbuildservice/v1alpha1"
 	releaseApi "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -472,6 +473,7 @@ var _ = framework.MvpDemoSuiteDescribe("MVP Demo tests", Label("mvp-demo"), func
 					GinkgoWriter.Printf("failed to get PipelineRun for a release '%s' in '%s' namespace: %+v\n", release.Name, managedNamespace, err)
 					return false
 				}
+				tests.ExpectPipelineRunNotToFail(pipelineRun)
 				return pipelineRun.IsDone() && pipelineRun.GetStatusCondition().GetCondition(apis.ConditionSucceeded).IsTrue()
 			}, releasePipelineTimeout, pipelineRunPollingInterval).Should(BeTrue())
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1,0 +1,17 @@
+package tests
+
+import (
+	"fmt"
+
+	. "github.com/onsi/gomega"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	
+	"knative.dev/pkg/apis"
+)
+
+func ExpectPipelineRunNotToFail(pr *v1beta1.PipelineRun) {
+	failed := pr.IsDone() && pr.GetStatusCondition().GetCondition(apis.ConditionSucceeded).IsFalse()
+	if failed {
+		Expect(failed, fmt.Sprintf("did not expect pr %s:%s to fail", pr.Namespace, pr.Name)).NotTo(BeTrue())
+	}
+}


### PR DESCRIPTION
# Description

An example of failing fast when possible, and always providing useful debug messages so that users unfamiliar with your test have a starting point for searching the must-gather data, and don't have to start reading the e2e-test code to see where to start triage

Ideally QE start creating additional stories off of https://issues.redhat.com/browse/RHTAP-914 to apply these patterns across the board.

## Issue ticket number and link

https://issues.redhat.com/browse/RHTAP-915

## Type of change

- [/] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

ran e2e's against my local cluster

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
