### PR TITLE
fix: sample app can be built successfully should use DEFAULT_QUAY_ORG

### DIFF
--- a/tests/mvp-demo/mvp-demo.go
+++ b/tests/mvp-demo/mvp-demo.go
@@ -227,7 +227,9 @@ var _ = framework.MvpDemoSuiteDescribe("MVP Demo tests", Label("mvp-demo"), func
 		})
 
 		It("sample app can be built successfully", func() {
-			_, err = f.AsKubeAdmin.HasController.CreateComponent(appName, componentName, userNamespace, sampleRepoURL, componentNewBaseBranch, "", constants.DefaultImagePushRepo, "", true)
+			quayOrg := utils.GetEnv(constants.DEFAULT_QUAY_ORG_ENV, constants.DefaultQuayOrg)
+			outputContainerImage := strings.ReplaceAll(constants.DefaultImagePushRepo, constants.DefaultQuayOrg, quayOrg)
+			_, err = f.AsKubeAdmin.HasController.CreateComponent(appName, componentName, userNamespace, sampleRepoURL, componentNewBaseBranch, "", outputContainerImage, "", true)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(f.AsKubeAdmin.CommonController, componentName, appName, userNamespace, "")).To(Succeed())
 		})


### PR DESCRIPTION
# Description

During my fix in https://github.com/redhat-appstudio/e2e-tests/pull/495 there was one spot I forgot to take into account
wrt `DEFAULT_QUAY_ORG`

## Issue ticket number and link

## Type of change

- [ /] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran mvp-demo locally

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
