### PR TITLE
test: SVPI-473 collect SPI ResourceQuota before and after + add more logs to GetResourceQuotaInfo function

### DIFF
--- a/pkg/utils/common/resource_quota.go
+++ b/pkg/utils/common/resource_quota.go
@@ -13,20 +13,29 @@ func (s *SuiteController) GetResourceQuota(namespace, ResourceQuotaName string) 
 	return s.KubeInterface().CoreV1().ResourceQuotas(namespace).Get(context.TODO(), ResourceQuotaName, metav1.GetOptions{})
 }
 
-// GetSpiResourceQuotaInfo returns the available spi resources and its usage in a given test, namespace, and ResourceQuota name
-func (s *SuiteController) GetSpiResourceQuotaInfo(test, namespace, resourceQuotaName string) error {
+// GetResourceQuotaInfo returns the available resources and its usage in a given test, namespace, and ResourceQuota name
+func (s *SuiteController) GetResourceQuotaInfo(test, namespace, resourceQuotaName string) error {
 	rq, err := s.GetResourceQuota(namespace, resourceQuotaName)
 	if err != nil {
+		GinkgoWriter.Printf("failed to get ResourceQuota %s in namespace %s: %v\n", resourceQuotaName, namespace, err)
 		return err
 	}
 
+	notFound := false
 	available := rq.Status.Hard
 	used := rq.Status.Used
 
 	for resourceName, availableQuantity := range available {
 		if usedQuantity, ok := used[resourceName]; ok {
-			GinkgoWriter.Printf("test: %s, namespace: %s, resource: %s, available: %s, used: %s\n", test, namespace, resourceName, availableQuantity.String(), usedQuantity.String())
+			GinkgoWriter.Printf("test: %s, namespace: %s, resourceQuota: %s, resource: %s, available: %s, used: %s\n", test, namespace, resourceQuotaName, resourceName, availableQuantity.String(), usedQuantity.String())
+		} else {
+			notFound = true
 		}
+	}
+
+	// something went wrong
+	if len(available) == 0 || len(used) == 0 || notFound {
+		GinkgoWriter.Printf("test: %s, namespace: %s, resourceQuota: %s, available resources: %s, used resources: %s\n", test, namespace, resourceQuotaName, available, used)
 	}
 
 	return nil

--- a/tests/e2e-demos/e2e-demo.go
+++ b/tests/e2e-demos/e2e-demo.go
@@ -67,6 +67,10 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 				namespace = fw.UserNamespace
 				Expect(namespace).NotTo(BeEmpty())
 
+				// collect SPI ResourceQuota metrics (temporary)
+				err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("e2e-demo", namespace, "appstudio-crds-spi")
+				Expect(err).NotTo(HaveOccurred())
+
 				suiteConfig, _ := GinkgoConfiguration()
 				GinkgoWriter.Printf("Parallel processes: %d\n", suiteConfig.ParallelTotal)
 				GinkgoWriter.Printf("Running on namespace: %s\n", namespace)
@@ -79,6 +83,10 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo"), func() {
 
 			// Remove all resources created by the tests
 			AfterAll(func() {
+				// collect SPI ResourceQuota metrics (temporary)
+				err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("e2e-demo", namespace, "appstudio-crds-spi")
+				Expect(err).NotTo(HaveOccurred())
+
 				if !CurrentSpecReport().Failed() {
 					Expect(fw.AsKubeDeveloper.HasController.DeleteAllComponentsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
 					Expect(fw.AsKubeAdmin.HasController.DeleteAllApplicationsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())

--- a/tests/e2e-demos/multi-component.go
+++ b/tests/e2e-demos/multi-component.go
@@ -115,6 +115,10 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo", "multi-component"), func() 
 				namespace = fw.UserNamespace
 				Expect(namespace).NotTo(BeEmpty())
 
+				// collect SPI ResourceQuota metrics (temporary)
+				err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("multi-component", namespace, "appstudio-crds-spi")
+				Expect(err).NotTo(HaveOccurred())
+
 				suiteConfig, _ := GinkgoConfiguration()
 				GinkgoWriter.Printf("Parallel processes: %d\n", suiteConfig.ParallelTotal)
 				GinkgoWriter.Printf("Running on namespace: %s\n", namespace)
@@ -128,6 +132,10 @@ var _ = framework.E2ESuiteDescribe(Label("e2e-demo", "multi-component"), func() 
 
 			// Remove all resources created by the tests
 			AfterAll(func() {
+				// collect SPI ResourceQuota metrics (temporary)
+				err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("multi-component", namespace, "appstudio-crds-spi")
+				Expect(err).NotTo(HaveOccurred())
+
 				if !CurrentSpecReport().Failed() {
 					Expect(fw.AsKubeDeveloper.HasController.DeleteAllComponentsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
 					Expect(fw.AsKubeAdmin.HasController.DeleteAllApplicationsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())

--- a/tests/spi/get-file-content.go
+++ b/tests/spi/get-file-content.go
@@ -37,12 +37,15 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "get-file-content"), func(
 			namespace = fw.UserNamespace
 			Expect(namespace).NotTo(BeEmpty())
 
+			// collect SPI ResourceQuota metrics (temporary)
+			err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("token-upload-rest-endpoint", namespace, "appstudio-crds-spi")
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		// Clean up after running these tests and before the next tests block: can't have multiple AccessTokens in Injected phase
 		AfterAll(func() {
 			// collect SPI ResourceQuota metrics (temporary)
-			err := fw.AsKubeAdmin.CommonController.GetSpiResourceQuotaInfo("get-file-content", namespace, "appstudio-crds-spi")
+			err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("get-file-content", namespace, "appstudio-crds-spi")
 			Expect(err).NotTo(HaveOccurred())
 
 			if !CurrentSpecReport().Failed() {

--- a/tests/spi/link-secret-sa.go
+++ b/tests/spi/link-secret-sa.go
@@ -46,12 +46,16 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "link-secret-sa"), func() 
 				Expect(err).NotTo(HaveOccurred())
 				namespace = fw.UserNamespace
 				Expect(namespace).NotTo(BeEmpty())
+
+				// collect SPI ResourceQuota metrics (temporary)
+				err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("token-upload-rest-endpoint", namespace, "appstudio-crds-spi")
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			// Clean up after running these tests and before the next tests block: can't have multiple AccessTokens in Injected phase
 			AfterAll(func() {
 				// collect SPI ResourceQuota metrics (temporary)
-				err := fw.AsKubeAdmin.CommonController.GetSpiResourceQuotaInfo("link-secret-sa", namespace, "appstudio-crds-spi")
+				err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("link-secret-sa", namespace, "appstudio-crds-spi")
 				Expect(err).NotTo(HaveOccurred())
 
 				if !CurrentSpecReport().Failed() {

--- a/tests/spi/quay-imagepullsecret-usage.go
+++ b/tests/spi/quay-imagepullsecret-usage.go
@@ -44,7 +44,6 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "quay-imagepullsecret-usag
 
 	Describe("SVPI-407 - Check ImagePullSecret usage for the private Quay image", Ordered, func() {
 		BeforeAll(func() {
-
 			if os.Getenv("CI") != "true" {
 				Skip(fmt.Sprintln("test skipped on local execution"))
 			}
@@ -53,6 +52,10 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "quay-imagepullsecret-usag
 			Expect(err).NotTo(HaveOccurred())
 			namespace = fw.UserNamespace
 			Expect(namespace).NotTo(BeEmpty())
+
+			// collect SPI ResourceQuota metrics (temporary)
+			err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("token-upload-rest-endpoint", namespace, "appstudio-crds-spi")
+			Expect(err).NotTo(HaveOccurred())
 
 			// Quay username and token are required by SPI to generate valid credentials
 			QuayAuthToken = utils.GetEnv(constants.QUAY_OAUTH_TOKEN_ENV, "")
@@ -64,7 +67,7 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "quay-imagepullsecret-usag
 		// Clean up after running these tests and before the next tests block: can't have multiple AccessTokens in Injected phase
 		AfterAll(func() {
 			// collect SPI ResourceQuota metrics (temporary)
-			err := fw.AsKubeAdmin.CommonController.GetSpiResourceQuotaInfo("quay-imagepullsecret-usage", namespace, "appstudio-crds-spi")
+			err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("quay-imagepullsecret-usage", namespace, "appstudio-crds-spi")
 			Expect(err).NotTo(HaveOccurred())
 
 			if !CurrentSpecReport().Failed() {

--- a/tests/spi/token-upload-k8s.go
+++ b/tests/spi/token-upload-k8s.go
@@ -49,10 +49,18 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "token-upload-k8s"), func(
 			Expect(err).NotTo(HaveOccurred())
 			namespace = fw.UserNamespace
 			Expect(namespace).NotTo(BeEmpty())
+
+			// collect SPI ResourceQuota metrics (temporary)
+			err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("token-upload-rest-endpoint", namespace, "appstudio-crds-spi")
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		// Clean up after running these tests and before the next tests block: can't have multiple AccessTokens in Injected phase
 		AfterAll(func() {
+			// collect SPI ResourceQuota metrics (temporary)
+			err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("token-upload-k8s", namespace, "appstudio-crds-spi")
+			Expect(err).NotTo(HaveOccurred())
+
 			if !CurrentSpecReport().Failed() {
 				Expect(fw.AsKubeAdmin.SPIController.DeleteAllBindingTokensInASpecificNamespace(namespace)).To(Succeed())
 				Expect(fw.AsKubeAdmin.SPIController.DeleteAllAccessTokensInASpecificNamespace(namespace)).To(Succeed())
@@ -133,12 +141,16 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "token-upload-k8s"), func(
 			Expect(err).NotTo(HaveOccurred())
 			namespace = fw.UserNamespace
 			Expect(namespace).NotTo(BeEmpty())
+
+			// collect SPI ResourceQuota metrics (temporary)
+			err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("token-upload-rest-endpoint", namespace, "appstudio-crds-spi")
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		// Clean up after running these tests and before the next tests block: can't have multiple AccessTokens in Injected phase
 		AfterAll(func() {
 			// collect SPI ResourceQuota metrics (temporary)
-			err := fw.AsKubeAdmin.CommonController.GetSpiResourceQuotaInfo("token-upload-k8s", namespace, "appstudio-crds-spi")
+			err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("token-upload-k8s", namespace, "appstudio-crds-spi")
 			Expect(err).NotTo(HaveOccurred())
 
 			if !CurrentSpecReport().Failed() {

--- a/tests/spi/token-upload-rest-endpoint.go
+++ b/tests/spi/token-upload-rest-endpoint.go
@@ -47,12 +47,16 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "token-upload-rest-endpoin
 				Expect(err).NotTo(HaveOccurred())
 				namespace = fw.UserNamespace
 				Expect(namespace).NotTo(BeEmpty())
+
+				// collect SPI ResourceQuota metrics (temporary)
+				err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("token-upload-rest-endpoint", namespace, "appstudio-crds-spi")
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			// Clean up after running these tests and before the next tests block: can't have multiple AccessTokens in Injected phase
 			AfterAll(func() {
 				// collect SPI ResourceQuota metrics (temporary)
-				err := fw.AsKubeAdmin.CommonController.GetSpiResourceQuotaInfo("token-upload-rest-endpoint", namespace, "appstudio-crds-spi")
+				err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("token-upload-rest-endpoint", namespace, "appstudio-crds-spi")
 				Expect(err).NotTo(HaveOccurred())
 
 				if !CurrentSpecReport().Failed() {


### PR DESCRIPTION
# Description

Although `status unknown for quota` seemed to not appear in the past few days, it appeared yesterday, as can be checked [here](https://search.ci.openshift.org/?search=status+unknown+for+quota&maxAge=336h&context=1&type=build-log&name=.*e2e-tests.*&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=jobl). Unfortunately, in the failed testcase, the metrics were not printed. Probably because something went wrong on getting the ResourceQuota information.

So, this PR adds some improvements to the `GetResourceQuotaInfo` function in order to add more logs when there is an error getting the ResourceQuota and when the ResourceQuota does not have any available or used resources.

Furthermore, this PR also collects the metrics before the SPI tests (the current code only collects after). Since this error also appears in e2e demo tests, this PR also collects the metrics on them.

## Issue ticket number and link
[SVPI-473](https://issues.redhat.com/browse/SVPI-473)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
