### PR TITLE
fix: disable flaky EC test

### DIFF
--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -190,7 +190,8 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 			Expect(reportLog).Should(ContainSubstring("msg: Pipeline task 'build-container' uses an unacceptable task bundle"))
 		})
 
-		It("verifies the release policy: Task bundle is out of date", func() {
+		// Test disabled temporarily until https://issues.redhat.com/browse/HACBS-2259
+		It("verifies the release policy: Task bundle is out of date", Pending, func() {
 			policy := ecp.EnterpriseContractPolicySpec{
 				Sources: []ecp.Source{
 					{


### PR DESCRIPTION
# Description

This change disables the EC test `verifies the release policy: Task bundle is out of date`. It has started to fail for now apparent reason. This allows us to debug the test without impacting other work.

## Issue ticket number and link

https://issues.redhat.com/browse/HACBS-2260

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
