### PR TITLE
fix: Check image controller annotations in component when image generate is set

### DIFF
--- a/pkg/utils/build/quay.go
+++ b/pkg/utils/build/quay.go
@@ -31,6 +31,16 @@ func GetQuayImageName(annotations map[string]string) (string, error) {
 	return strings.Join(tokens[2:], "/"), nil
 }
 
+func IsImageAnnotationPresent(annotations map[string]string) bool {
+	image_annotation_str := annotations["image.redhat.com/image"]
+	return image_annotation_str != ""
+}
+
+func ImageAnnotationGenerateValueIsNotFailed(annotations map[string]string) bool {
+	generate_value_str := annotations["image.redhat.com/generate"]
+	return generate_value_str != "failed"
+}
+
 func GetRobotAccountName(imageName string) string {
 	tokens := strings.Split(imageName, "/")
 	return strings.Join(tokens, "")


### PR DESCRIPTION
# Description

This PR addresses story: https://issues.redhat.com/browse/STONEBLD-1183 and also added a missing error checking when component is recreated.

## Issue ticket number and link
https://issues.redhat.com/browse/STONEBLD-1183

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
