### PR TITLE
chore: added collaborators to root OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,3 +4,12 @@ approvers:
 - psturc
 - jkopriva
 - sawood14012
+- albarbaro
+- kasemAlem
+- jinqi7
+- tisutisu
+- srivickynesh
+- cuipinghuo
+- dheerajodha
+- naftalysh
+- Dannyb48


### PR DESCRIPTION
# Why

some people listed in [CODEOWNERS file](https://github.com/redhat-appstudio/e2e-tests/blob/5a05bc2d057c2c0de09f11e998337b0e906c70e8/.github/CODEOWNERS#L8) and people with write permissions to the repo are not able to approve PRs via the usual prow workflow (i.e. by adding the `/approve` comment), because they are not listed in OWNERS file

## Issue ticket number and link
N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

-

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
