### PR TITLE
feat(HACBS-2127): add author to ReleasePlan labels

### DIFF
--- a/pkg/utils/integration/controller.go
+++ b/pkg/utils/integration/controller.go
@@ -267,6 +267,7 @@ func (h *SuiteController) CreateReleasePlan(applicationName, namespace string) (
 			Namespace:    namespace,
 			Labels: map[string]string{
 				releasemetadata.AutoReleaseLabel: "true",
+				releasemetadata.AuthorLabel:      "username",
 			},
 		},
 		Spec: releasev1alpha1.ReleasePlanSpec{

--- a/pkg/utils/release/controller.go
+++ b/pkg/utils/release/controller.go
@@ -223,6 +223,7 @@ func (s *SuiteController) CreateReleasePlan(name, namespace, application, target
 			Namespace:    namespace,
 			Labels: map[string]string{
 				releaseMetadata.AutoReleaseLabel: autoReleaseLabel,
+				releaseMetadata.AuthorLabel:      "username",
 			},
 		},
 		Spec: releaseApi.ReleasePlanSpec{


### PR DESCRIPTION
A new feature in the Release service relies on an author label existing in the ReleasePlan for the automated usecase. This is done via webhooks, so the author label should be manually added to the ReleasePlan CRs.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
