### PR TITLE
feat: add pruning e2e-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The following environment variables are used to launch the Red Hat AppStudio ins
 | `INFRA_DEPLOYMENTS_BRANCH` | no | A valid infra-deployments branch. | `main` |
 | `E2E_TEST_SUITE_LABEL` | no | Run only test suites with the given Giknkgo label | '' |
 | `KLOG_VERBOSITY` | no | Level of verbosity for `klog` | 1 |
+| `IMAGE_TAG_EXPIRATION` | no | Expiration for tags created by pull-request pipelineruns, format: digits + `h` (hours), `d` (days) or `w` (weeks), e. g. `5d` | `6h` |
 
 1. Install dependencies:
 

--- a/magefiles/installation/install.go
+++ b/magefiles/installation/install.go
@@ -66,6 +66,9 @@ type InstallAppStudio struct {
 
 	// Oauth2 token for default quay organization
 	DefaultImageQuayOrgOAuth2Token string
+
+	// Default expiration for image tags
+	DefaultImageTagExpiration string
 }
 
 func NewAppStudioInstallController() (*InstallAppStudio, error) {
@@ -88,6 +91,7 @@ func NewAppStudioInstallController() (*InstallAppStudio, error) {
 		QuayToken:                        utils.GetEnv("QUAY_TOKEN", ""),
 		DefaultImageQuayOrg:              utils.GetEnv("DEFAULT_QUAY_ORG", DEFAULT_E2E_QUAY_ORG),
 		DefaultImageQuayOrgOAuth2Token:   utils.GetEnv("DEFAULT_QUAY_ORG_TOKEN", ""),
+		DefaultImageTagExpiration:        utils.GetEnv(constants.IMAGE_TAG_EXPIRATION_ENV, constants.DefaultImageTagExpiration),
 	}, nil
 }
 
@@ -114,6 +118,7 @@ func (i *InstallAppStudio) setInstallationEnvironments() {
 	os.Setenv("QUAY_TOKEN", i.QuayToken)
 	os.Setenv("IMAGE_CONTROLLER_QUAY_ORG", i.DefaultImageQuayOrg)
 	os.Setenv("IMAGE_CONTROLLER_QUAY_TOKEN", i.DefaultImageQuayOrgOAuth2Token)
+	os.Setenv("BUILD_SERVICE_IMAGE_TAG_EXPIRATION", i.DefaultImageTagExpiration)
 }
 
 func (i *InstallAppStudio) cloneInfraDeployments() (*git.Remote, error) {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -109,6 +109,10 @@ const (
 	DefaultPipelineServiceAccountClusterRole = "appstudio-pipelines-runner"
 
 	PaCPullRequestBranchPrefix = "appstudio-"
+
+	// Expiration for image tags
+	IMAGE_TAG_EXPIRATION_ENV  string = "IMAGE_TAG_EXPIRATION"
+	DefaultImageTagExpiration string = "6h"
 )
 
 var (

--- a/pkg/utils/build/image.go
+++ b/pkg/utils/build/image.go
@@ -1,0 +1,67 @@
+package build
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	"github.com/openshift/library-go/pkg/image/reference"
+	"github.com/openshift/oc/pkg/cli/image/extract"
+	"github.com/openshift/oc/pkg/cli/image/imagesource"
+	imageInfo "github.com/openshift/oc/pkg/cli/image/info"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func ExtractImage(image string) (string, error) {
+	dockerImageRef, err := reference.Parse(image)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse docker pull spec (image) %s, error: %+v", image, err)
+	}
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "sbom")
+	if err != nil {
+		return "", fmt.Errorf("error when creating a temp directory for extracting files: %+v", err)
+	}
+	GinkgoWriter.Printf("extracting contents of container image %s to dir: %s\n", image, tmpDir)
+	eMapping := extract.Mapping{
+		ImageRef: imagesource.TypedImageReference{Type: "docker", Ref: dockerImageRef},
+		To:       tmpDir,
+	}
+	e := extract.NewExtractOptions(genericclioptions.IOStreams{Out: os.Stdout, ErrOut: os.Stderr})
+	e.Mappings = []extract.Mapping{eMapping}
+
+	if err := e.Run(); err != nil {
+		return "", fmt.Errorf("error: %+v", err)
+	}
+	return tmpDir, nil
+}
+
+func ImageFromPipelineRun(pipelineRun *v1beta1.PipelineRun) (*imageInfo.Image, error) {
+	var outputImage string
+	for _, parameter := range pipelineRun.Spec.Params {
+		if parameter.Name == "output-image" {
+			outputImage = parameter.Value.StringVal
+		}
+	}
+	if outputImage == "" {
+		return nil, fmt.Errorf("output-image in PipelineRun not found")
+	}
+
+	dockerImageRef, err := reference.Parse(outputImage)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing outputImage to dockerImageRef, %w", err)
+	}
+
+	imageRetriever := imageInfo.ImageRetriever{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	image, err := imageRetriever.Image(ctx, imagesource.TypedImageReference{Type: "docker", Ref: dockerImageRef})
+	if err != nil {
+		return nil, fmt.Errorf("error getting image from imageRetriver, %w", err)
+	}
+	return image, nil
+}

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -26,7 +26,6 @@ import (
 	buildservice "github.com/redhat-appstudio/build-service/api/v1alpha1"
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "HACBS"), func() {
@@ -283,11 +282,26 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				Expect(robotAccountExist).To(BeTrue(), "quay robot account does not exists")
 
 			})
-			It("image tag is updated successfully", func() {
-				//TODO: check if image tag present once below issue is resolved
-				// https://issues.redhat.com/browse/SRVKP-3064
-				// https://github.com/openshift-pipelines/pipeline-service/pull/632
+		})
 
+		When("image tag is updated successfully", func() {
+			//TODO: check if image tag present once below issue is resolved
+			// https://issues.redhat.com/browse/SRVKP-3064
+			// https://github.com/openshift-pipelines/pipeline-service/pull/632
+
+			It("should ensure pruning labels are set", Label(buildTemplatesTestLabel), func() {
+				pipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
+				Expect(err).ShouldNot(HaveOccurred())
+
+				image, err := build.ImageFromPipelineRun(pipelineRun)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				labels := image.Config.Config.Labels
+				Expect(labels).ToNot(BeEmpty())
+
+				expiration, ok := labels["quay.expires-after"]
+				Expect(ok).To(BeTrue())
+				Expect(expiration).To(Equal(utils.GetEnv(constants.IMAGE_TAG_EXPIRATION_ENV, constants.DefaultImageTagExpiration)))
 			})
 			It("eventually leads to a creation of a PR comment with the PipelineRun status report", func() {
 				var comments []*github.IssueComment
@@ -359,6 +373,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		When("the PaC init branch is merged", func() {
 			var mergeResult *github.PullRequestMergeResult
 			var mergeResultSha string
+			var pipelineRun *v1beta1.PipelineRun
 
 			BeforeAll(func() {
 				Eventually(func() error {
@@ -375,7 +390,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval = time.Second * 1
 
 				Eventually(func() bool {
-					pipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, mergeResultSha)
+					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, mergeResultSha)
 					if err != nil {
 						GinkgoWriter.Println("PipelineRun has not been created yet")
 						return false
@@ -387,6 +402,18 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			It("pipelineRun should eventually finish", func() {
 				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, mergeResultSha, 2)).To(Succeed())
 			})
+
+			It("does not have expiration set", func() {
+				image, err := build.ImageFromPipelineRun(pipelineRun)
+				Expect(err).ShouldNot(HaveOccurred())
+
+				labels := image.Config.Config.Labels
+				Expect(labels).ToNot(BeEmpty())
+
+				expiration, ok := labels["quay.expires-after"]
+				Expect(ok).To(BeFalse())
+				Expect(expiration).To(BeEmpty())
+			})
 		})
 
 		When("the component is removed and recreated (with the same name in the same namespace)", func() {
@@ -397,7 +424,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				interval := 1 * time.Second
 				Eventually(func() bool {
 					_, err := f.AsKubeAdmin.HasController.GetHasComponent(componentName, testNamespace)
-					return errors.IsNotFound(err)
+					return k8sErrors.IsNotFound(err)
 				}, timeout, interval).Should(BeTrue(), "timed out when waiting for the app %s to be deleted in %s namespace", applicationName, testNamespace)
 				// Check removal of image repo
 				Eventually(func() (bool, error) {
@@ -624,7 +651,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			_, err := f.AsKubeAdmin.CommonController.GetSecret(testNamespace, constants.RegistryAuthSecretName)
 			if err != nil {
 				// If we have an error when getting RegistryAuthSecretName, it should be IsNotFound err
-				Expect(errors.IsNotFound(err)).To(BeTrue())
+				Expect(k8sErrors.IsNotFound(err)).To(BeTrue())
 			} else {
 				Skip("a registry auth secret is already created in testing namespace - skipping....")
 			}


### PR DESCRIPTION
# Description

Created two new e2e-tests for checking if pruning labels are set / not set correctly. Added new pkg image.go with common functions for working with images 

## Issue ticket number and link

[STONEBLD-1210](https://issues.redhat.com/browse/STONEBLD-1210)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally with `./bin/e2e-appstudio --ginkgo.label-filter="github-webhook" --ginkgo.v`

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
