### PR TITLE
fix: framework init, log more info during fw init

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -42,7 +42,7 @@ const (
 	SKIP_HAS_SECRET_CHECK_ENV string = "SKIP_HAS_SECRET_CHECK"
 
 	// Sandbox kubeconfig user path
-	USER_USER_KUBE_CONFIG_PATH_ENV string = "USER_KUBE_CONFIG_PATH"
+	USER_KUBE_CONFIG_PATH_ENV string = "USER_KUBE_CONFIG_PATH"
 	// Release e2e auth for build and release quay keys
 
 	QUAY_OAUTH_TOKEN_RELEASE_SOURCE string = "QUAY_OAUTH_TOKEN_RELEASE_SOURCE"

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -60,7 +60,7 @@ func NewFrameworkWithTimeout(userName string, timeout time.Duration) (*Framework
 	err = retry.Do(
 		func() error {
 			if k, err = kubeCl.NewDevSandboxProxyClient(userName); err != nil {
-				GinkgoWriter.Printf("error when creating dev sandbox proxy client: %+v", err)
+				GinkgoWriter.Printf("error when creating dev sandbox proxy client: %+v\n", err)
 			}
 			return err
 		},

--- a/pkg/sandbox/keycloak.go
+++ b/pkg/sandbox/keycloak.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
@@ -64,7 +66,7 @@ func (k *SandboxController) GetKeycloakToken(clientID string, userName string, p
 }
 
 /*
-RegisterKeyclokUser create a username in keycloak service and return if succeed or not
+RegisterKeycloakUser create a username in keycloak service and return if succeed or not
 curl --location --request POST 'https://<keycloak-route>/auth/admin/realms/testrealm/users' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJyS2VyZnczU2tzV2hBUF9TeUJuMDRaRm5Pa09ITVFRRmpnOGhjaG12X3VVIn0.eyJleHAiOjE2NzQ3NTkyODksImlhdCI6MTY3NDc1OTIyOSwianRpIjoiY2ZjNzNjMjEtZDU5Mi00MmI4LTk4MWMtYjc5MjAxNzI3OTJhIiwiaXNzIjoiaHR0cHM6Ly9rZXljbG9hay1kZXYtc3NvLmFwcHMuY2x1c3Rlci05cm05ei45cm05ei5zYW5kYm94MTE3OS5vcGVudGxjLmNvbS9hdXRoL3JlYWxtcy9tYXN0ZXIiLCJzdWIiOiI4ODcxMmJjOS1kZDBiLTQxNTktOGE1Ny1mZTRjMDlmYzBhM2IiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJhZG1pbi1jbGkiLCJzZXNzaW9uX3N0YXRlIjoiM2I3MDM5NmItMzk4Yy00MjQyLTljZDMtZGJlYjM0ZWVjYmE0IiwiYWNyIjoiMSIsInNjb3BlIjoicHJvZmlsZSBlbWFpbCIsInNpZCI6IjNiNzAzOTZiLTM5OGMtNDI0Mi05Y2QzLWRiZWIzNGVlY2JhNCIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwicHJlZmVycmVkX3VzZXJuYW1lIjoiYWRtaW4ifQ.GBHKQC0VZk4nEWVXDYC-Npk5Z503xlkDNbcrgd9nRTWcLZdD6HmgKnvGgoVYBssiSQyBYnAAqVQLGslbENjtohOlU4UxV0-Tsr2OpJUlKP0oMBVcna745UHAxU2JcVraVR4UkiryZbAOTJyUYKdhszqmfkGWPukTAo4lB2GO7HdfyU1UAwp8mzfLQ6WWV-LmeFjUUpwGOUed3Ztoa4DMBnVNFp7WHqoFyPO6xSTqq59ai__bJ8_8W7KfUTI6Rmfcno-6_9PtWFC8_bvs8bRBV7Xs8j4wn-7Y2-f9WTGC8EfUTacVGTf1ma-lBUEzWKodc7XH_5O18Huko3eS3RMDTA' \
@@ -84,7 +86,7 @@ curl --location --request POST 'https://<keycloak-route>/auth/admin/realms/testr
 	                                 ]
 	                 }"
 */
-func (k *SandboxController) RegisterKeyclokUser(userName string, keycloakToken string, realm string) (user *KeycloakUser, err error) {
+func (k *SandboxController) RegisterKeycloakUser(userName string, keycloakToken string, realm string) (user *KeycloakUser, err error) {
 	user = k.getKeycloakUserSpec(userName)
 	payload, err := json.Marshal(user)
 	if err != nil {
@@ -137,9 +139,7 @@ func (s *SandboxController) IsKeycloakRunning() error {
 		sets, err := s.KubeClient.AppsV1().StatefulSets(DEFAULT_KEYCLOAK_NAMESPACE).Get(context.Background(), DEFAULT_KEYCLOAK_INSTANCE_NAME, metav1.GetOptions{})
 
 		if err != nil {
-			klog.Infof("keycloak instance is not ready. Please check keycloak deployment: %v", err)
-
-			return false, err
+			return false, fmt.Errorf("keycloak instance is not ready. Please check keycloak deployment: %+v", err)
 		}
 
 		if sets.Status.ReadyReplicas == *sets.Spec.Replicas {
@@ -170,10 +170,9 @@ func (s *SandboxController) GetKeycloakAdminSecret() (adminPassword string, err 
 func (s *SandboxController) KeycloakUserExists(realm string, token string, username string) bool {
 	///{realm}/users?username=toto
 	///admin/realms/{my-realm}/users?search={username}
-	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/auth/admin/realms/%s/users?search=%s", s.KeycloakUrl, realm, username), strings.NewReader(""))
-
+	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/auth/admin/realms/%s/users?username=%s", s.KeycloakUrl, realm, username), strings.NewReader(""))
 	if err != nil {
-		klog.Errorf("failed to get user: %v", err)
+		GinkgoWriter.Printf("failed to create an HTTP request in order to get a keycloak user: %+v\n", err)
 		return false
 	}
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
@@ -181,10 +180,24 @@ func (s *SandboxController) KeycloakUserExists(realm string, token string, usern
 
 	response, err := s.HttpClient.Do(request)
 
-	if err != nil || response.StatusCode != 200 {
+	if err != nil {
+		GinkgoWriter.Printf("failed when searching for a keycloak user: %+v\n", err)
 		return false
 	}
 	defer response.Body.Close()
 
-	return true
+	body, _ := io.ReadAll(response.Body)
+	if err != nil {
+		GinkgoWriter.Printf("failed to read a response body from keycloak server: %+v\n", err)
+		return false
+	}
+	// Keycloak API server returns status code 200 even if no user is found, thus we need to parse the response body
+	// https://www.keycloak.org/docs-api/18.0/rest-api/#_users_resource
+	var users []any
+	err = json.Unmarshal(body, &users)
+	if err != nil {
+		GinkgoWriter.Printf("failed when unmarshalling response body: %+v\n", err)
+	}
+
+	return len(users) > 0
 }

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -223,6 +223,10 @@ func (s *SandboxController) RegisterSandboxUser(userName string) (compliantUsern
 		for _, condition := range userSignup.Status.Conditions {
 			if condition.Type == toolchainApi.UserSignupComplete && condition.Status == corev1.ConditionTrue {
 				compliantUsername = userSignup.Status.CompliantUsername
+				if len(compliantUsername) < 1 {
+					GinkgoWriter.Printf("Status.CompliantUsername field in UserSignup CR %s in %s namespace is empty\n", userSignup.GetName(), userSignup.GetNamespace())
+					return false, nil
+				}
 				return true, nil
 			}
 		}


### PR DESCRIPTION
# Description

* If a username passed to a `NewFramework()` method has length more than 20 characters, it is shortened by a toolchain controller, but the resulting value is not picked up by e2e-tests framework. That issue was found while investigating the CI failure for [this change](https://github.com/redhat-appstudio/e2e-tests/pull/541/commits/3a73fe9a3f0a62bc4f297a1734fc1fb407304890). This PR should address the issue [here](https://github.com/redhat-appstudio/e2e-tests/compare/main...psturc:update-framework-init?expand=1#diff-d6d998723333eefe28e969421f10d0d6792ea384314d77c99dc7d6b5edc1a347R225)
* added a [warning message](https://github.com/redhat-appstudio/e2e-tests/compare/main...psturc:update-framework-init?expand=1#diff-b247c3614709818eed09ee97e1d6988bd26d0d11e7ad8269143bb84745e5b273R54) about using such username as an input param for the framework init method
* added more logging of errors encountered during framework init
* fixed typos

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
ginkgo --label-filter="ec" ./cmd -- --config-suites=$PWD/tests/e2e-demos/config/default.yaml
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
