### PR TITLE
test: spi tests - get resource after resource creation

### DIFF
--- a/pkg/utils/tekton/controller.go
+++ b/pkg/utils/tekton/controller.go
@@ -821,3 +821,23 @@ func (h *SuiteController) DeleteAllTasksInASpecificNamespace(namespace string) e
 func (h *SuiteController) DeleteAllTaskRunsInASpecificNamespace(namespace string) error {
 	return h.KubeRest().DeleteAllOf(context.TODO(), &v1beta1.TaskRun{}, crclient.InNamespace(namespace))
 }
+
+// GetTask returns the requested Task object
+func (s *SuiteController) GetTask(name, namespace string) (*v1beta1.Task, error) {
+	namespacedName := types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}
+
+	task := v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	err := s.KubeRest().Get(context.TODO(), namespacedName, &task)
+	if err != nil {
+		return nil, err
+	}
+	return &task, nil
+}

--- a/tests/spi/get-file-content.go
+++ b/tests/spi/get-file-content.go
@@ -61,15 +61,15 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "get-file-content"), func(
 		It("creates SPIFileContentRequest", func() {
 			SPIFcr, err = fw.AsKubeDeveloper.SPIController.CreateSPIFileContentRequest("gh-spi-filecontent-request", namespace, GithubPrivateRepoURL, GithubPrivateRepoFilePath)
 			Expect(err).NotTo(HaveOccurred())
+
+			SPIFcr, err = fw.AsKubeDeveloper.SPIController.GetSPIFileContentRequest(SPIFcr.Name, namespace)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("SPIFileContentRequest should be in AwaitingTokenData phase", func() {
 			Eventually(func() bool {
 				SPIFcr, err = fw.AsKubeDeveloper.SPIController.GetSPIFileContentRequest(SPIFcr.Name, namespace)
-
-				if err != nil {
-					return false
-				}
+				Expect(err).NotTo(HaveOccurred())
 
 				return SPIFcr.Status.Phase == v1beta1.SPIFileContentRequestPhaseAwaitingTokenData
 			}, 2*time.Minute, 10*time.Second).Should(BeTrue(), "")
@@ -80,10 +80,7 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "get-file-content"), func(
 			// the UploadUrl in SPITokenBinding should be available before uploading the token
 			Eventually(func() bool {
 				SPIFcr, err = fw.AsKubeDeveloper.SPIController.GetSPIFileContentRequest(SPIFcr.Name, namespace)
-
-				if err != nil {
-					return false
-				}
+				Expect(err).NotTo(HaveOccurred())
 
 				return SPIFcr.Status.TokenUploadUrl != ""
 			}, 1*time.Minute, 10*time.Second).Should(BeTrue(), "uploadUrl not set")
@@ -107,10 +104,7 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "get-file-content"), func(
 		It("SPIFileContentRequest should be in Delivered phase and content should be provided", func() {
 			Eventually(func() bool {
 				SPIFcr, err = fw.AsKubeDeveloper.SPIController.GetSPIFileContentRequest(SPIFcr.Name, namespace)
-
-				if err != nil {
-					return false
-				}
+				Expect(err).NotTo(HaveOccurred())
 
 				return SPIFcr.Status.Phase == v1beta1.SPIFileContentRequestPhaseDelivered && SPIFcr.Status.Content != ""
 			}, 2*time.Minute, 10*time.Second).Should(BeTrue(), "content not provided by SPIFileContentRequest")

--- a/tests/spi/link-secret-sa.go
+++ b/tests/spi/link-secret-sa.go
@@ -90,16 +90,16 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "link-secret-sa"), func() 
 					test.IsImagePullSecret,
 					test.IsManagedServiceAccount)
 				Expect(err).NotTo(HaveOccurred())
+
+				binding, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessTokenBinding(binding.Name, namespace)
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			// start of upload token
 			It("SPITokenBinding to be in AwaitingTokenData phase", func() {
 				Eventually(func() bool {
 					binding, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessTokenBinding(binding.Name, namespace)
-
-					if err != nil {
-						return false
-					}
+					Expect(err).NotTo(HaveOccurred())
 
 					return (binding.Status.Phase == v1beta1.SPIAccessTokenBindingPhaseAwaitingTokenData)
 				}, 1*time.Minute, 5*time.Second).Should(BeTrue(), "SPIAccessTokenBinding is not in AwaitingTokenData phase")
@@ -109,10 +109,7 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "link-secret-sa"), func() 
 				// the UploadUrl in SPITokenBinding should be available before uploading the token
 				Eventually(func() bool {
 					binding, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessTokenBinding(binding.Name, namespace)
-
-					if err != nil {
-						return false
-					}
+					Expect(err).NotTo(HaveOccurred())
 
 					return binding.Status.UploadUrl != ""
 				}, 1*time.Minute, 10*time.Second).Should(BeTrue(), "uploadUrl not set")

--- a/tests/spi/token-upload-k8s.go
+++ b/tests/spi/token-upload-k8s.go
@@ -77,15 +77,15 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "token-upload-k8s"), func(
 		It("creates SPITokenBinding", func() {
 			SPITokenBinding, err = fw.AsKubeDeveloper.SPIController.CreateSPIAccessTokenBinding(tokenBindingName, namespace, RepoURL, "", "kubernetes.io/basic-auth")
 			Expect(err).NotTo(HaveOccurred())
+
+			SPITokenBinding, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessTokenBinding(SPITokenBinding.Name, namespace)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("creates secret with access token and associate it to an existing SPIAccessToken", func() {
 			Eventually(func() bool {
 				SPITokenBinding, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessTokenBinding(SPITokenBinding.Name, namespace)
-
-				if err != nil {
-					return false
-				}
+				Expect(err).NotTo(HaveOccurred())
 
 				return (SPITokenBinding.Status.LinkedAccessTokenName != "")
 			}, 1*time.Minute, 5*time.Second).Should(BeTrue(), "LinkedAccessTokenName should not be empty")
@@ -101,9 +101,8 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "token-upload-k8s"), func(
 		It("SPITokenBinding should be in Injected phase", func() {
 			Eventually(func() bool {
 				SPITokenBinding, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessTokenBinding(SPITokenBinding.Name, namespace)
-				if err != nil {
-					return false
-				}
+				Expect(err).NotTo(HaveOccurred())
+
 				return SPITokenBinding.Status.Phase == v1beta1.SPIAccessTokenBindingPhaseInjected
 			}, 2*time.Minute, 10*time.Second).Should(BeTrue(), "SPIAccessTokenBinding is not in Injected phase")
 		})

--- a/tests/spi/token-upload-rest-endpoint.go
+++ b/tests/spi/token-upload-rest-endpoint.go
@@ -71,6 +71,9 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "token-upload-rest-endpoin
 			It("creates SPITokenBinding", func() {
 				SPITokenBinding, err = fw.AsKubeDeveloper.SPIController.CreateSPIAccessTokenBinding(SPITokenBindingName, namespace, test.RepoURL, "", "kubernetes.io/basic-auth")
 				Expect(err).NotTo(HaveOccurred())
+
+				SPITokenBinding, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessTokenBinding(SPITokenBinding.Name, namespace)
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			var SPIAccessCheck *v1beta1.SPIAccessCheck
@@ -78,12 +81,12 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "token-upload-rest-endpoin
 				It("creates SPIAccessCheck", func() {
 					SPIAccessCheck, err = fw.AsKubeDeveloper.SPIController.CreateSPIAccessCheck(SPIAccessCheckPrefixName, namespace, test.RepoURL)
 					Expect(err).NotTo(HaveOccurred())
+
+					SPIAccessCheck, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessCheck(SPIAccessCheck.Name, namespace)
+					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("checks if repository is accessible", func() {
-					SPIAccessCheck, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessCheck(SPIAccessCheck.Name, namespace)
-					Expect(err).NotTo(HaveOccurred())
-
 					Eventually(func() bool {
 						SPIAccessCheck, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessCheck(SPIAccessCheck.Name, namespace)
 						Expect(err).NotTo(HaveOccurred())
@@ -113,10 +116,7 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "token-upload-rest-endpoin
 				// wait SPITokenBinding to be in AwaitingTokenData phase before trying to upload a token
 				Eventually(func() bool {
 					SPITokenBinding, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessTokenBinding(SPITokenBinding.Name, namespace)
-
-					if err != nil {
-						return false
-					}
+					Expect(err).NotTo(HaveOccurred())
 
 					return (SPITokenBinding.Status.Phase == v1beta1.SPIAccessTokenBindingPhaseAwaitingTokenData)
 				}, 1*time.Minute, 5*time.Second).Should(BeTrue(), "SPIAccessTokenBinding is not in AwaitingTokenData phase")
@@ -126,10 +126,7 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "token-upload-rest-endpoin
 				// the UploadUrl in SPITokenBinding should be available before uploading the token
 				Eventually(func() bool {
 					SPITokenBinding, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessTokenBinding(SPITokenBinding.Name, namespace)
-
-					if err != nil {
-						return false
-					}
+					Expect(err).NotTo(HaveOccurred())
 
 					return SPITokenBinding.Status.UploadUrl != ""
 				}, 1*time.Minute, 10*time.Second).Should(BeTrue(), "uploadUrl not set")
@@ -178,6 +175,9 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "token-upload-rest-endpoin
 			Describe("SVPI-404 - Check access to GitHub repository after token upload", func() {
 				It("creates SPIAccessCheck", func() {
 					SPIAccessCheck, err = fw.AsKubeDeveloper.SPIController.CreateSPIAccessCheck(SPIAccessCheckPrefixName, namespace, test.RepoURL)
+					Expect(err).NotTo(HaveOccurred())
+
+					SPIAccessCheck, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessCheck(SPIAccessCheck.Name, namespace)
 					Expect(err).NotTo(HaveOccurred())
 				})
 


### PR DESCRIPTION
# Description

We came across a [CI job](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/redhat-appstudio_e2e-tests/527/pull-ci-redhat-appstudio-e2e-tests-main-redhat-appstudio-e2e/1663454847149543424) that failed on getting SPIAccessCheck and SPIFileContentRequest right after its creation. It seems to report `504 Gateway Time-out` in both tests.

Since this error is being targeted in the `Eventually`, this PR proposes getting the resource after the resource creation in the same `It` to be more clear to read the error.

## Issue ticket number and link
[RHTAPBUGS-354](https://issues.redhat.com/browse/RHTAPBUGS-354)
[RHTAPBUGS-355](https://issues.redhat.com/browse/RHTAPBUGS-355)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
