### PR TITLE
chore: add pmacik to root OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -13,3 +13,4 @@ approvers:
 - dheerajodha
 - naftalysh
 - Dannyb48
+- pmacik


### PR DESCRIPTION
# Description

To be added to the [openshift/release: ci-operator/config/redhat-appstudio/e2e-tests/OWNERS](https://github.com/openshift/release/blob/master/ci-operator/config/redhat-appstudio/e2e-tests/OWNERS) and [openshift/release: ci-operator/jobs/redhat-appstudio/e2e-tests/OWNERS](https://github.com/openshift/release/blob/master/ci-operator/jobs/redhat-appstudio/e2e-tests/OWNERS) I should be in the root OWNERS file of this repo.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
