### PR TITLE
feat(RHTAP-970): Create a load test that tracks max concurrency with builds below given threshold

### DIFF
--- a/tests/load-tests/ci-scripts/max-concurrency/collect-results.sh
+++ b/tests/load-tests/ci-scripts/max-concurrency/collect-results.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# shellcheck disable=SC1090
+source "/usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${1:-concurrent}"
+
+pushd "${2:-.}"
+
+echo "Collecting load test results"
+cp -vf ./tests/load-tests/load-tests.max-concurrency.*.log "$ARTIFACT_DIR"
+cp -vf ./tests/load-tests/load-tests.max-concurrency.json "$ARTIFACT_DIR"
+
+csv_delim=";"
+csv_delim_quoted="\"$csv_delim\""
+dt_format='"%Y-%m-%dT%H:%M:%SZ"'
+
+## PipelineRun timestamps
+echo "Collecting PipelineRun timestamps..."
+pipelinerun_timestamps=$ARTIFACT_DIR/pipelineruns.tekton.dev_timestamps.csv
+echo "PipelineRun${csv_delim}Namespace${csv_delim}Succeeded${csv_delim}Reason${csv_delim}Message${csv_delim}Created${csv_delim}Started${csv_delim}FinallyStarted${csv_delim}Completed${csv_delim}Created->Started${csv_delim}Started->FinallyStarted${csv_delim}FinallyStarted->Completed${csv_delim}SucceededDuration${csv_delim}FailedDuration" >"$pipelinerun_timestamps"
+jq_cmd=".items[] | (.metadata.name) \
++ $csv_delim_quoted + (.metadata.namespace) \
++ $csv_delim_quoted + (.status.conditions[0].status) \
++ $csv_delim_quoted + (.status.conditions[0].reason) \
++ $csv_delim_quoted + (.status.conditions[0].message|split($csv_delim_quoted)|join(\"_\")) \
++ $csv_delim_quoted + (.metadata.creationTimestamp) \
++ $csv_delim_quoted + (.status.startTime) \
++ $csv_delim_quoted + (.status.finallyStartTime) \
++ $csv_delim_quoted + (.status.completionTime) \
++ $csv_delim_quoted + (if .status.startTime != null and .metadata.creationTimestamp != null then ((.status.startTime | strptime($dt_format) | mktime) - (.metadata.creationTimestamp | strptime($dt_format) | mktime) | tostring) else \"\" end) \
++ $csv_delim_quoted + (if .status.finallyStartTime != null and .status.startTime != null then ((.status.finallyStartTime | strptime($dt_format) | mktime) - (.status.startTime | strptime($dt_format) | mktime) | tostring) else \"\" end) \
++ $csv_delim_quoted + (if .status.completionTime != null and .status.finallyStartTime != null then ((.status.completionTime | strptime($dt_format) | mktime) - (.status.finallyStartTime | strptime($dt_format) | mktime) | tostring) else \"\" end) \
++ $csv_delim_quoted + (if .status.conditions[0].status == \"True\" and .status.completionTime != null and .metadata.creationTimestamp != null then ((.status.completionTime | strptime($dt_format) | mktime) - (.metadata.creationTimestamp | strptime($dt_format) | mktime) | tostring) else \"\" end) \
++ $csv_delim_quoted + (if .status.conditions[0].status == \"False\" and .status.completionTime != null and .metadata.creationTimestamp != null then ((.status.completionTime | strptime($dt_format) | mktime) - (.metadata.creationTimestamp | strptime($dt_format) | mktime) | tostring) else \"\" end)"
+oc get pipelineruns.tekton.dev -A -o json | jq "$jq_cmd" | sed -e "s/\n//g" -e "s/^\"//g" -e "s/\"$//g" -e "s/Z;/;/g" >>"$pipelinerun_timestamps"
+
+popd

--- a/tests/load-tests/ci-scripts/max-concurrency/load-test.sh
+++ b/tests/load-tests/ci-scripts/max-concurrency/load-test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# shellcheck disable=SC1090
+source "/usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${1:-concurrent}"
+
+pushd "${2:-./tests/load-tests}"
+
+export DOCKER_CONFIG_JSON QUAY_E2E_ORGANIZATION MY_GITHUB_ORG GITHUB_TOKEN
+DOCKER_CONFIG_JSON=$QUAY_TOKEN
+QUAY_E2E_ORGANIZATION=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/quay-org)
+MY_GITHUB_ORG=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/github-org)
+
+./run-max-concurrency.sh
+
+popd

--- a/tests/load-tests/run-max-concurrency.sh
+++ b/tests/load-tests/run-max-concurrency.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+export DOCKER_CONFIG_JSON MY_GITHUB_ORG GITHUB_TOKEN
+DOCKER_CONFIG_JSON=${DOCKER_CONFIG_JSON:-}
+
+load_test() {
+    threads=${1:-1}
+    go run loadtest.go \
+        --component-repo "${COMPONENT_REPO:-https://github.com/nodeshift-starters/devfile-sample.git}" \
+        --username "$USER_PREFIX-$(printf "%04d" "$threads")" \
+        --users 1 \
+        -w \
+        -l \
+        -t "$threads" \
+        --disable-metrics \
+        --pipeline-skip-initial-checks="${PIPELINE_SKIP_INITIAL_CHECKS:-true}"
+}
+
+if [ -z ${DOCKER_CONFIG_JSON+x} ]; then
+    echo "env DOCKER_CONFIG_JSON need to be defined"
+    exit 1
+else echo "DOCKER_CONFIG_JSON is set"; fi
+
+USER_PREFIX=${USER_PREFIX:-testuser}
+# Max length of compliant username is 20 characters. We add "-XXXX-XXXX" suffix for the test users' name so max length of the prefix is 10.
+# See https://github.com/codeready-toolchain/toolchain-common/blob/master/pkg/usersignup/usersignup.go#L16
+if [ ${#USER_PREFIX} -gt 10 ]; then
+    echo "Maximal allowed length of user prefix is 10 characters. The '$USER_PREFIX' length of ${#USER_PREFIX} exceeds the limit."
+    exit 1
+else
+    output=load-tests.max-concurrency.json
+    maxThreads=${MAX_THREADS:-10}
+    threshold=${THRESHOLD:-300}
+    echo '{"maxThreads": '"$maxThreads"', "threshold": '"$threshold"', "maxConcurrencyReached": 0, "steps": []}' | jq >"$output"
+    for t in $(seq 1 "${MAX_THREADS:-10}"); do
+        oc get usersignups.toolchain.dev.openshift.com -A -o name | grep "$USER_PREFIX" | xargs oc delete -n toolchain-host-operator
+        while true; do
+            echo "Waiting until all namespaces with '$USER_PREFIX' prefix are gone..."
+            oc get ns | grep "$USER_PREFIX" >/dev/null 2>&1 || break 1
+            sleep 5s
+        done
+        load_test "$t"
+        jq --slurpfile result "load-tests.json" '.steps += $result' "$output" >$$.json && mv -f $$.json "$output"
+        mv -f load-tests.log "load-tests.max-concurrency.$(printf "%04d" "$t").log"
+        pipelineRunThresholdExceeded=$(jq -rc ".runPipelineSucceededTimeMax > $threshold" load-tests.json)
+        pipelineRunKPI=$(jq -rc ".runPipelineSucceededTimeMax" load-tests.json)
+        if [ "$pipelineRunThresholdExceeded" = "true" ]; then
+            echo "The maximal time a pipeline run took to succeed (${pipelineRunKPI}s) has exceeded a threshold of ${threshold}s with $t threads."
+            break
+        else
+            jq ".maxConcurrencyReached = $t" "$output" >$$.json && mv -f $$.json "$output"
+        fi
+    done
+    DRY_RUN=false ./clear.sh "$USER_PREFIX"
+fi


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

[RHTAP-970](https://issues.redhat.com/browse/RHTAP-970)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested in OpenShift CI - https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/39960/rehearse-39960-periodic-ci-redhat-appstudio-e2e-tests-main-load-test-max-concurrency-basic/1664662821641654272

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
