### PR TITLE
fix: set StandingAttribution label in ReleasePlans

### DIFF
--- a/pkg/utils/integration/controller.go
+++ b/pkg/utils/integration/controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/devfile/library/pkg/util"
 	. "github.com/onsi/ginkgo/v2"
 	appstudioApi "github.com/redhat-appstudio/application-api/api/v1alpha1"
@@ -13,7 +14,6 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/common"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
 	integrationv1alpha1 "github.com/redhat-appstudio/integration-service/api/v1alpha1"
-	codereadytoolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	releasemetadata "github.com/redhat-appstudio/release-service/metadata"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -267,7 +267,7 @@ func (h *SuiteController) CreateReleasePlan(applicationName, namespace string) (
 			Namespace:    namespace,
 			Labels: map[string]string{
 				releasemetadata.AutoReleaseLabel: "true",
-				releasemetadata.AuthorLabel:      "username",
+				releasemetadata.AttributionLabel: "true",
 			},
 		},
 		Spec: releasev1alpha1.ReleasePlanSpec{
@@ -503,7 +503,6 @@ func (h *SuiteController) GetSpaceRequests(namespace string) (*codereadytoolchai
 func (h *SuiteController) GetDeploymentTargets(namespace string) (*appstudioApi.DeploymentTargetList, error) {
 	deploymentTargetList := &appstudioApi.DeploymentTargetList{}
 
-
 	opts := []client.ListOption{
 		client.InNamespace(namespace),
 	}
@@ -518,7 +517,6 @@ func (h *SuiteController) GetDeploymentTargets(namespace string) (*appstudioApi.
 
 func (h *SuiteController) GetDeploymentTargetClaims(namespace string) (*appstudioApi.DeploymentTargetClaimList, error) {
 	deploymentTargetClaimList := &appstudioApi.DeploymentTargetClaimList{}
-
 
 	opts := []client.ListOption{
 		client.InNamespace(namespace),

--- a/pkg/utils/release/controller.go
+++ b/pkg/utils/release/controller.go
@@ -226,7 +226,7 @@ func (s *SuiteController) CreateReleasePlan(name, namespace, application, target
 			Namespace:    namespace,
 			Labels: map[string]string{
 				releaseMetadata.AutoReleaseLabel: autoReleaseLabel,
-				releaseMetadata.AuthorLabel:      "username",
+				releaseMetadata.AttributionLabel: "true",
 			},
 		},
 		Spec: releaseApi.ReleasePlanSpec{


### PR DESCRIPTION
The StandingAttribution label should have been set in ReleasePlans, not the Author label.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
