### PR TITLE
fix: RHTAPBUGS-398: RetryOnConflict when update a component

### DIFF
--- a/pkg/utils/has/controller.go
+++ b/pkg/utils/has/controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
 	rclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -699,13 +700,20 @@ func (h *SuiteController) RetriggerComponentPipelineRun(component *appservice.Co
 		// To retrigger simple build PipelineRun we just need to update the initial build annotation
 		// in Component CR
 	} else {
-		component, err := h.GetHasComponent(component.GetName(), component.GetNamespace())
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			component, err := h.GetHasComponent(component.GetName(), component.GetNamespace())
+			if err != nil {
+				return fmt.Errorf("failed to get component for PipelineRun %q in %q namespace: %+v", pr.GetName(), pr.GetNamespace(), err)
+			}
+			delete(component.Annotations, constants.ComponentInitialBuildAnnotationKey)
+			if err = h.KubeRest().Update(context.Background(), component); err != nil {
+				return fmt.Errorf("failed to update Component %q in %q namespace", component.GetName(), component.GetNamespace())
+			}
+			return err
+		})
+
 		if err != nil {
-			return "", fmt.Errorf("failed to get component %q for PipelineRun %q in %q namespace: %+v", component.GetName(), pr.GetName(), pr.GetNamespace(), err)
-		}
-		delete(component.Annotations, constants.ComponentInitialBuildAnnotationKey)
-		if err = h.KubeRest().Update(context.Background(), component); err != nil {
-			return "", fmt.Errorf("failed to update Component %q in %q namespace", component.GetName(), component.GetNamespace())
+			return "", err
 		}
 	}
 	watch, err := h.PipelineClient().TektonV1beta1().PipelineRuns(component.GetNamespace()).Watch(context.Background(), metav1.ListOptions{})


### PR DESCRIPTION
# Description

Multiple controller are updating a component at the same time. This PR use retryOnConflict method to update component resources.

## Issue ticket number and link
[RHTAPBUGS-398](https://issues.redhat.com//browse/RHTAPBUGS-398)
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
