### PR TITLE
fix: PipelineSelector - use static annotation for match

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -113,7 +113,6 @@ const (
 
 var (
 	ComponentDefaultLabel                    = map[string]string{"e2e-test": "true"}
-	ComponentDefaultAnnotation               = map[string]string{ComponentInitialBuildAnnotationKey: "processed"}
 	ComponentPaCRequestAnnotation            = map[string]string{"appstudio.openshift.io/pac-provision": "request"}
 	ImageControllerAnnotationDeleteRepoTrue  = map[string]string{"image.redhat.com/generate": "true", "image.redhat.com/delete-image-repo": "true"}
 	ImageControllerAnnotationDeleteRepoFalse = map[string]string{"image.redhat.com/generate": "true", "image.redhat.com/delete-image-repo": "false"}

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -537,7 +537,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 								ProjectType:        "hello-world",
 								DockerfileRequired: pointer.Bool(true),
 								ComponentName:      compDetected.ComponentStub.ComponentName,
-								Annotations:        constants.ComponentDefaultAnnotation,
+								Annotations:        map[string]string{"skip-initial-checks": "true"},
 								Labels:             constants.ComponentDefaultLabel,
 							},
 						},


### PR DESCRIPTION
Currently testing of annotation match is done on "appstudio.openshift.io/component-initial-build" which is generated during build and it's not available when component is created. That's place for race-contiditions, changing to static annotation which is set with component creation.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
