### PR TITLE
fix: while waiting to release pipelinerun if any failed test will fail

### DIFF
--- a/tests/release/e2e-test-push-image-to-pyxis.go
+++ b/tests/release/e2e-test-push-image-to-pyxis.go
@@ -257,6 +257,11 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1571]test-release-e2e-push-image-
 					return false
 				}
 
+				if utils.PipelineRunFailed(releasePr) || utils.PipelineRunFailed(additionalReleasePr) {
+					GinkgoWriter.Printf("\n One of two PipelineRuns failed: %s   %s", releasePr.Name, additionalReleasePr.Name)
+					return false
+				}
+
 				return releasePr.HasStarted() && releasePr.IsDone() && releasePr.Status.GetCondition(apis.ConditionSucceeded).IsTrue() &&
 					additionalReleasePr.HasStarted() && additionalReleasePr.IsDone() && additionalReleasePr.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
 			}, releasePipelineRunCompletionTimeout, defaultInterval).Should(BeTrue())

--- a/tests/release/e2e-test-push-image-to-pyxis.go
+++ b/tests/release/e2e-test-push-image-to-pyxis.go
@@ -257,11 +257,8 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1571]test-release-e2e-push-image-
 					return false
 				}
 
-				if utils.PipelineRunFailed(releasePr) || utils.PipelineRunFailed(additionalReleasePr) {
-					GinkgoWriter.Printf("\n One of two PipelineRuns failed: %s   %s", releasePr.Name, additionalReleasePr.Name)
-					return false
-				}
-
+				Expect(utils.HasPipelineRunFailed(releasePr)).NotTo(BeTrue(), fmt.Sprintf("did not expect PipelineRun %s:%s to fail", releasePr.GetNamespace(), releasePr.GetName()))
+				Expect(utils.HasPipelineRunFailed(additionalReleasePr)).NotTo(BeTrue(), fmt.Sprintf("did not expect PipelineRun %s:%s to fail", additionalReleasePr.GetNamespace(), additionalReleasePr.GetName()))
 				return releasePr.HasStarted() && releasePr.IsDone() && releasePr.Status.GetCondition(apis.ConditionSucceeded).IsTrue() &&
 					additionalReleasePr.HasStarted() && additionalReleasePr.IsDone() && additionalReleasePr.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
 			}, releasePipelineRunCompletionTimeout, defaultInterval).Should(BeTrue())


### PR DESCRIPTION
# Description
  We see in issue reported that when verifying the two Release PipeliuneRuns that if one PR fails , 
  the test will wail the whole timeout threshold defined for it , this is behavior make test slower. 
  the purpose of this PR is to fix this issue. 
  
  Once the fix was pushed the test failed on missing required parameter in release pipelinerun
  `verify_ec_task_bundle` , which related to the change been made and merged in [PR](https://github.com/redhat-appstudio/release-service/pull/205) 
  
the fix was made for all release e2e-tests, ran locally and it passed .

## [RHTAPBUGS-121](https://issues.redhat.com/browse/RHTAPBUGS-121)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
