### PR TITLE
feat(HACBS-2216): Removem chains-ca-cert support

### DIFF
--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -39,10 +39,6 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 			err := fwk.AsKubeAdmin.CommonController.WaitForPodSelector(fwk.AsKubeAdmin.CommonController.IsPodRunning, constants.TEKTON_CHAINS_NS, "app", "tekton-chains-controller", 60, 100)
 			Expect(err).NotTo(HaveOccurred())
 		})
-		It("verifies if the correct secrets have been created", func() {
-			_, err := fwk.AsKubeAdmin.CommonController.GetSecret(constants.TEKTON_CHAINS_NS, "chains-ca-cert")
-			Expect(err).NotTo(HaveOccurred())
-		})
 		It("verifies if the correct roles are created", func() {
 			_, csaErr := fwk.AsKubeAdmin.CommonController.GetRole("chains-secret-admin", constants.TEKTON_CHAINS_NS)
 			Expect(csaErr).NotTo(HaveOccurred())


### PR DESCRIPTION
# Description

The chains-ca-cert Secret is no longer needed. See https://issues.redhat.com/browse/HACBS-2216. This change removes the test that verifies it exists, so we can actually remove it from the cluster in https://github.com/openshift-pipelines/pipeline-service/pull/673.

## Issue ticket number and link
https://issues.redhat.com/browse/HACBS-2216

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested against my dev cluster.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
