### PR TITLE
fix: build: remove inappropriate label

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -289,7 +289,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			// https://issues.redhat.com/browse/SRVKP-3064
 			// https://github.com/openshift-pipelines/pipeline-service/pull/632
 
-			It("should ensure pruning labels are set", Label(buildTemplatesTestLabel), func() {
+			It("should ensure pruning labels are set", func() {
 				pipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
 				Expect(err).ShouldNot(HaveOccurred())
 


### PR DESCRIPTION
# Description

`Label(buildTemplatesTestLabel)` belongs only to build-templates.go test file. This was probably a copy-paste issue.

## Issue ticket number and link
N/A
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
N/A

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
