### PR TITLE
fix: remove E2E_APPLICATIONS_NAMESPACE env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following environment variables are used to launch the Red Hat AppStudio ins
 | `DEFAULT_QUAY_ORG_TOKEN` | yes | A quay token of OAuth application for `DEFAULT_QUAY_ORG` with scopes -  Administer organizations, Adminster repositories, Create Repositories | ''  |
 | `MY_GITHUB_ORG` | no (recommended) | GitHub organization (must be organization, cannot use regular GitHub account!) where to create/push Red Hat AppStudio Applications. You can create your GitHub organization for free  | `redhat-appstudio-qe`  |
 | `QUAY_E2E_ORGANIZATION` | no (recommended) | Quay organization/account where to push components containers. It is recommended to create your own account | `redhat-appstudio-qe` |
-| `E2E_APPLICATIONS_NAMESPACE` | no | Name of the namespace used for running HAS E2E tests | `appstudio-e2e-test` |
+| `E2E_APPLICATIONS_NAMESPACE` | no | Name of the namespace used for running build-templates E2E tests | '' |
 | `PRIVATE_DEVFILE_SAMPLE` | no | The name of the private git repository used in HAS E2E tests. Your GITHUB_TOKEN should be able to read from it. | `https://github.com/redhat-appstudio-qe/private-quarkus-devfile-sample` |
 | `QUAY_OAUTH_USER` | no | A valid quay robot account username to make quay oauth | '' |
 | `QUAY_OAUTH_TOKEN` | no | A valid quay quay robot account token to make oauth against quay.io. | '' |

--- a/magefiles/installation/install.go
+++ b/magefiles/installation/install.go
@@ -87,7 +87,6 @@ func NewAppStudioInstallController() (*InstallAppStudio, error) {
 		InfraDeploymentsOrganizationName: utils.GetEnv("INFRA_DEPLOYMENTS_ORG", DEFAULT_INFRA_DEPLOYMENTS_GH_ORG),
 		LocalForkName:                    DEFAULT_LOCAL_FORK_NAME,
 		LocalGithubForkOrganization:      utils.GetEnv("MY_GITHUB_ORG", DEFAULT_LOCAL_FORK_ORGANIZATION),
-		E2EApplicationsNamespace:         utils.GetEnv("E2E_APPLICATIONS_NAMESPACE", DEFAULT_E2E_APPLICATIONS_NAMEPSPACE),
 		QuayToken:                        utils.GetEnv("QUAY_TOKEN", ""),
 		DefaultImageQuayOrg:              utils.GetEnv("DEFAULT_QUAY_ORG", DEFAULT_E2E_QUAY_ORG),
 		DefaultImageQuayOrgOAuth2Token:   utils.GetEnv("DEFAULT_QUAY_ORG_TOKEN", ""),
@@ -113,7 +112,6 @@ func (i *InstallAppStudio) setInstallationEnvironments() {
 	os.Setenv("MY_GITHUB_ORG", i.LocalGithubForkOrganization)
 	os.Setenv("MY_GITHUB_TOKEN", utils.GetEnv("GITHUB_TOKEN", ""))
 	os.Setenv("MY_GIT_FORK_REMOTE", i.LocalForkName)
-	os.Setenv("E2E_APPLICATIONS_NAMESPACE", i.E2EApplicationsNamespace)
 	os.Setenv("TEST_BRANCH_ID", util.GenerateRandomString(4))
 	os.Setenv("QUAY_TOKEN", i.QuayToken)
 	os.Setenv("IMAGE_CONTROLLER_QUAY_ORG", i.DefaultImageQuayOrg)


### PR DESCRIPTION
# Description
remove `E2E_APPLICATIONS_NAMESPACE` env var from installation script so that build-templates test uses the test framework initialization by default in openshift-ci
https://github.com/redhat-appstudio/e2e-tests/blob/daec5a209de5d01aa9832f8d7074630bc5d43d8e/tests/build/build_templates.go#L42-L55

## Issue ticket number and link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI 🤷 

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
