### PR TITLE
fix(load-test): Stop creating redhat-appstudio-registry-pull-secret in user namespace

### DIFF
--- a/cmd/loadTests.go
+++ b/cmd/loadTests.go
@@ -551,17 +551,6 @@ func userJourneyThread(frameworkMap *sync.Map, threadWaitGroup *sync.WaitGroup, 
 				continue
 			}
 			usernamespace := framework.UserNamespace
-			_, errors := framework.AsKubeAdmin.CommonController.CreateRegistryAuthSecret(
-				constants.RegistryAuthSecretName,
-				usernamespace,
-				utils.GetDockerConfigJson(),
-			)
-			if errors != nil {
-				logError(3, fmt.Sprintf("Unable to create the secret %s in namespace %s: %v", constants.RegistryAuthSecretName, usernamespace, errors))
-				FailedResourceCreationsPerThread[threadIndex] += 1
-				increaseBar(resourcesBar, resourcesBarMutex)
-				continue
-			}
 			ApplicationName := fmt.Sprintf("%s-app", username)
 			app, err := framework.AsKubeDeveloper.HasController.CreateHasApplicationWithTimeout(ApplicationName, usernamespace, 60*time.Minute)
 			if err != nil {

--- a/docs/LoadTests.md
+++ b/docs/LoadTests.md
@@ -10,12 +10,8 @@ This Test Section Provides Load Testing Scripts for Red Hat AppStudio
 
 ## Running the script
 1. Change your directory to `tests/load-tests` 
-2. Set the following environment variables with your encoded docker config json:
-```bash
-  export DOCKER_CONFIG_JSON=<PLEASE_ENTER_BASE64_ENCODED_CONFIG>
-```
-3. Additional environment variables are required to set for the e2e framework that the load test uses. Refer to [Running the tests](https://github.com/redhat-appstudio/e2e-tests#running-the-tests).
-4. Run the bash script
+2. Environment variables are required to set for the e2e framework that the load test uses. Refer to [Running the tests](https://github.com/redhat-appstudio/e2e-tests#running-the-tests).
+3. Run the bash script
 ```
 ./run.sh 
 ```
@@ -25,7 +21,6 @@ You can configure the parameters by editing `run.sh` and add/change parameters(e
 ## How does this work 
 The Script works in Steps
 - Starts by creating `n` number of UserSignup CRD's which will create `n` number of NameSpaces , number of users can be changed by the flag `--users`
-- Next the Script Adds a Secret named `redhat-appstudio-registry-pull-secret` which will contain the docker config you provided when you run the script
 - Then it proceeds by creating AppStudio Applications for each user followed by Appstudio Component, i.e Creates users on a 1:1 basis 
 - Creating the Component will start the pipelines, if the `-w` flag is given it will wait for the pipelines to finish then print results 
 - Then after the tests are completed it will dump the results / stats, on error the stats will still get dumped along with the trace

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -29,9 +29,6 @@ const (
 	// User for running the end-to-end Tekton Chains tests
 	TEKTON_CHAINS_E2E_USER string = "chains-e2e"
 
-	//base64 Encoded docker config json value to create registry pull secret
-	DOCKER_CONFIG_JSON string = "DOCKER_CONFIG_JSON"
-
 	//Cluster Registration namespace
 	CLUSTER_REG_NS string = "cluster-reg-config" // #nosec
 

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -116,10 +116,6 @@ func GetQuayIOOrganization() string {
 	return GetEnv(constants.QUAY_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe")
 }
 
-func GetDockerConfigJson() string {
-	return GetEnv(constants.DOCKER_CONFIG_JSON, "")
-}
-
 func IsPrivateHostname(url string) bool {
 	// https://www.ibm.com/docs/en/networkmanager/4.2.0?topic=translation-private-address-ranges
 	privateIPAddressPrefixes := []string{"10.", "172.1", "172.2", "172.3", "192.168"}

--- a/tests/load-tests/ci-scripts/load-test.sh
+++ b/tests/load-tests/ci-scripts/load-test.sh
@@ -9,8 +9,7 @@ source "/usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${1:
 
 pushd "${2:-./tests/load-tests}"
 
-export DOCKER_CONFIG_JSON QUAY_E2E_ORGANIZATION MY_GITHUB_ORG GITHUB_TOKEN
-DOCKER_CONFIG_JSON=$QUAY_TOKEN
+export QUAY_E2E_ORGANIZATION MY_GITHUB_ORG GITHUB_TOKEN
 QUAY_E2E_ORGANIZATION=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/quay-org)
 MY_GITHUB_ORG=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/github-org)
 

--- a/tests/load-tests/ci-scripts/max-concurrency/load-test.sh
+++ b/tests/load-tests/ci-scripts/max-concurrency/load-test.sh
@@ -9,8 +9,7 @@ source "/usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${1:
 
 pushd "${2:-./tests/load-tests}"
 
-export DOCKER_CONFIG_JSON QUAY_E2E_ORGANIZATION MY_GITHUB_ORG GITHUB_TOKEN
-DOCKER_CONFIG_JSON=$QUAY_TOKEN
+export QUAY_E2E_ORGANIZATION MY_GITHUB_ORG GITHUB_TOKEN
 QUAY_E2E_ORGANIZATION=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/quay-org)
 MY_GITHUB_ORG=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/github-org)
 

--- a/tests/load-tests/run-max-concurrency.sh
+++ b/tests/load-tests/run-max-concurrency.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-export DOCKER_CONFIG_JSON MY_GITHUB_ORG GITHUB_TOKEN
-DOCKER_CONFIG_JSON=${DOCKER_CONFIG_JSON:-}
+export MY_GITHUB_ORG GITHUB_TOKEN
 
 load_test() {
     threads=${1:-1}
@@ -14,11 +13,6 @@ load_test() {
         --disable-metrics \
         --pipeline-skip-initial-checks="${PIPELINE_SKIP_INITIAL_CHECKS:-true}"
 }
-
-if [ -z ${DOCKER_CONFIG_JSON+x} ]; then
-    echo "env DOCKER_CONFIG_JSON need to be defined"
-    exit 1
-else echo "DOCKER_CONFIG_JSON is set"; fi
 
 USER_PREFIX=${USER_PREFIX:-testuser}
 # Max length of compliant username is 20 characters. We add "-XXXX-XXXX" suffix for the test users' name so max length of the prefix is 10.

--- a/tests/load-tests/run.sh
+++ b/tests/load-tests/run.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
-export DOCKER_CONFIG_JSON MY_GITHUB_ORG GITHUB_TOKEN
-DOCKER_CONFIG_JSON=${DOCKER_CONFIG_JSON:-}
-
-if [ -z ${DOCKER_CONFIG_JSON+x} ]; then
-    echo "env DOCKER_CONFIG_JSON need to be defined"
-    exit 1
-else echo "DOCKER_CONFIG_JSON is set"; fi
+export MY_GITHUB_ORG GITHUB_TOKEN
 
 USER_PREFIX=${USER_PREFIX:-testuser}
 # Max length of compliant username is 20 characters. We add "-XXXX" suffix for the test users' name so max length of the prefix is 15.


### PR DESCRIPTION
# Description

With #482 the `redhat-appstudio-registry-pull-secret` secret is created (and set to the value of `QUAY_TOKEN` variable) by the e2e framework automatically, so when the load test attempts to create the secret, it fails for "already exist" reason.

This PR:
* Removes the step to create `redhat-appstudio-registry-pull-secret` secret
* Removes use of the `DOCKER_CONFIG_JSON` environment variable that was used to set the above secret

## Issue ticket number and link


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

In OpenShift CI: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/40331/rehearse-40331-periodic-ci-redhat-appstudio-e2e-tests-main-load-test-max-concurrency-basic/1669345903418281984

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
