### PR TITLE
fix(RHTAPBUGS-407): build components sequentially in pyxis test

### DIFF
--- a/tests/release/e2e-test-push-image-to-pyxis.go
+++ b/tests/release/e2e-test-push-image-to-pyxis.go
@@ -41,6 +41,8 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1571]test-release-e2e-push-image-
 
 	var component1, component2 *appservice.Component
 
+	var componentDetected, additionalComponentDetected appservice.ComponentDetectionDescription
+
 	BeforeAll(func() {
 		fw, err = framework.NewFramework(utils.GetGeneratedNamespace("e2e-pyxis"))
 		Expect(err).NotTo(HaveOccurred())
@@ -121,7 +123,6 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1571]test-release-e2e-push-image-
 
 		// using cdq since git ref is not known
 		compName = componentName
-		var componentDetected appservice.ComponentDetectionDescription
 		cdq, err := fw.AsKubeAdmin.HasController.CreateComponentDetectionQuery(compName, devNamespace, gitSourceComponentUrl, "", "", "", false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(cdq.Status.ComponentDetected)).To(Equal(1), "Expected length of the detected Components was not 1")
@@ -133,7 +134,6 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1571]test-release-e2e-push-image-
 
 		// using cdq since git ref is not known
 		additionalCompName = additionalComponentName
-		var additionalComponentDetected appservice.ComponentDetectionDescription
 		cdq, err = fw.AsKubeAdmin.HasController.CreateComponentDetectionQuery(additionalCompName, devNamespace, additionalGitSourceComponentUrl, "", "", "", false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(cdq.Status.ComponentDetected)).To(Equal(1), "Expected length of the detected Components was not 1")
@@ -187,12 +187,6 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1571]test-release-e2e-push-image-
 
 		_, err = fw.AsKubeAdmin.HasController.CreateHasApplication(applicationNameDefault, devNamespace)
 		Expect(err).NotTo(HaveOccurred())
-
-		component1, err = fw.AsKubeAdmin.HasController.CreateComponentFromStub(componentDetected, devNamespace, "", "", applicationNameDefault)
-		Expect(err).NotTo(HaveOccurred())
-
-		component2, err = fw.AsKubeAdmin.HasController.CreateComponentFromStub(additionalComponentDetected, devNamespace, "", "", applicationNameDefault)
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterAll(func() {
@@ -208,8 +202,15 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1571]test-release-e2e-push-image-
 
 	var _ = Describe("Post-release verification", func() {
 
-		It("verifies that build PipelineRuns are created for each Component in dev namespace and both succeed", func() {
+		It("verifies that Component 1 can be created and build PipelineRun is created for it in dev namespace and succeeds", func() {
+			component1, err = fw.AsKubeAdmin.HasController.CreateComponentFromStub(componentDetected, devNamespace, "", "", applicationNameDefault)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(fw.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component1, "", 2)).To(Succeed())
+		})
+
+		It("verifies that Component 2 can be created and build PipelineRun is created for it in dev namespace and succeeds", func() {
+			component2, err = fw.AsKubeAdmin.HasController.CreateComponentFromStub(additionalComponentDetected, devNamespace, "", "", applicationNameDefault)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(fw.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component2, "", 2)).To(Succeed())
 		})
 


### PR DESCRIPTION
# Description

The push-to-pyxis test uses two components. Creating them at the same time results in two Snapshots and, subsequently, two release PipelineRuns created around the same time (once each component build finishes). This can cause a race condition when trying to create image in Pyxis or pushing sbom data into Pyxis twice for the same component at the same time.

The real fix will come in a follow up story - the release service will have to somehow limit concurrent PipelineRuns for the same Application.

But for now, let's reduce the risk of this happening by building one component and only once it finishes, build the second one. That way there will be sufficient gap between the start times of the two release PipelineRuns.

## Issue ticket number and link

https://issues.redhat.com/browse/RHTAPBUGS-407

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The changes will be verified by having a successful e2e run in this PR.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
