### PR TITLE
test: Change tests according to image controller always deletes component image repository

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -113,8 +113,7 @@ const (
 )
 
 var (
-	ComponentDefaultLabel                    = map[string]string{"e2e-test": "true"}
-	ComponentPaCRequestAnnotation            = map[string]string{"appstudio.openshift.io/pac-provision": "request"}
-	ImageControllerAnnotationDeleteRepoTrue  = map[string]string{"image.redhat.com/generate": "true", "image.redhat.com/delete-image-repo": "true"}
-	ImageControllerAnnotationDeleteRepoFalse = map[string]string{"image.redhat.com/generate": "true", "image.redhat.com/delete-image-repo": "false"}
+	ComponentDefaultLabel                      = map[string]string{"e2e-test": "true"}
+	ComponentPaCRequestAnnotation              = map[string]string{"appstudio.openshift.io/pac-provision": "request"}
+	ImageControllerAnnotationRequestPublicRepo = map[string]string{"image.redhat.com/generate": `{"visibility": "public"}`}
 )

--- a/pkg/utils/has/controller.go
+++ b/pkg/utils/has/controller.go
@@ -209,7 +209,7 @@ func (h *SuiteController) CreateComponent(applicationName, componentName, namesp
 		containerImage = containerImageSource
 	} else {
 		// When no image image is selected then add annotatation to generate new image repository
-		annotations = utils.MergeMaps(annotations, constants.ImageControllerAnnotationDeleteRepoTrue)
+		annotations = utils.MergeMaps(annotations, constants.ImageControllerAnnotationRequestPublicRepo)
 	}
 	component := &appservice.Component{
 		ObjectMeta: metav1.ObjectMeta{
@@ -270,14 +270,9 @@ func (h *SuiteController) ComponentDeleted(component *appservice.Component) wait
 }
 
 // CreateComponentWithPaCEnabled creates a component with "pipelinesascode: '1'" annotation that is used for triggering PaC builds
-func (h *SuiteController) CreateComponentWithPaCEnabled(applicationName, componentName, namespace, gitSourceURL, baseBranch string, deleteRepo bool) (*appservice.Component, error) {
+func (h *SuiteController) CreateComponentWithPaCEnabled(applicationName, componentName, namespace, gitSourceURL, baseBranch string) (*appservice.Component, error) {
 
-	var annotations map[string]string
-	if deleteRepo {
-		annotations = utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationDeleteRepoTrue)
-	} else {
-		annotations = utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationDeleteRepoFalse)
-	}
+	annotations := utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationRequestPublicRepo)
 
 	component := &appservice.Component{
 		ObjectMeta: metav1.ObjectMeta{
@@ -326,7 +321,7 @@ func (h *SuiteController) CreateComponentFromStubSkipInitialChecks(compDetected 
 	if outputContainerImage != "" {
 		component.Spec.ContainerImage = outputContainerImage
 	} else {
-		component.Annotations = utils.MergeMaps(component.Annotations, constants.ImageControllerAnnotationDeleteRepoTrue)
+		component.Annotations = utils.MergeMaps(component.Annotations, constants.ImageControllerAnnotationRequestPublicRepo)
 	}
 
 	if component.Spec.TargetPort == 0 {
@@ -573,7 +568,7 @@ func (h *SuiteController) CreateComponentFromDevfile(applicationName, componentN
 	} else if containerImageSource != "" {
 		component.Spec.ContainerImage = containerImageSource
 	} else {
-		component.Annotations = constants.ImageControllerAnnotationDeleteRepoTrue
+		component.Annotations = constants.ImageControllerAnnotationRequestPublicRepo
 	}
 	err := h.KubeRest().Create(context.TODO(), component)
 	if err != nil {

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -125,8 +125,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 		When("a new component without specified branch is created", Label("pac-custom-default-branch"), func() {
 			BeforeAll(func() {
-				deleteRepo := false
-				_, err = f.AsKubeDeveloper.HasController.CreateComponentWithPaCEnabled(applicationName, defaultBranchTestComponentName, testNamespace, helloWorldComponentGitSourceURL, "", deleteRepo)
+				_, err = f.AsKubeDeveloper.HasController.CreateComponentWithPaCEnabled(applicationName, defaultBranchTestComponentName, testNamespace, helloWorldComponentGitSourceURL, "")
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 
@@ -208,13 +207,13 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 					return exists
 				}, timeout, interval).Should(BeFalse(), "timed out when waiting for the branch to be deleted")
 			})
-			It("related image repo should not be deleted but the robot account should be deleted after deleting the component", func() {
+			It("related image repo and the robot account should be deleted after deleting the component", func() {
 				timeout = time.Second * 60
 				interval = time.Second * 1
-				// Check image repo should not be deleted
+				// Check image repo should be deleted
 				Eventually(func() (bool, error) {
 					return build.DoesImageRepoExistInQuay(imageRepoName)
-				}, timeout, interval).Should(BeTrue(), "timed out when checking if image repo got deleted")
+				}, timeout, interval).Should(BeFalse(), "timed out when checking if image repo got deleted")
 				// Check robot account should be deleted
 				Eventually(func() (bool, error) {
 					return build.DoesRobotAccountExistInQuay(robotAccountName)
@@ -226,8 +225,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		When("a new Component with specified custom branch is created", Label("custom-branch"), func() {
 			BeforeAll(func() {
 				// Create a component with Git Source URL, a specified git branch and marking delete-repo=true
-				deleteRepo := true
-				component, err = f.AsKubeAdmin.HasController.CreateComponentWithPaCEnabled(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, componentBaseBranchName, deleteRepo)
+				component, err = f.AsKubeAdmin.HasController.CreateComponentWithPaCEnabled(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, componentBaseBranchName)
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 			It("triggers a PipelineRun", func() {
@@ -435,8 +433,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 					return build.DoesRobotAccountExistInQuay(robotAccountName)
 				}, timeout, interval).Should(BeFalse(), "timed out when waiting for robot account to be deleted")
 
-				deleteRepo := true
-				_, err = f.AsKubeAdmin.HasController.CreateComponentWithPaCEnabled(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, componentBaseBranchName, deleteRepo)
+				_, err = f.AsKubeAdmin.HasController.CreateComponentWithPaCEnabled(applicationName, componentName, testNamespace, helloWorldComponentGitSourceURL, componentBaseBranchName)
 			})
 
 			It("should no longer lead to a creation of a PaC PR", func() {

--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -259,7 +259,7 @@ var _ = framework.RhtapDemoSuiteDescribe("RHTAP Demo", Label("rhtap-demo"), func
 		When("Component with PaC is created", func() {
 
 			It("triggers creation of a PR in the sample repo", func() {
-				component, err = f.AsKubeAdmin.HasController.CreateComponentWithPaCEnabled(appName, componentName, userNamespace, sampleRepoURL, componentNewBaseBranch, true)
+				component, err = f.AsKubeAdmin.HasController.CreateComponentWithPaCEnabled(appName, componentName, userNamespace, sampleRepoURL, componentNewBaseBranch)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				pacBranchName := fmt.Sprintf("appstudio-%s", component.GetName())


### PR DESCRIPTION
# Description

This PR changes e2e tests expectations regarding Component image repository lifecycle. With [new behavior](https://github.com/redhat-appstudio/image-controller/pull/34), Image Controller always deletes image repository of the Component, when the Component gets deleted.
Annotation `image.redhat.com/delete-image-repo` is deprecated and will have no effect.

## Issue ticket number and link

[STONEBLD-1340](https://issues.redhat.com/browse/STONEBLD-1340)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
