### PR TITLE
fix: adding an exception for both release pipelineruns, so if one of t…

### DIFF
--- a/tests/release/e2e-test-push-image-to-pyxis.go
+++ b/tests/release/e2e-test-push-image-to-pyxis.go
@@ -257,6 +257,10 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1571]test-release-e2e-push-image-
 					return false
 				}
 
+				//Fail the test if any of the two release pipelineruns failed.
+				Expect(utils.HasPipelineRunFailed(releasePr)).To(BeTrue(), fmt.Sprintf("did not expect PipelineRun %s/%s to fail", releasePr.GetNamespace(), releasePr.GetName()))
+				Expect(utils.HasPipelineRunFailed(additionalReleasePr)).To(BeTrue(), fmt.Sprintf("did not expect PipelineRun %s/%s to fail", additionalReleasePr.GetNamespace(), additionalReleasePr.GetName()))
+
 				return releasePr.HasStarted() && releasePr.IsDone() && releasePr.Status.GetCondition(apis.ConditionSucceeded).IsTrue() &&
 					additionalReleasePr.HasStarted() && additionalReleasePr.IsDone() && additionalReleasePr.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
 			}, releasePipelineRunCompletionTimeout, defaultInterval).Should(BeTrue())


### PR DESCRIPTION
…hem failed test will fail.

In release e2e-test  `e2e-test-push-image-to-pyxis.go`  we have a test to ensure two release pipelineruns to success  
within defined timeout. We added an exception if one failed before timeout then test will set as failed and not wait till timeout exceeded .
## [RHTAPBUGS-121](https://issues.redhat.com/browse/RHTAPBUGS-121) 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
