### PR TITLE
test: fix timeout

### DIFF
--- a/tests/release/const.go
+++ b/tests/release/const.go
@@ -62,6 +62,7 @@ const (
 	avgControllerQueryTimeout             = 5 * time.Minute
 	pipelineServiceAccountCreationTimeout = 7 * time.Minute
 	releaseDeploymentTimeout              = 10 * time.Minute
+	releaseFinishedTimeout                = 5 * time.Minute
 
 	defaultInterval = 100 * time.Millisecond
 )

--- a/tests/release/e2e-test-default-with-deployment.go
+++ b/tests/release/e2e-test-default-with-deployment.go
@@ -223,7 +223,7 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1199]test-release-e2e-with-deploy
 					return fmt.Errorf("release %s/%s is not marked as deployed yet", releaseCR.GetNamespace(), releaseCR.GetName())
 				}
 				return nil
-			}, releaseCreationTimeout, defaultInterval).Should(Succeed())
+			}, releaseDeploymentTimeout, defaultInterval).Should(Succeed())
 		})
 		It("tests a Release CR is marked as successfully deployed", func() {
 			Eventually(func() error {
@@ -235,7 +235,7 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1199]test-release-e2e-with-deploy
 					return fmt.Errorf("release %s/%s is not marked as finished yet", releaseCR.GetNamespace(), releaseCR.GetName())
 				}
 				return nil
-			}, releaseDeploymentTimeout, defaultInterval).Should(Succeed())
+			}, releaseCreationTimeout, defaultInterval).Should(Succeed())
 		})
 	})
 })

--- a/tests/release/e2e-test-default-with-deployment.go
+++ b/tests/release/e2e-test-default-with-deployment.go
@@ -235,7 +235,7 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1199]test-release-e2e-with-deploy
 					return fmt.Errorf("release %s/%s is not marked as finished yet", releaseCR.GetNamespace(), releaseCR.GetName())
 				}
 				return nil
-			}, releaseCreationTimeout, defaultInterval).Should(Succeed())
+			}, releaseFinishedTimeout, defaultInterval).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
# Description

There is a recent [PR](https://github.com/redhat-appstudio/e2e-tests/commit/a0a9bfd558f9dfb56dd46c2095ec8485c4391985#diff-0ef984b13662fe17a6a6a36aadf17220299b09e9af0e7e59b3f9ebe6f2dfd2e8R226) that changed the timeout on _It Spec_ `tests a Release CR reports that the deployment was successful`, from 10 to 5, which sometimes is not enough for the release to be marked as deployed (more details, see https://github.com/redhat-appstudio/e2e-tests/pull/601).

So, this PR reverts it, since some jobs are failing because the timeout is not enough. Example:

job: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/redhat-appstudio_e2e-tests/619/pull-ci-redhat-appstudio-e2e-tests-main-redhat-appstudio-e2e/1677202396054294528#1:build-log.txt%3A1016
logs: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/redhat-appstudio_e2e-tests/619/pull-ci-redhat-appstudio-e2e-tests-main-redhat-appstudio-e2e/1677202396054294528/artifacts/redhat-appstudio-e2e/redhat-appstudio-gather/artifacts/releases.json 

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
