### PR TITLE
fix: Do not require attestations to have 2 layers

### DIFF
--- a/pkg/utils/tekton/controller.go
+++ b/pkg/utils/tekton/controller.go
@@ -507,15 +507,6 @@ func findCosignResultsForImage(imageRef string) (*CosignResult, error) {
 		errMsg += fmt.Sprintf("error when getting attestation tag: %+v\n", err)
 	} else {
 		results.attestationImageRef = attestationTag.ImageRef
-		// we want two layers, one for TaskRun and one for PipelineRun
-		// attestations, i.e. that the Chains controller reconciled both and
-		// uploaded them as layers
-		//
-		// this needs to change if/when Chains controller does not produce two layers
-		layersExpected := 2
-		if len(attestationTag.Layers) < layersExpected {
-			errMsg += fmt.Sprintf("attestation tag doesn't have the expected number of layers (%d)\n", layersExpected)
-		}
 	}
 
 	if len(errMsg) > 0 {

--- a/pkg/utils/tekton/controller_test.go
+++ b/pkg/utils/tekton/controller_test.go
@@ -72,25 +72,29 @@ func TestFindingCosignResults(t *testing.T) {
 		ExpectedErrors          []string
 		Result                  *CosignResult
 	}{
-		{"happy day", true, true, []any{"", ""}, []string{}, &CosignResult{
+		{"happy day", true, true, []any{""}, []string{}, &CosignResult{
 			signatureImageRef:   signatureImageRef,
 			attestationImageRef: attestationImageRef,
 		}},
-		{"missing signature", false, true, []any{"", ""}, []string{"error when getting signature"}, &CosignResult{
+		{"happy day multiple attestations", true, true, []any{"", ""}, []string{}, &CosignResult{
+			signatureImageRef:   signatureImageRef,
+			attestationImageRef: attestationImageRef,
+		}},
+		{"missing signature", false, true, []any{""}, []string{"error when getting signature"}, &CosignResult{
 			signatureImageRef:   "",
 			attestationImageRef: attestationImageRef,
 		}},
-		{"missing attestation", true, false, []any{"", ""}, []string{"error when getting attestation"}, &CosignResult{
+		{"missing attestation", true, false, []any{""}, []string{"error when getting attestation"}, &CosignResult{
 			signatureImageRef:   signatureImageRef,
 			attestationImageRef: "",
 		}},
-		{"missing signature and attestation", false, false, []any{"", ""}, []string{"error when getting attestation", "error when getting signature"}, &CosignResult{
+		{"missing signature and attestation", false, false, []any{""}, []string{"error when getting attestation", "error when getting signature"}, &CosignResult{
 			signatureImageRef:   "",
 			attestationImageRef: "",
 		}},
-		{"missing layer in attestation", true, true, []any{""}, []string{"attestation tag doesn't have the expected number of layers"}, &CosignResult{
+		{"missing layers in attestation", true, true, []any{}, []string{"cannot get layers from"}, &CosignResult{
 			signatureImageRef:   signatureImageRef,
-			attestationImageRef: attestationImageRef,
+			attestationImageRef: "",
 		}},
 	}
 


### PR DESCRIPTION


# Description

With HACBS-2209, Tekton Chains will only produce a single attestation, for the PipelineRun. This is expected. This change updates the tests to no longer assert that the attestation image has 2 layers. This is an implementation detail anyways. It is better asserted indirectly by testing the actual functionality of Enterprise Contract.

Note that this assertion has failed before due to a different issue which is explained in the second comment in [RHTAPBUGS-375](https://issues.redhat.com//browse/RHTAPBUGS-375). It is expected that this patch will also address that issue by making the originaly reported underlying problem more obvious. There the PipelineRun failed for a different reason.

## Issue ticket number and link

https://issues.redhat.com/browse/RHTAPBUGS-375

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
