### PR TITLE
refactor(HACBS-2375): adjust release test to pyxis changes

### DIFF
--- a/pkg/utils/release/controller.go
+++ b/pkg/utils/release/controller.go
@@ -354,11 +354,12 @@ func (s *SuiteController) CreateComponentWithDockerSource(applicationName, compo
 	return component, nil
 }
 
-// CreateComponentWithDockerSource creates a component based on container image source.
-func (s *SuiteController) GetSbomPyxisByImageID(pyxisStageURL, imageID string,
+// GetPyxisImageByImageID makes a GET request to stage Pyxis to get an image
+// and returns it.
+func (s *SuiteController) GetPyxisImageByImageID(pyxisStageImagesApiEndpoint, imageID string,
 	pyxisCertDecoded, pyxisKeyDecoded []byte) ([]byte, error) {
 
-	url := fmt.Sprintf("%s%s", pyxisStageURL, imageID)
+	url := fmt.Sprintf("%s%s", pyxisStageImagesApiEndpoint, imageID)
 
 	// Create a TLS configuration with the key and certificate
 	cert, err := tls.X509KeyPair(pyxisCertDecoded, pyxisKeyDecoded)

--- a/pkg/utils/release/sbom.go
+++ b/pkg/utils/release/sbom.go
@@ -50,15 +50,6 @@ type ContentManifest struct {
 	ID string `json:"_id"`
 }
 
-// ContentManifestComponent contains information of components in SBOM
-type ContentManifestComponent struct {
-	ID      string `json:"_id"`
-	Name    string `json:"name"`
-	Purl    string `json:"purl"`
-	Type    string `json:"type"`
-	Version string `json:"version"`
-}
-
 // Defines a struct FreshnessGrade with fields for creation date, grade, and start date.
 type FreshnessGrade struct {
 	CreationDate string `json:"creation_date"`
@@ -78,20 +69,19 @@ type ParsedData struct {
 // content manifest components, creator information, creation date, Docker image digest,
 // freshness grades, image ID, last update date, last updated by, object type, and parsed data.
 type Image struct {
-	ID                        string                     `json:"_id"`
-	Links                     Links                      `json:"_links"`
-	Architecture              string                     `json:"architecture"`
-	Certified                 bool                       `json:"certified"`
-	ContentManifest           ContentManifest            `json:"content_manifest"`
-	ContentManifestComponents []ContentManifestComponent `json:"content_manifest_components"`
-	CreatedBy                 string                     `json:"created_by"`
-	CreatedOnBehalfOf         interface{}                `json:"created_on_behalf_of"`
-	CreationDate              string                     `json:"creation_date"`
-	DockerImageDigest         string                     `json:"docker_image_digest"`
-	FreshnessGrades           []FreshnessGrade           `json:"freshness_grades"`
-	ImageID                   string                     `json:"image_id"`
-	LastUpdateDate            string                     `json:"last_update_date"`
-	LastUpdatedBy             string                     `json:"last_updated_by"`
-	ObjectType                string                     `json:"object_type"`
-	ParsedData                ParsedData                 `json:"parsed_data"`
+	ID                string           `json:"_id"`
+	Links             Links            `json:"_links"`
+	Architecture      string           `json:"architecture"`
+	Certified         bool             `json:"certified"`
+	ContentManifest   ContentManifest  `json:"content_manifest"`
+	CreatedBy         string           `json:"created_by"`
+	CreatedOnBehalfOf interface{}      `json:"created_on_behalf_of"`
+	CreationDate      string           `json:"creation_date"`
+	DockerImageDigest string           `json:"docker_image_digest"`
+	FreshnessGrades   []FreshnessGrade `json:"freshness_grades"`
+	ImageID           string           `json:"image_id"`
+	LastUpdateDate    string           `json:"last_update_date"`
+	LastUpdatedBy     string           `json:"last_updated_by"`
+	ObjectType        string           `json:"object_type"`
+	ParsedData        ParsedData       `json:"parsed_data"`
 }

--- a/tests/release/const.go
+++ b/tests/release/const.go
@@ -47,7 +47,7 @@ const (
 	additionalComponentName         string = "simple-python"
 	additionalGitSourceComponentUrl string = "https://github.com/devfile-samples/devfile-sample-python-basic"
 	addtionalOutputContainerImage   string = constants.DefaultReleasedImagePushRepo
-	pyxisStageURL                   string = "https://pyxis.preprod.api.redhat.com/v1/images/id/"
+	pyxisStageImagesApiEndpoint     string = "https://pyxis.preprod.api.redhat.com/v1/images/id/"
 
 	namespaceCreationTimeout              = 5 * time.Minute
 	namespaceDeletionTimeout              = 5 * time.Minute

--- a/tests/release/e2e-test-push-image-to-pyxis.go
+++ b/tests/release/e2e-test-push-image-to-pyxis.go
@@ -351,15 +351,15 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1571]test-release-e2e-push-image-
 		It("validates that imageIds from task create-pyxis-image exist in Pyxis.", func() {
 			for _, imageID := range imageIDs {
 				Eventually(func() error {
-					body, err := fw.AsKubeAdmin.ReleaseController.GetSbomPyxisByImageID(pyxisStageURL, imageID,
+					body, err := fw.AsKubeAdmin.ReleaseController.GetPyxisImageByImageID(pyxisStageImagesApiEndpoint, imageID,
 						[]byte(pyxisCertDecoded), []byte(pyxisKeyDecoded))
 					Expect(err).NotTo(HaveOccurred(), "failed to get response body")
 
 					sbomImage := release.Image{}
 					Expect(json.Unmarshal(body, &sbomImage)).To(Succeed(), "failed to unmarshal body content: %s", string(body))
 
-					if len(sbomImage.ContentManifestComponents) < 1 {
-						return fmt.Errorf("ContentManifestComponents field is empty for sbom image: %+v", sbomImage)
+					if sbomImage.ContentManifest.ID == "" {
+						return fmt.Errorf("ContentManifest field is empty for sbom image: %+v", sbomImage)
 					}
 
 					return nil


### PR DESCRIPTION
# Description

Pyxis containerImage object will no longer
contain the embedded contentManifestComponent objects.

If we really still wanted to check that there is at least one component in Pyxis, we could use graphql and edges to get this information.

But it's probably ok for us to just check that a manifest is included in the image - that still confirms that upload_sbom script did something. If the upload_sbom script didn't run, the manifest id would be empty.

## Issue ticket number and link

https://issues.redhat.com/browse/HACBS-2375

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I wrote a simple go program where I copied the `GetPyxisImageByImageID` function and ran it on two different images - one with a linked manifest object and one without it. That way I was able to confirm that when the manifest object is not there, the id will be an empty string in the resulting struct object.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
