### PR TITLE
fix: add back ability to override the quay repo used for push/pull images

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -321,8 +321,11 @@ func (ci CI) setRequiredEnvVars() error {
 				var tektonObj runtime.Object
 
 				tag := fmt.Sprintf("%d-%s", time.Now().Unix(), util.GenerateRandomString(4))
-				var newS2iJavaTaskRef, _ = name.ParseReference(fmt.Sprintf("%s:task-bundle-%s", constants.DefaultImagePushRepo, tag))
-				var newJavaBuilderPipelineRef, _ = name.ParseReference(fmt.Sprintf("%s:pipeline-bundle-%s", constants.DefaultImagePushRepo, tag))
+				quayOrg := utils.GetEnv(constants.DEFAULT_QUAY_ORG_ENV, constants.DefaultQuayOrg)
+				newS2iJavaTaskImg := strings.ReplaceAll(constants.DefaultImagePushRepo, constants.DefaultQuayOrg, quayOrg)
+				var newS2iJavaTaskRef, _ = name.ParseReference(fmt.Sprintf("%s:task-bundle-%s", newS2iJavaTaskImg, tag))
+				newJavaBuilderPipelineImg := strings.ReplaceAll(constants.DefaultImagePushRepo, constants.DefaultQuayOrg, quayOrg)
+				var newJavaBuilderPipelineRef, _ = name.ParseReference(fmt.Sprintf("%s:pipeline-bundle-%s", newJavaBuilderPipelineImg, tag))
 				var newReqprocessorImage = os.Getenv("JVM_BUILD_SERVICE_REQPROCESSOR_IMAGE")
 				var newTaskYaml, newPipelineYaml []byte
 


### PR DESCRIPTION
# Description

It looks like that as part of a refactor, my fix from https://github.com/redhat-appstudio/e2e-tests/pull/495 was lost as logic was moved to the magefile stuff.

This is adding it back, to allow for running the e2e's locally using an individual's quay repos instead of the official appstudio e2e ones.

## Issue ticket number and link

## Type of change

- [ /] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [/ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
