### PR TITLE
fix: upgrade ec release policy

### DIFF
--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -217,7 +217,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 				Sources: []ecp.Source{
 					{
 						Policy: []string{
-							"oci::quay.io/hacbs-contract/ec-release-policy:git-086f871@sha256:373a5c4c1d34123836cbfc11826f6bbf6fdf8f0dfae333a2686bbe941c4f79ef",
+							"oci::quay.io/hacbs-contract/ec-release-policy:git-e908e45@sha256:e90f160c60acd9ef18f503556d635bb3c6b17b75c65d39efb7462a4d4950086a",
 						},
 						Data: []string{
 							"oci::quay.io/hacbs-contract/ec-policy-data:git-8629680@sha256:ee5708dda57216647f63032dd3e63375e70e2353cb1ad10c9ab5493b9236c23e",


### PR DESCRIPTION
# Description

This upgrades EC release policy to the latest version which includes a fix[1] needed for the upgraded version of OPA in[2].

The proper fix would not use a pinned version of rules/data but rely on the defaults from the `enterprise-contract/default` ConfigMap, as used in other scenarios. This is not possible at the moment because we need a change[3] that restores the missing acceptable bundles merged first.

[1] https://github.com/enterprise-contract/ec-policies/pull/546
[2] https://github.com/enterprise-contract/ec-cli/pull/801
[3] https://github.com/redhat-appstudio/infra-deployments/pull/2130

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally without cluster by running the `ec` CLI.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
