### PR TITLE
fix: `ec` label instead of `enterprise-contract`

### DIFF
--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -14,7 +14,7 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
 )
 
-var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests", Label("enterprise-contract", "HACBS"), func() {
+var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests", Label("ec", "HACBS"), func() {
 
 	defer GinkgoRecover()
 	var fwk *framework.Framework


### PR DESCRIPTION
# Description

These tests were skipped when running tests in infra-deployments from[1]:

```
exec: ginkgo "-p" "--output-interceptor-mode=none" "--timeout=90m" "--output-dir=/logs/artifacts" "--junit-report=e2e-report.xml" "--label-filter=e2e-demo,rhtap-demo,spi-suite,integration-service,o11y,ec,byoc" "./cmd" "--" "--config-suites=/tmp/tmp.NlhpfTvYoJ/tests/e2e-demos/config/default.yaml" "--generate-rppreproc-report=true" "--rp-preproc-dir=/logs/artifacts"
```

Notice that `enterprise-contract` label is not included but `ec` label is.

This leads to issues like on [2] run going undetected.

So this changes the label to `ec` so the test suite runs on changes to infra-deployments.

[1] https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/redhat-appstudio_infra-deployments/2122/pull-ci-redhat-appstudio-infra-deployments-main-appstudio-e2e-tests/1681252356039118848/artifacts/appstudio-e2e-tests/redhat-appstudio-e2e/build-log.txt
[2] https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/redhat-appstudio_e2e-tests/628/pull-ci-redhat-appstudio-e2e-tests-main-redhat-appstudio-e2e/1681556441929879552

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Was not

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
