### PR TITLE
test: Removes the check requiring a SBOM component to have a version

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -302,7 +302,6 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 					for _, component := range cyclonedx.Components {
 						Expect(component.Name).ToNot(BeEmpty())
 						Expect(component.Type).ToNot(BeEmpty())
-						Expect(component.Version).ToNot(BeEmpty())
 
 						if component.Type == "library" {
 							Expect(component.Purl).ToNot(BeEmpty())


### PR DESCRIPTION
# Description

With the addition of Cachi2 components in the final SBOM, some components will no longer have a version in it. Currently, the check that covers SBOM generation requires all components to have non-empty version.

Example of a Cachi2 reported component without a version: Golang std packages

```
 {
    "name": "vendor/golang.org/x/text/unicode/bidi",
    "properties": [
      {
        "name": "cachi2:found_by",
        "value": "cachi2"
      }
    ],
    "purl": "pkg:golang/vendor/golang.org/x/text/unicode/bidi?type=package",
    "type": "library"
 }
```

Related PRs:
https://github.com/redhat-appstudio/build-definitions/pull/481
https://github.com/containerbuildsystem/cachi2/pull/223

## Issue ticket number and link

[STONEBLD-1357](https://issues.redhat.com//browse/STONEBLD-1357)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This PR removes a single line that's causing the CI for https://github.com/redhat-appstudio/build-definitions/pull/481 to fail. This is due to a structural change in the SBOM, as described above.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
