### PR TITLE
chore: reinstate skipped tests

### DIFF
--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -429,7 +429,6 @@ var _ = framework.RhtapDemoSuiteDescribe("RHTAP Demo", Label("rhtap-demo"), func
 
 		When("Release PipelineRun is triggered", func() {
 			It("should eventually succeed", func() {
-				Skip("Skip until bug is fixed: https://issues.redhat.com/browse/RHTAPBUGS-356")
 				Eventually(func() error {
 					pipelineRun, err = f.AsKubeAdmin.ReleaseController.GetPipelineRunInNamespace(managedNamespace, release.Name, release.Namespace)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -443,7 +442,6 @@ var _ = framework.RhtapDemoSuiteDescribe("RHTAP Demo", Label("rhtap-demo"), func
 		})
 		When("Release PipelineRun is completed", func() {
 			It("should lead to Release CR being marked as succeeded", func() {
-				Skip("Skip until bug is fixed: https://issues.redhat.com/browse/RHTAPBUGS-356")
 				Eventually(func() error {
 					release, err = f.AsKubeAdmin.ReleaseController.GetRelease(release.Name, "", userNamespace)
 					Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
# Description

With https://issues.redhat.com/browse/RHTAPBUGS-356 resolved, these tests should be running.

Ref. https://issues.redhat.com/browse/HACBS-2402

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I'll let the CI do it's work...

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
