### PR TITLE
feat(load-test): Make it possible to specify thread increase step in max-concurrency scenarios

### DIFF
--- a/tests/load-tests/run-max-concurrency.sh
+++ b/tests/load-tests/run-max-concurrency.sh
@@ -34,10 +34,11 @@ if [ ${#USER_PREFIX} -gt 10 ]; then
     exit 1
 else
     output=load-tests.max-concurrency.json
+    maxConcurrencyStep=${MAX_CONCURRENCY_STEP:-1}
     maxThreads=${MAX_THREADS:-10}
     threshold=${THRESHOLD:-300}
-    echo '{"maxThreads": '"$maxThreads"', "threshold": '"$threshold"', "maxConcurrencyReached": 0}' | jq >"$output"
-    for t in $(seq 1 "${MAX_THREADS:-10}"); do
+    echo '{"maxThreads": '"$maxThreads"', "maxConcurrencyStep": '"$maxConcurrencyStep"', "threshold": '"$threshold"', "maxConcurrencyReached": 0}' | jq >"$output"
+    for t in $(seq 1 "${maxConcurrencyStep}" "${maxThreads}"); do
         echo "Deleting resources from previous steps"
         for res in pipelineruns.tekton.dev components.appstudio.redhat.com componentdetectionqueries.appstudio.redhat.com snapshotenvironmentbindings.appstudio.redhat.com applications.appstudio.redhat.com; do
             echo -e " * $res"


### PR DESCRIPTION
# Description

Currently, in `max-concurrency` scenarios the sequence of the number of threads starts with number 1 and then it is increased by 1 until the thread number reaches `MAX_THREADS` value or the `THRESHOLD` value for max pipeline run time is exceeded.

With the current performance of RHTAP the max concurrency in CI the max concurrency is not reached before the [job to execute the test](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-redhat-appstudio-e2e-tests-main-load-test-max-concurrency-basic) times out (8 hours) - which causes the job to fail.

We need to increase the step in thread count sequence to be able to reach higher concurrency sooner.

This PR:
* Adds possibility to configure the size of the step in sequence via `MAX_CONCURRENCY_STEP` (with the default value `1`) environment variable.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
