### PR TITLE
fix remote secret test

### DIFF
--- a/tests/spi/remote-secret.go
+++ b/tests/spi/remote-secret.go
@@ -61,11 +61,12 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "remote-secret"), func() {
 			remoteSecret, err = fw.AsKubeDeveloper.SPIController.CreateRemoteSecret(remoteSecretName, namespace, []string{targetNamespace1, targetNamespace2})
 			Expect(err).NotTo(HaveOccurred())
 
-			remoteSecret, err = fw.AsKubeDeveloper.SPIController.GetRemoteSecret(remoteSecret.Name, namespace)
-			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() bool {
+				remoteSecret, err = fw.AsKubeDeveloper.SPIController.GetRemoteSecret(remoteSecretName, namespace)
+				Expect(err).NotTo(HaveOccurred())
 
-			dataNotObtained := meta.IsStatusConditionFalse(remoteSecret.Status.Conditions, "DataObtained")
-			Expect(dataNotObtained).To(BeTrue())
+				return meta.IsStatusConditionFalse(remoteSecret.Status.Conditions, "DataObtained")
+			}, 5*time.Minute, 5*time.Second).Should(BeTrue(), fmt.Sprintf("RemoteSecret %s/%s is not waiting for data", namespace, remoteSecretName))
 		})
 
 		It("creates upload secret", func() {


### PR DESCRIPTION
# Description

Unfortunately, remote secret e2e test is failing because the RemoteSecret object status is being checked right after the creation, which is not time enough. This PR adds an `Eventually` to the verification.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
