### PR TITLE
test: skip remote secret test

### DIFF
--- a/tests/spi/remote-secret.go
+++ b/tests/spi/remote-secret.go
@@ -19,7 +19,9 @@ import (
  * Description: SVPI-541 - Basic remote secret functionalities
  */
 
-var _ = framework.SPISuiteDescribe(Label("spi-suite", "remote-secret"), func() {
+// pending because https://github.com/redhat-appstudio/remote-secret/pull/57 will break the tests
+// we will need to update the current test after merging the PR
+var _ = framework.SPISuiteDescribe(Label("spi-suite", "remote-secret"), Pending, func() {
 
 	defer GinkgoRecover()
 


### PR DESCRIPTION
# Description

https://github.com/redhat-appstudio/remote-secret/pull/57 will break the tests since it will introduce a new logic. Deploying to different namespaces is going to be disallowed by default. So, in order to not break the tests, we need to skip them provisory and update them after merging the new logic on remote secret repo side

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
