### PR TITLE
fix: Release CR is failing due to short timeout of 2 minutes, bumped …

### DIFF
--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -51,7 +51,7 @@ const (
 	// Timeouts
 	appDeployTimeout            = time.Minute * 20
 	appRouteAvailableTimeout    = time.Minute * 5
-	customResourceUpdateTimeout = time.Minute * 2
+	customResourceUpdateTimeout = time.Minute * 5
 	jvmRebuildTimeout           = time.Minute * 20
 	mergePRTimeout              = time.Minute * 1
 	pipelineRunStartedTimeout   = time.Minute * 5


### PR DESCRIPTION
…to 5 mins.

# Description

Found that the rhtap-test  failed many times when  validating Release CR to turn to succeeded, the failure was because the release pipelinerun took more than the defined timeout threshold which is 2 minutes , 
based on this we fixed with setting the timeout threshold to 5 minutes.

## [RHTAPBUGS-511](https://issues.redhat.com/browse/RHTAPBUGS-511)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
