### PR TITLE
feat(RHTAP-1304): Make it possible to override infra-deployments org and branch for load test

### DIFF
--- a/tests/load-tests/ci-scripts/setup-cluster.sh
+++ b/tests/load-tests/ci-scripts/setup-cluster.sh
@@ -13,31 +13,38 @@ pushd "${2:-.}"
 echo "Installing app-studio and tweaking cluster configuration"
 go mod tidy
 go mod vendor
-export MY_GITHUB_ORG QUAY_E2E_ORGANIZATION INFRA_DEPLOYMENTS_ORG INFRA_DEPLOYMENTS_BRANCH TEKTON_PERF_THREADS_PER_CONTROLLER TEKTON_PERF_KUBE_API_QPS TEKTON_PERF_KUBE_API_BURST TEKTON_PERF_ENABLE_PROFILING TEKTON_PERF_PROFILE_CPU_PERIOD
+export MY_GITHUB_ORG QUAY_E2E_ORGANIZATION INFRA_DEPLOYMENTS_ORG INFRA_DEPLOYMENTS_BRANCH TEKTON_PERF_ENABLE_PROFILING TEKTON_PERF_PROFILE_CPU_PERIOD
 MY_GITHUB_ORG=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/github-org)
 QUAY_E2E_ORGANIZATION=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/quay-org)
-INFRA_DEPLOYMENTS_ORG=$MY_GITHUB_ORG
-INFRA_DEPLOYMENTS_BRANCH=tekton-tuning-$(mktemp -u XXXX)
-TEKTON_PERF_THREADS_PER_CONTROLLER=${TEKTON_PERF_THREADS_PER_CONTROLLER:-32}
-TEKTON_PERF_KUBE_API_QPS=${TEKTON_PERF_KUBE_API_QPS:-50}
-TEKTON_PERF_KUBE_API_BURST=${TEKTON_PERF_KUBE_API_BURST:-50}
+INFRA_DEPLOYMENTS_ORG=${INFRA_DEPLOYMENTS_ORG:-redhat-appstudio}
+INFRA_DEPLOYMENTS_BRANCH=${INFRA_DEPLOYMENTS_BRANCH:-main}
 
 ## Tweak infra-deployments
-echo "Tweaking infra-deployments"
-infra_deployment_dir=$(mktemp -d)
-git clone --branch main "https://${GITHUB_TOKEN}@github.com/redhat-appstudio/infra-deployments.git" "$infra_deployment_dir"
-envsubst <tests/load-tests/ci-scripts/tekton-performance/update-tekton-config-performance.yaml >"$infra_deployment_dir/components/pipeline-service/development/update-tekton-config-performance.yaml"
-pushd "$infra_deployment_dir"
-git checkout -b "$INFRA_DEPLOYMENTS_BRANCH" origin/main
-git add "$infra_deployment_dir/components/pipeline-service/development/update-tekton-config-performance.yaml"
-git commit -m "WIP: tekton performance tuning"
-git remote add tekton-tuning "https://${GITHUB_TOKEN}@github.com/$INFRA_DEPLOYMENTS_ORG/infra-deployments.git"
-git push -u tekton-tuning "$INFRA_DEPLOYMENTS_BRANCH"
-popd
-rm -rf "$infra_deployment_dir"
+if [ "${TWEAK_INFRA_DEPLOYMENTS:-false}" == "true" ]; then
+    export TEKTON_PERF_THREADS_PER_CONTROLLER TEKTON_PERF_KUBE_API_QPS TEKTON_PERF_KUBE_API_BURST
+    TEKTON_PERF_THREADS_PER_CONTROLLER=${TEKTON_PERF_THREADS_PER_CONTROLLER:-32}
+    TEKTON_PERF_KUBE_API_QPS=${TEKTON_PERF_KUBE_API_QPS:-50}
+    TEKTON_PERF_KUBE_API_BURST=${TEKTON_PERF_KUBE_API_BURST:-50}
+    echo "Tweaking infra-deployments"
+    infra_deployment_dir=$(mktemp -d)
+    git clone --branch "${INFRA_DEPLOYMENTS_BRANCH}" "https://${GITHUB_TOKEN}@github.com/${INFRA_DEPLOYMENTS_ORG}/infra-deployments.git" "$infra_deployment_dir"
+    INFRA_DEPLOYMENTS_ORG="${MY_GITHUB_ORG}"
+    INFRA_DEPLOYMENTS_BRANCH="tekton-tuning-$(mktemp -u XXXX)"
+    envsubst <tests/load-tests/ci-scripts/tekton-performance/update-tekton-config-performance.yaml >"$infra_deployment_dir/components/pipeline-service/development/update-tekton-config-performance.yaml"
+    pushd "$infra_deployment_dir"
+    git checkout -b "$INFRA_DEPLOYMENTS_BRANCH" origin/main
+    git add "$infra_deployment_dir/components/pipeline-service/development/update-tekton-config-performance.yaml"
+    git commit -m "WIP: tekton performance tuning"
+    git remote add tekton-tuning "https://${GITHUB_TOKEN}@github.com/$INFRA_DEPLOYMENTS_ORG/infra-deployments.git"
+    git push -u tekton-tuning "$INFRA_DEPLOYMENTS_BRANCH"
+    popd
+    rm -rf "$infra_deployment_dir"
+fi
 
 ## Install infra-deployments
 echo "Installing infra-deployments"
+echo "  GitHub org: ${INFRA_DEPLOYMENTS_ORG}"
+echo "  GitHub branch: ${INFRA_DEPLOYMENTS_BRANCH}"
 make local/cluster/prepare
 
 ## Enable profiling in Tekton controller


### PR DESCRIPTION
# Description

Currently `infra-deployments` that the load test uses to install RHTAP in CI is always based on upstream `main` branch.

This PR:
* Modifies the `setup-cluster.sh` CI script to take variables `INFRA_DEPLOYMENTS_ORG` and `INFRA_DEPLOYMENTS_BRANCH` from environment set by the CI jobs to the respective org and branch (e.g. https://github.com/openshift/release/pull/41722)
* Introduces `TWEAK_INFRA_DEPLOYMENTS` variable to only touch infra deployments with load-test specific changes when that variable is set to `true`.

## Issue ticket number and link

[RHTAP-1304](https://issues.redhat.com/browse/RHTAP-1304)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
