### PR TITLE
fix: RHTAPBUGS-536 Wait for branch to exist

### DIFF
--- a/pkg/apis/github/git.go
+++ b/pkg/apis/github/git.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
+
+	. "github.com/onsi/gomega"
 
 	"github.com/google/go-github/v44/github"
 )
@@ -36,6 +39,12 @@ func (g *Github) CreateRef(repository, baseBranchName, sha, newBranchName string
 	if err != nil {
 		return fmt.Errorf("error when creating a new branch '%s' for the repo '%s': %+v", newBranchName, repository, err)
 	}
+	Eventually(func(gomega Gomega) {
+		exist, err := g.ExistsRef(repository, newBranchName)
+		gomega.Expect((err)).NotTo(HaveOccurred())
+		gomega.Expect(exist).To(Equal(true))
+
+	}, 2*time.Minute, 2*time.Second).Should(Succeed()) //Wait for the branch to actually exist
 	return nil
 }
 

--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -60,6 +60,7 @@ const (
 	snapshotTimeout             = time.Minute * 4
 	releaseTimeout              = time.Minute * 4
 	testPipelineTimeout         = time.Minute * 15
+	branchCreateTimeout         = time.Minute * 1
 
 	// Intervals
 	defaultPollingInterval    = time.Second * 2


### PR DESCRIPTION
# Description

Tests sometime fail in BeforeAll in rhtap-demo.go on "branch not found" right after the branch was created & tests tries to create file there. This PR adds wait for the branch to actually exist (GH GetRef() returns true). This should hopefully resolve [RHTAPBUGS-536](https://issues.redhat.com//browse/RHTAPBUGS-536)

## Issue ticket number and link
https://issues.redhat.com/browse/RHTAPBUGS-536

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Run locally few times. Worked fine.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
