### PR TITLE
test: add github oauth test flow to spi component

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -11,3 +11,4 @@ Tests folder contains E2E related to several components divided in folders:
 | `integration-service` | https://github.com/redhat-appstudio/integration-service | N/A |  |
 | `load-tests` | N/A | [LoadTests.md](/docs/LoadTests.md) |  |
 | `release` | https://github.com/redhat-appstudio/release-service | N/A |  |
+| `spi` | https://github.com/redhat-appstudio/service-provider-integration-operator | [README.md](/tests/spi/README.md) | |

--- a/tests/spi/README.md
+++ b/tests/spi/README.md
@@ -10,11 +10,37 @@ Steps to run 'spi-suite':
 
 #### Environments
 
-Valid Quay username and token are required to be able to run the suite: SPI will use them to create valid configurations to test private container image deployment. 
 Values can be provided by setting the following environment variables.
 
 | Variable | Required | Explanation | Default Value |
 |---|---|---|---|
 | `QUAY_OAUTH_USER` | yes | A quay.io username used to push/build containers  | ''  |
 | `QUAY_OAUTH_TOKEN` | yes | A quay.io token used to push/build containers. Note: the token and username must be a robot account with access to your repository | '' |
+| `SPI_GITHUB_CLIENT_ID` | yes | Github Oauth application Client ID  | ''  |
+| `SPI_GITHUB_CLIENT_SECRET` | yes | Github Oauth application Client secret | ''  |
+| `CYPRESS_GH_USER` | yes | Github user used by Cypress to simulate user's in-browser login  | ''  |
+| `CYPRESS_GH_PASSWORD` | yes | Github password used by Cypress to simulate user's in-browser login  | ''  |
+| `CYPRESS_GH_2FA_CODE` | yes | Github user 2FA code used by Cypress to simulate user's in-browser login | ''  |
+| `OAUTH_REDIRECT_PROXY_URL` | yes | Redirect Proxy public url | ''  |
 
+### Private Repositories
+
+Valid Quay username and token are required to be able to run the suite: SPI will use them to create valid configurations to test private container image deployment. 
+
+### OAuth flow tests
+
+The oauth authentication flow involves some steps that can only be executed in the browser; e2e-tests do this by using [cypress](https://github.com/cypress-io/cypress) framework to simulate the user steps. The specs that Cypress will run are located in [this repository](https://github.com/redhat-appstudio-qe/cypress-browser-oauth-flow). After creating SPI needed resources, e2e completes the steps a user would perform in a browser by creating a short-lived pod with the Cypress image, injecting the cypress specs by cloning the above repo and running them.
+To complete the authentication, a test user is needed: the tests expect username, password and the 2FA setup key to be provided. 
+
+SPI service needs to be configured to use the authentication providers. E2E-tests do this automatically in the setup phase, by expecting the clientid and secret of an oauth application for each supported provider to be supplied via environment variables. 
+
+If tests are running in CI, we need to handle the dynamic url the cluster is assigned with every time e2e-tests run. To do that, we use a simple redirect proxy that allows us to: 
+- set a static oauth callback url in the providers configuration; 
+- redirect the callback calls from the authentication providers to the spi component in our cluster. 
+The OAUTH_REDIRECT_PROXY_URL env should contains the url of such proxy and the callback url of you oauth apps should be set with the same url. 
+The proxy is stateless, requires no prior registration and the redirect translation will happen automatically using the state data provided by the SPI component itself.
+The redirect proxy used is in [this repository](https://github.com/redhat-appstudio-qe/spi-oauth-redirect-proxy).
+
+If not running in CI, SPI expects that the callback url in the provider configuration is set to the default one: homepage URL + /oauth/callback
+
+Tested provider are: Github.

--- a/tests/spi/oauth.go
+++ b/tests/spi/oauth.go
@@ -1,0 +1,178 @@
+package spi
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
+	"github.com/redhat-appstudio/service-provider-integration-operator/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+/*
+ * Component: spi
+ * Description: SVPI-395 - Github OAuth flow to upload token
+ */
+
+var _ = framework.SPISuiteDescribe(Label("spi-suite", "gh-oauth-flow"), func() {
+
+	defer GinkgoRecover()
+
+	var fw *framework.Framework
+	var err error
+	var namespace string
+	var CYPRESS_GH_USER string
+	var CYPRESS_GH_PASSWORD string
+	var CYPRESS_GH_2FA_CODE string
+
+	Describe("SVPI-395 - Github OAuth flow to upload token", Ordered, func() {
+		BeforeAll(func() {
+			if os.Getenv("CI") != "true" {
+				Skip(fmt.Sprintln("test skipped on local execution"))
+			}
+			// Initialize the tests controllers
+			fw, err = framework.NewFramework(utils.GetGeneratedNamespace("spi-demos-oauth"))
+			Expect(err).NotTo(HaveOccurred())
+			namespace = fw.UserNamespace
+			Expect(namespace).NotTo(BeEmpty())
+
+			CYPRESS_GH_USER = utils.GetEnv("CYPRESS_GH_USER", "")
+			Expect(CYPRESS_GH_USER).NotTo(BeEmpty(), "Please provide CYPRESS_GH_USER")
+
+			CYPRESS_GH_PASSWORD = utils.GetEnv("CYPRESS_GH_PASSWORD", "")
+			Expect(CYPRESS_GH_PASSWORD).NotTo(BeEmpty(), "Please provide CYPRESS_GH_PASSWORD")
+
+			CYPRESS_GH_2FA_CODE = utils.GetEnv("CYPRESS_GH_2FA_CODE", "")
+			Expect(CYPRESS_GH_2FA_CODE).NotTo(BeEmpty(), "Please provide CYPRESS_GH_2FA_CODE env")
+
+		})
+
+		// Clean up after running these tests and before the next tests block: can't have multiple AccessTokens in Injected phase
+		AfterAll(func() {
+
+			if !CurrentSpecReport().Failed() {
+				Expect(fw.AsKubeAdmin.SPIController.DeleteAllBindingTokensInASpecificNamespace(namespace)).To(Succeed())
+				Expect(fw.AsKubeAdmin.SPIController.DeleteAllAccessTokensInASpecificNamespace(namespace)).To(Succeed())
+			}
+		})
+
+		var SPITokenBinding *v1beta1.SPIAccessTokenBinding
+		var CYPRESS_SPI_OAUTH_URL string
+		tokenBindingName := "spi-token-binding-oauth-"
+		OAUTH_REDIRECT_PROXY_URL := utils.GetEnv("OAUTH_REDIRECT_PROXY_URL", "")
+
+		if utils.GetEnv("CI", "") == "true" {
+			/*
+				If we are running this test in CI, we need to handle the dynamic url the cluster is assigned with.
+				To do that, we use a redirect proxy that allows us to have a static oauth url in the providers configuration and, at the same time,
+				will redirect the callback call to the spi component in our cluster. OAUTH_REDIRECT_PROXY_URL env should contains the url of such proxy.
+				If not running in CI, SPI expects that the callback url in the provider configuration is set to the default one: homepage URL + /oauth/callback
+			*/
+			It("ensure OauthRedirectProxyUrl is set", func() {
+
+				Expect(OAUTH_REDIRECT_PROXY_URL).NotTo(BeEmpty(), "OAUTH_REDIRECT_PROXY_URL env is not set")
+
+				spiNamespace := "spi-system"
+				config, err := fw.AsKubeAdmin.CommonController.GetConfigMap("spi-oauth-service-environment-config", spiNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(config.Data["OAUTH_REDIRECT_PROXY_URL"]).NotTo(BeEmpty())
+
+			})
+		}
+
+		It("creates SPITokenBinding", func() {
+			SPITokenBinding, err = fw.AsKubeDeveloper.SPIController.CreateSPIAccessTokenBinding(tokenBindingName, namespace, RepoURL, "", "kubernetes.io/basic-auth")
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() bool {
+				SPITokenBinding, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessTokenBinding(SPITokenBinding.Name, namespace)
+				Expect(err).NotTo(HaveOccurred())
+
+				return (SPITokenBinding.Status.OAuthUrl != "")
+			}, 1*time.Minute, 10*time.Second).Should(BeTrue(), "OAuthUrl should not be empty")
+
+			CYPRESS_SPI_OAUTH_URL = SPITokenBinding.Status.OAuthUrl
+			Expect(CYPRESS_SPI_OAUTH_URL).NotTo(BeEmpty())
+
+			k8s_token, err := utils.GetOpenshiftToken()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8s_token).NotTo(BeEmpty())
+
+			CYPRESS_SPI_OAUTH_URL = CYPRESS_SPI_OAUTH_URL + "&k8s_token=" + k8s_token
+		})
+
+		It("run browser oauth login flow in cypress pod", func() {
+
+			// Now we create a short-living pod that will use cypress to perform the browser login flow
+			cypressPod := &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cypress-script",
+					Namespace: namespace,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "cypress-test",
+							Image:   "cypress/included",
+							Command: []string{"/bin/sh", "-c"},
+							Args:    []string{"git clone https://github.com/redhat-appstudio-qe/cypress-browser-oauth-flow; cd cypress-browser-oauth-flow; npm install; cypress run --spec cypress/e2e/spec.cy.js;"},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "CYPRESS_GH_USER",
+									Value: CYPRESS_GH_USER,
+								},
+								{
+									Name:  "CYPRESS_GH_PASSWORD",
+									Value: CYPRESS_GH_PASSWORD,
+								},
+								{
+									Name:  "CYPRESS_GH_2FA_CODE",
+									Value: CYPRESS_GH_2FA_CODE,
+								},
+								{
+									Name:  "CYPRESS_SPI_OAUTH_URL",
+									Value: CYPRESS_SPI_OAUTH_URL,
+								},
+							},
+							ImagePullPolicy: corev1.PullIfNotPresent,
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			}
+
+			_, err := fw.AsKubeAdmin.CommonController.KubeInterface().CoreV1().Pods(namespace).Create(context.TODO(), cypressPod, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// check pod is completed without error
+
+			Eventually(func() bool {
+				pod, err := fw.AsKubeAdmin.CommonController.GetPod(namespace, cypressPod.Name)
+				Expect(err).NotTo(HaveOccurred())
+
+				return (pod.Status.Phase == corev1.PodSucceeded)
+			}, 5*time.Minute, 5*time.Second).Should(BeTrue(), "Cypress pod did not completed oauth flow")
+
+		})
+
+		It("SPITokenBinding should be in Injected phase", func() {
+			Eventually(func() bool {
+				SPITokenBinding, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessTokenBinding(SPITokenBinding.Name, namespace)
+				Expect(err).NotTo(HaveOccurred())
+
+				return SPITokenBinding.Status.Phase == v1beta1.SPIAccessTokenBindingPhaseInjected
+			}, 2*time.Minute, 10*time.Second).Should(BeTrue(), "SPIAccessTokenBinding is not in Injected phase")
+		})
+
+	})
+})


### PR DESCRIPTION
# Description

This PR introduce tests for the oauth flow in SPI component. 
The tests use [cypress](https://github.com/cypress-io/cypress) framework to simulate the user authentication steps in the browser. The specs that Cypress will run are located in [this repository](https://github.com/redhat-appstudio-qe/cypress-browser-oauth-flow).
To run in CI, we use a simple redirect proxy (dogfooded in RHATP prod) that allows us to: 
- set a static oauth callback url in the providers configuration; 
- redirect the callback calls from the authentication providers to the spi component in our cluster. 

The proxy is stateless, requires no prior registration and the redirect translation will happen automatically using the state data provided by the SPI component itself. The redirect proxy used is in [this repository](https://github.com/redhat-appstudio-qe/spi-oauth-redirect-proxy).
To use the redirect proxy, SPI needs the OAUTH_REDIRECT_PROXY_URL parameter configured, so the cluster setup steps have also been updated. 

## Issue ticket number and link

[SVPI-395](https://issues.redhat.com/browse/SVPI-395)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`E2E_TEST_SUITE_LABEL=spi-suite make local/test/e2e`

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
