### PR TITLE
fix: RHTAPBUGS-541 increasing timeout when checking if taskrun is complete

### DIFF
--- a/tests/spi/quay-imagepullsecret-usage.go
+++ b/tests/spi/quay-imagepullsecret-usage.go
@@ -222,7 +222,7 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "quay-imagepullsecret-usag
 					Expect(err).NotTo(HaveOccurred())
 
 					return TaskRun.Status.CompletionTime
-				}, 1*time.Minute, 5*time.Second).ShouldNot(BeNil(), "timed out waiting for taskrun %s/%s to get completed", TaskRun.GetNamespace(), TaskRun.GetName())
+				}, 5*time.Minute, 5*time.Second).ShouldNot(BeNil(), "timed out waiting for taskrun %s/%s to get completed", TaskRun.GetNamespace(), TaskRun.GetName())
 			})
 
 			It("checks if taskrun is successful", func() {


### PR DESCRIPTION
# Description
The current timeout is 1min when checking if taskrun is complete, which can not be enough, as is the example of [this job](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/redhat-appstudio_infra-deployments/2172/pull-ci-redhat-appstudio-infra-deployments-main-appstudio-e2e-tests/1686352720824373248#1:build-log.txt%3A1015) (it took around 2min). This PR increases it to 5min to cover edge cases like this.

## Issue ticket number and link
[RHTAPBUGS-541](https://issues.redhat.com/browse/RHTAPBUGS-541)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
