### PR TITLE
chore: GetComponentPipelineRun reliability fix

### DIFF
--- a/pkg/utils/has/components.go
+++ b/pkg/utils/has/components.go
@@ -70,6 +70,10 @@ func (h *HasController) GetComponentPipelineRun(componentName string, applicatio
 		return nil, fmt.Errorf("error listing pipelineruns in %s namespace: %v", namespace, err)
 	}
 
+	if len(list.Items) > 1 {
+		return nil, fmt.Errorf("multiple pipelineruns found for component %s", componentName)
+	}
+
 	if len(list.Items) > 0 {
 		return &list.Items[0], nil
 	}


### PR DESCRIPTION
This is somewhat experimental, but I have seen a failure where calls to GetComponentPipelineRun have resulted in racey behavior in a test: https://issues.redhat.com/browse/STONEBLD-1582

Changing it to enforce a single pipelinerun should prevent future potential races.

This is not ready to merge, I just want to see what the effect will be on the current test suite results.