### PR TITLE
fix(RHTAP-1416): Add PR number to USER_PREFIX to avoid naming collisions while running multiple PRs in parallel

### DIFF
--- a/tests/load-tests/ci-scripts/collect-results.sh
+++ b/tests/load-tests/ci-scripts/collect-results.sh
@@ -9,6 +9,8 @@ source "/usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${1:
 
 pushd "${2:-.}"
 
+source "./tests/load-tests/ci-scripts/user-prefix.sh"
+
 echo "Collecting load test results"
 load_test_log=$ARTIFACT_DIR/load-tests.log
 cp -vf ./tests/load-tests/*.log "$ARTIFACT_DIR"

--- a/tests/load-tests/ci-scripts/load-test.sh
+++ b/tests/load-tests/ci-scripts/load-test.sh
@@ -9,6 +9,8 @@ source "/usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${1:
 
 pushd "${2:-./tests/load-tests}"
 
+source "./ci-scripts/user-prefix.sh"
+
 export QUAY_E2E_ORGANIZATION MY_GITHUB_ORG GITHUB_TOKEN TEKTON_PERF_ENABLE_PROFILING TEKTON_PERF_PROFILE_CPU_PERIOD KUBE_SCHEDULER_LOG_LEVEL
 QUAY_E2E_ORGANIZATION=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/quay-org)
 MY_GITHUB_ORG=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/github-org)

--- a/tests/load-tests/ci-scripts/max-concurrency/load-test.sh
+++ b/tests/load-tests/ci-scripts/max-concurrency/load-test.sh
@@ -9,6 +9,8 @@ source "/usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${1:
 
 pushd "${2:-./tests/load-tests}"
 
+source "./ci-scripts/user-prefix.sh"
+
 export QUAY_E2E_ORGANIZATION MY_GITHUB_ORG GITHUB_TOKEN TEKTON_PERF_ENABLE_PROFILING TEKTON_PERF_PROFILE_CPU_PERIOD
 QUAY_E2E_ORGANIZATION=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/quay-org)
 MY_GITHUB_ORG=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/github-org)

--- a/tests/load-tests/ci-scripts/user-prefix.sh
+++ b/tests/load-tests/ci-scripts/user-prefix.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+export USER_PREFIX
+
+if [ -n "${PULL_NUMBER:-}" ]; then
+    new_prefix="${USER_PREFIX}-${PULL_NUMBER}"
+    echo "To avoid naming collisions adding PR number to USER_PREFIX: '${USER_PREFIX}' -> '${new_prefix}'"
+    USER_PREFIX="$new_prefix"
+fi


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

[RHTAP-1416](https://issues.redhat.com/browse/RHTAP-1416)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
