### PR TITLE
fix: count the application type purls in test 

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -303,7 +303,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 						Expect(component.Name).ToNot(BeEmpty())
 						Expect(component.Type).ToNot(BeEmpty())
 
-						if component.Type == "library" {
+						if component.Type == "library" || component.Type == "application" {
 							Expect(component.Purl).ToNot(BeEmpty())
 							numberOfLibraryComponents++
 						}


### PR DESCRIPTION
After updating syft, this testcase is failing as it is counting only purls of type "library". But currently syft generates purls also for type "application". For example:

            "type": "application",
            "name": "python",
            "version": "3.11.1",
            "cpe": "cpe:2.3:a:python_software_foundation:python:3.11.1:*:*:*:*:*:*:*",
            "purl": "pkg:generic/python@3.11.1",

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
