### PR TITLE
chore(ci): add workaround for new OSP ver

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -15,8 +15,15 @@ spec:
     - name: output-image
       value: "quay.io/redhat-appstudio/pull-request-builds:e2e-{{revision}}"
   pipelineRef:
-    name: docker-build
-    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+    params:
+      - name: bundle
+        value: >-
+          quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+      - name: name
+        value: docker-build
+      - name: kind
+        value: Pipeline
+    resolver: bundles
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -15,8 +15,15 @@ spec:
     - name: output-image
       value: 'quay.io/redhat-appstudio/e2e-tests:{{revision}}'
   pipelineRef:
-    name: docker-build
-    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+    params:
+      - name: bundle
+        value: >-
+          quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+      - name: name
+        value: docker-build
+      - name: kind
+        value: Pipeline
+    resolver: bundles
   workspaces:
     - name: workspace
       volumeClaimTemplate:


### PR DESCRIPTION
# Description

### Why do we need this PR?

Recently the RHTAP CI check in the [PRs started failing](https://github.com/redhat-appstudio/e2e-tests/pull/662/checks?check_run_id=15575405866) with a similar error as shown below:
```
Error retrieving pipeline for pipelinerun tekton-ci/integration-service-pull-request-8mdtv: failed to get pipeline:
error requesting remote resource: error getting "bundleresolver" "tekton-ci/bundles-2eaa2963a940eb40a21b75a6baacc12b":
could not find object in image with kind: Task and name: docker-build
```
This is due to some recent changes in the PipelineRun definition in the tekton-ci, where we'd need to specify the bundles inside a resolver format and also specifically mention the `kind: Pipeline` (by default it would pick up the value `Task` and that explains the error seen above).

You can read the entire discussion on this within [this Slack thread](https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1690994401490699).

This move will increase the overall efficiency of the RHTAP builds and put less stress on the cluster.

### What does this PR do?

This PR reformats the bundle used in the RHTAP yaml files by using resolvers.

## Issue ticket number and link

https://issues.redhat.com/browse/RHTAPBUGS-547

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

CI is my friend.