### PR TITLE
fix: Moved the proxyplugin creation to BeforeAll section

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -53,6 +53,10 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 				kubeadminClient = f.AsKubeAdmin
 			}
 
+			// create the proxyplugin for tekton-results
+			_, err = kubeadminClient.CommonController.CreateProxyPlugin("tekton-results", "toolchain-host-operator", "tekton-results", "tekton-results")
+			Expect(err).NotTo(HaveOccurred())
+
 			_, err = kubeadminClient.HasController.GetApplication(applicationName, testNamespace)
 			// In case the app with the same name exist in the selected namespace, delete it first
 			if err == nil {
@@ -163,9 +167,6 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 				var pr *v1beta1.PipelineRun
 
 				BeforeAll(func() {
-					// create the proxyplugin for tekton-results
-					_, err = kubeadminClient.CommonController.CreateProxyPlugin("tekton-results", "toolchain-host-operator", "tekton-results", "tekton-results")
-					Expect(err).NotTo(HaveOccurred())
 
 					regProxyUrl := fmt.Sprintf("%s/plugins/tekton-results", f.ProxyUrl)
 					resultClient = pipeline.NewClient(regProxyUrl, f.UserToken)


### PR DESCRIPTION
# Description

When running selected test with label `build-templates-e2e` it was failing while deleting ProxyPlugin in the AfterAll block, since we were creating ProxyPlugin in the It block. Moved it to BeforeAll so that the running tests with `build-templates-e2e` won't fail.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
