### PR TITLE
feat(HACBS-2400): Chains secret from OpenShift Pipelines

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -25,11 +25,8 @@ const (
 	// The private devfile sample git repository to use in certain HAS e2e tests
 	PRIVATE_DEVFILE_SAMPLE string = "PRIVATE_DEVFILE_SAMPLE" // #nosec
 
-	// The Tekton Chains namespace for its deployments (no longer separate from the rest of tekton)
-	TEKTON_CHAINS_DEPLOYMENT_NS string = "openshift-pipelines" // #nosec
-
-	// The namespace the pipeline service uses for the chains key
-	TEKTON_CHAINS_KEY_NS string = "tekton-chains" // #nosec
+	// The namespace where Tekton Chains and its secrets are deployed.
+	TEKTON_CHAINS_NS string = "openshift-pipelines" // #nosec
 
 	// User for running the end-to-end Tekton Chains tests
 	TEKTON_CHAINS_E2E_USER string = "chains-e2e"

--- a/pkg/utils/tekton/controller.go
+++ b/pkg/utils/tekton/controller.go
@@ -591,7 +591,7 @@ func (k KubeController) CreateOrUpdateSigningSecret(publicKey []byte, name, name
 }
 
 func (k KubeController) GetTektonChainsPublicKey() ([]byte, error) {
-	namespace := constants.TEKTON_CHAINS_KEY_NS
+	namespace := constants.TEKTON_CHAINS_NS
 	secretName := "public-key"
 	dataKey := "cosign.pub"
 
@@ -646,7 +646,7 @@ func (k KubeController) CreateOrUpdatePolicyConfiguration(namespace string, poli
 }
 
 func (k KubeController) GetRekorHost() (rekorHost string, err error) {
-	api := k.Tektonctrl.KubeInterface().CoreV1().ConfigMaps(constants.TEKTON_CHAINS_DEPLOYMENT_NS)
+	api := k.Tektonctrl.KubeInterface().CoreV1().ConfigMaps(constants.TEKTON_CHAINS_NS)
 	ctx := context.TODO()
 
 	cm, err := api.Get(ctx, "chains-config", metav1.GetOptions{})

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -36,23 +36,23 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 
 	Context("infrastructure is running", Label("pipeline"), func() {
 		It("verifies if the chains controller is running", func() {
-			err := fwk.AsKubeAdmin.CommonController.WaitForPodSelector(fwk.AsKubeAdmin.CommonController.IsPodRunning, constants.TEKTON_CHAINS_DEPLOYMENT_NS, "app", "tekton-chains-controller", 60, 100)
+			err := fwk.AsKubeAdmin.CommonController.WaitForPodSelector(fwk.AsKubeAdmin.CommonController.IsPodRunning, constants.TEKTON_CHAINS_NS, "app", "tekton-chains-controller", 60, 100)
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("verifies if the correct roles are created", func() {
-			_, csaErr := fwk.AsKubeAdmin.CommonController.GetRole("chains-secret-admin", constants.TEKTON_CHAINS_KEY_NS)
+			_, csaErr := fwk.AsKubeAdmin.CommonController.GetRole("chains-secret-admin", constants.TEKTON_CHAINS_NS)
 			Expect(csaErr).NotTo(HaveOccurred())
 			_, srErr := fwk.AsKubeAdmin.CommonController.GetRole("secret-reader", "openshift-ingress-operator")
 			Expect(srErr).NotTo(HaveOccurred())
 		})
 		It("verifies if the correct rolebindings are created", func() {
-			_, csaErr := fwk.AsKubeAdmin.CommonController.GetRoleBinding("chains-secret-admin", constants.TEKTON_CHAINS_KEY_NS)
+			_, csaErr := fwk.AsKubeAdmin.CommonController.GetRoleBinding("chains-secret-admin", constants.TEKTON_CHAINS_NS)
 			Expect(csaErr).NotTo(HaveOccurred())
 			_, csrErr := fwk.AsKubeAdmin.CommonController.GetRoleBinding("chains-secret-reader", "openshift-ingress-operator")
 			Expect(csrErr).NotTo(HaveOccurred())
 		})
 		It("verifies if the correct service account is created", func() {
-			_, err := fwk.AsKubeAdmin.CommonController.GetServiceAccount("chains-secrets-admin", constants.TEKTON_CHAINS_KEY_NS)
+			_, err := fwk.AsKubeAdmin.CommonController.GetServiceAccount("chains-secrets-admin", constants.TEKTON_CHAINS_NS)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -167,12 +167,12 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 			publicSecretName := "cosign-public-key"
 
 			BeforeAll(func() {
-				// Copy the public key from tekton-chains/signing-secrets to a new
+				// Copy the public key from openshift-pipelines/signing-secrets to a new
 				// secret that contains just the public key to ensure that access
 				// to password and private key are not needed.
 				publicKey, err := kubeController.GetTektonChainsPublicKey()
 				Expect(err).ToNot(HaveOccurred())
-				GinkgoWriter.Printf("Copy public key from %s/signing-secrets to a new secret\n", constants.TEKTON_CHAINS_KEY_NS)
+				GinkgoWriter.Printf("Copy public key from %s/signing-secrets to a new secret\n", constants.TEKTON_CHAINS_NS)
 				Expect(kubeController.CreateOrUpdateSigningSecret(
 					publicKey, publicSecretName, namespace)).To(Succeed())
 

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -39,22 +39,6 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 			err := fwk.AsKubeAdmin.CommonController.WaitForPodSelector(fwk.AsKubeAdmin.CommonController.IsPodRunning, constants.TEKTON_CHAINS_NS, "app", "tekton-chains-controller", 60, 100)
 			Expect(err).NotTo(HaveOccurred())
 		})
-		It("verifies if the correct roles are created", func() {
-			_, csaErr := fwk.AsKubeAdmin.CommonController.GetRole("chains-secret-admin", constants.TEKTON_CHAINS_NS)
-			Expect(csaErr).NotTo(HaveOccurred())
-			_, srErr := fwk.AsKubeAdmin.CommonController.GetRole("secret-reader", "openshift-ingress-operator")
-			Expect(srErr).NotTo(HaveOccurred())
-		})
-		It("verifies if the correct rolebindings are created", func() {
-			_, csaErr := fwk.AsKubeAdmin.CommonController.GetRoleBinding("chains-secret-admin", constants.TEKTON_CHAINS_NS)
-			Expect(csaErr).NotTo(HaveOccurred())
-			_, csrErr := fwk.AsKubeAdmin.CommonController.GetRoleBinding("chains-secret-reader", "openshift-ingress-operator")
-			Expect(csrErr).NotTo(HaveOccurred())
-		})
-		It("verifies if the correct service account is created", func() {
-			_, err := fwk.AsKubeAdmin.CommonController.GetServiceAccount("chains-secrets-admin", constants.TEKTON_CHAINS_NS)
-			Expect(err).NotTo(HaveOccurred())
-		})
 	})
 
 	Context("test creating and signing an image and task", Label("pipeline"), func() {

--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -45,7 +45,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 		}
 		publicKey, err := kubeController.GetTektonChainsPublicKey()
 		Expect(err).ToNot(HaveOccurred())
-		GinkgoWriter.Printf("Copy public key from %s/signing-secrets to a new secret\n", constants.TEKTON_CHAINS_KEY_NS)
+		GinkgoWriter.Printf("Copy public key from %s/signing-secrets to a new secret\n", constants.TEKTON_CHAINS_NS)
 		Expect(kubeController.CreateOrUpdateSigningSecret(
 			publicKey, publicSecretName, namespace)).To(Succeed())
 


### PR DESCRIPTION

# Description

Tekton Chains is now managed as part of the OpenShift Pipelines operator. As such, its resources now reside in the `openshift-pipelines` namespace instead of `tekton-chains`.

This also removes some of the infrastructure checks performed by the e2e tests. This is deemed too low-level for these tests. Instead, let's continue to use the e2e tests to test the expected behavior and not care too much about the implementation details.

## Issue ticket number and link
https://issues.redhat.com/browse/HACBS-2400

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
