### PR TITLE
fix: Improve error message matching

### DIFF
--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -101,7 +101,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 			reportLog, err := utils.GetContainerLogs(fwk.AsKubeAdmin.CommonController.KubeInterface(), tr.Status.PodName, "step-report", namespace)
 			GinkgoWriter.Printf("*** Logs from pod '%s', container '%s':\n----- START -----%s----- END -----\n", tr.Status.PodName, "step-report", reportLog)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(reportLog).Should(ContainSubstring("msg: No image attestations found matching the given public key"))
+			Expect(reportLog).Should(ContainSubstring("No image attestations found matching the given public key"))
 		})
 
 		It("verifies ec cli supports the current policy config fields used by the ec-policies rego rules", func() {
@@ -209,7 +209,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 			reportLog, err := utils.GetContainerLogs(fwk.AsKubeAdmin.CommonController.KubeInterface(), tr.Status.PodName, "step-report", namespace)
 			GinkgoWriter.Printf("*** Logs from pod '%s', container '%s':\n----- START -----%s----- END -----\n", tr.Status.PodName, "step-report", reportLog)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(reportLog).Should(ContainSubstring("msg: Pipeline task 'build-container' uses an unacceptable task bundle"))
+			Expect(reportLog).Should(ContainSubstring("Pipeline task 'build-container' uses an unacceptable task bundle"))
 		})
 
 		It("verifies the release policy: Task bundles are latest versions", func() {
@@ -287,7 +287,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 			reportLog, err := utils.GetContainerLogs(fwk.AsKubeAdmin.CommonController.KubeInterface(), tr.Status.PodName, "step-report", namespace)
 			GinkgoWriter.Printf("*** Logs from pod '%s', container '%s':\n----- START -----%s----- END -----\n", tr.Status.PodName, "step-report", reportLog)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(reportLog).Should(ContainSubstring("msg: Pipeline task 'show-summary' uses an unpinned task bundle reference"))
+			Expect(reportLog).Should(ContainSubstring("Pipeline task 'show-summary' uses an unpinned task bundle reference"))
 		})
 	})
 })


### PR DESCRIPTION

# Description

The tests may fail if the error message exceeds a certain length which causes a multi-line string to be used, for example:

```yaml
msg: |-
  No image attestations found matching the given public key
```

Prior to this change, the tests expect it to be:

```yaml
msg: No image attestations found matching the given public key
```

With this change, either format matches.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
