### PR TITLE
test: RHTAPBUGS-556 check first errorBuffer before buffer on spi access control e2e test

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -565,7 +565,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 		AfterAll(func() {
 			if !CurrentSpecReport().Failed() {
 				Expect(f.AsKubeAdmin.HasController.DeleteApplication(applicationName, testNamespace, false)).To(Succeed())
-				Expect(f.SandboxController.DeleteUserSignup(f.UserName)).NotTo(BeFalse())
+				Expect(f.SandboxController.DeleteUserSignup(f.UserName)).To(BeTrue())
 			}
 
 			// Delete new branches created by PaC and a testing branch used as a component's base branch

--- a/tests/spi/access-control.go
+++ b/tests/spi/access-control.go
@@ -260,8 +260,8 @@ spec:
 				Stderr: errBuffer,
 			})
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("reason: %v", err))
+			Expect(errBuffer.String()).To(BeEmpty(), fmt.Sprintf("reason: %v", errBuffer.String()))
 			Expect(buffer.String()).NotTo(BeEmpty())
-			Expect(errBuffer.String()).To(BeEmpty())
 		}
 
 		// check if guest user's pod deployed in guest user's workspace should be able to construct an API request that reads code in the Github repo for primary's user workspace


### PR DESCRIPTION
# Description

Unfortunately, some jobs are failing with an empty buffer string when the guest user makes a POST request to `spifilecontentrequests`, from within a pod.

In order to investigate it (since I was not able to reproduce it locally yet), this PR changes the order of the assertions and improves it to check first if the `errBuffer` is empty in order to get more information, in case it fails.

## Issue ticket number and link
[RHTAPBUGS-556](https://issues.redhat.com/browse/RHTAPBUGS-556)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
