### PR TITLE
chore: include build container memory metrics on load test collection

### DIFF
--- a/tests/load-tests/ci-scripts/max-concurrency/collect-results.sh
+++ b/tests/load-tests/ci-scripts/max-concurrency/collect-results.sh
@@ -79,7 +79,8 @@ ${csv_delim}ClusterPipelineRunCountAvg\
 ${csv_delim}ClusterPipelineWorkqueueDepthAvg\
 ${csv_delim}ClusterPipelineScheduleFirstPodAvg\
 ${csv_delim}ClusterTaskrunThrottledByNodeResourcesAvg\
-${csv_delim}ClusterTaskRunThrottledByDefinedQuotaAvg" \
+${csv_delim}ClusterTaskRunThrottledByDefinedQuotaAvg \
+${csv_delim}ContainerMemoryWorkingSetBytesTestNamespacesBuildContainersAvg" \
     >"$max_concurrency_csv"
 cat $output_dir/load-tests.max-concurrency.*.json |
     jq -rc "(.threads | tostring) \
@@ -99,7 +100,8 @@ cat $output_dir/load-tests.max-concurrency.*.json |
     + $csv_delim_quoted + (.measurements.tekton_tekton_pipelines_controller_workqueue_depth.mean | tostring) \
     + $csv_delim_quoted + (.measurements.pipelinerun_duration_scheduled_seconds.mean | tostring) \
     + $csv_delim_quoted + (.measurements.tekton_pipelines_controller_running_taskruns_throttled_by_node.mean | tostring) \
-    + $csv_delim_quoted + (.measurements.tekton_pipelines_controller_running_taskruns_throttled_by_quota.mean | tostring)" \
+    + $csv_delim_quoted + (.measurements.tekton_pipelines_controller_running_taskruns_throttled_by_quota.mean | tostring) \
+    + $csv_delim_quoted + (.measurements.container_memory_working_set_bytes_test_namespaces_build_containers.mean | tostring)" \
         >>"$max_concurrency_csv"
 
 ## PipelineRun timestamps

--- a/tests/load-tests/cluster_read_config.yaml
+++ b/tests/load-tests/cluster_read_config.yaml
@@ -37,3 +37,7 @@
 - name: measurements.tekton_pipelines_controller_running_taskruns_throttled_by_quota
   monitoring_query: sum(tekton_pipelines_controller_running_taskruns_throttled_by_quota_count)
   monitoring_step: 15
+
+- name: measurements.container_memory_working_set_bytes_test_namespaces_build_containers
+  monitoring_query: sum(container_memory_working_set_bytes{namespace=~'test-rhtap-.*-tenant',pod=~'devfile-sample-.*-build-container-pod'})
+  monitoring_step: 15


### PR DESCRIPTION

# Description

We want to gather build container memory usage during our load tests to understand the difference between using default storage or memory for the buildah root-dir / emptydir volume.

First, we'll see if existing post run collection can obtain container mem (believe… the answer is no though).
If that does not work, we'll see how hard it is to run collection in the background while the test is running.

/assign @pmacik 

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [/] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
