### PR TITLE
feat(RHTAP-1337): Properly cleanup in stage

### DIFF
--- a/cmd/loadTests.go
+++ b/cmd/loadTests.go
@@ -545,13 +545,16 @@ func StageCleanup(users []loadtestUtils.User) {
 
 	for _, user := range users {
 		framework := frameworkForUser(user.Username)
-		err := framework.AsKubeDeveloper.HasController.DeleteAllApplicationsInASpecificNamespace(framework.UserNamespace, 60*time.Minute)
+		err := framework.AsKubeDeveloper.HasController.DeleteAllApplicationsOneByOneInASpecificNamespace(framework.UserNamespace, 5*time.Minute)
 		if err != nil {
 			klog.Errorf("while deleting resources for user: %s, got error: %v\n", user.Username, err)
 		}
 
+		err = framework.AsKubeDeveloper.HasController.DeleteAllComponentDetectionQueriesOneByOneInASpecificNamespace(framework.UserNamespace, 5*time.Minute)
+		if err != nil {
+			klog.Errorf("while deleting component detection queries for user: %s, got error: %v\n", user.Username, err)
+		}
 	}
-
 }
 
 func maxDurationFromArray(durations []time.Duration) time.Duration {

--- a/cmd/loadTests.go
+++ b/cmd/loadTests.go
@@ -545,12 +545,12 @@ func StageCleanup(users []loadtestUtils.User) {
 
 	for _, user := range users {
 		framework := frameworkForUser(user.Username)
-		err := framework.AsKubeDeveloper.HasController.DeleteAllApplicationsOneByOneInASpecificNamespace(framework.UserNamespace, 5*time.Minute)
+		err := framework.AsKubeDeveloper.HasController.DeleteAllApplicationsInASpecificNamespace(framework.UserNamespace, 5*time.Minute)
 		if err != nil {
 			klog.Errorf("while deleting resources for user: %s, got error: %v\n", user.Username, err)
 		}
 
-		err = framework.AsKubeDeveloper.HasController.DeleteAllComponentDetectionQueriesOneByOneInASpecificNamespace(framework.UserNamespace, 5*time.Minute)
+		err = framework.AsKubeDeveloper.HasController.DeleteAllComponentDetectionQueriesInASpecificNamespace(framework.UserNamespace, 5*time.Minute)
 		if err != nil {
 			klog.Errorf("while deleting component detection queries for user: %s, got error: %v\n", user.Username, err)
 		}

--- a/pkg/utils/has/applications.go
+++ b/pkg/utils/has/applications.go
@@ -101,31 +101,6 @@ func (h *HasController) ApplicationDeleted(application *appservice.Application) 
 	}
 }
 
-// DeleteAllApplicationsOneByOneInASpecificNamespace removes all application CRs one by one from a specific namespace.
-// That function is a workaround of the "DeleteAllApplicationsInASpecificNamespace" function which uses the deletecollection verb of the application object which
-// is not permitted as per this PR - https://github.com/codeready-toolchain/toolchain-e2e/pull/774
-// That function uses the list and delete verbs of the application object
-func (h *HasController) DeleteAllApplicationsOneByOneInASpecificNamespace(namespace string, timeout time.Duration) error {
-	applicationList := &appservice.ApplicationList{}
-	if err := h.KubeRest().List(context.Background(), applicationList, &rclient.ListOptions{Namespace: namespace}); err != nil {
-		return fmt.Errorf("error listing applications from the namespace %s: %+v", namespace, err)
-	}
-
-	for i := range applicationList.Items {
-		application := &applicationList.Items[i]
-		if err := h.KubeRest().Delete(context.TODO(), application); err != nil {
-			return fmt.Errorf("error deleting application %s from the namespace %s: %+v", application.Name, namespace, err)
-		}
-	}
-
-	return utils.WaitUntil(func() (done bool, err error) {
-		if err := h.KubeRest().List(context.Background(), applicationList, &rclient.ListOptions{Namespace: namespace}); err != nil {
-			return false, nil
-		}
-		return len(applicationList.Items) == 0, nil
-	}, timeout)
-}
-
 // DeleteAllApplicationsInASpecificNamespace removes all application CRs from a specific namespace. Useful when creating a lot of resources and want to remove all of them
 func (h *HasController) DeleteAllApplicationsInASpecificNamespace(namespace string, timeout time.Duration) error {
 	if err := h.KubeRest().DeleteAllOf(context.TODO(), &appservice.Application{}, rclient.InNamespace(namespace)); err != nil {

--- a/pkg/utils/has/componentdetectionqueries.go
+++ b/pkg/utils/has/componentdetectionqueries.go
@@ -72,31 +72,6 @@ func (h *HasController) CreateComponentDetectionQueryWithTimeout(name string, na
 	return componentDetectionQuery, nil
 }
 
-// DeleteAllComponentDetectionQueriesOneByOneInASpecificNamespace removes all CDQs CRs one by one from a specific namespace.
-// That function is a workaround of the "DeleteAllComponentDetectionQueriesInASpecificNamespace" function which uses the deletecollection verb of the CDQ object which
-// is not permitted as per this PR - https://github.com/codeready-toolchain/toolchain-e2e/pull/774
-// That function uses the list and delete verbs of the CDQ object
-func (h *HasController) DeleteAllComponentDetectionQueriesOneByOneInASpecificNamespace(namespace string, timeout time.Duration) error {
-	componentDetectionQueriesList := &appservice.ComponentDetectionQueryList{}
-	if err := h.KubeRest().List(context.Background(), componentDetectionQueriesList, &rclient.ListOptions{Namespace: namespace}); err != nil {
-		return fmt.Errorf("error listing component detection queries from the namespace %s: %+v", namespace, err)
-	}
-
-	for i := range componentDetectionQueriesList.Items {
-		query := &componentDetectionQueriesList.Items[i]
-		if err := h.KubeRest().Delete(context.TODO(), query); err != nil {
-			return fmt.Errorf("error deleting component detection query %s from the namespace %s: %+v", query.Name, namespace, err)
-		}
-	}
-
-	return utils.WaitUntil(func() (done bool, err error) {
-		if err := h.KubeRest().List(context.Background(), componentDetectionQueriesList, &rclient.ListOptions{Namespace: namespace}); err != nil {
-			return false, nil
-		}
-		return len(componentDetectionQueriesList.Items) == 0, nil
-	}, timeout)
-}
-
 // DeleteAllComponentDetectionQueriesInASpecificNamespace removes all CDQs CRs from a specific namespace. Useful when creating a lot of resources and want to remove all of them
 func (h *HasController) DeleteAllComponentDetectionQueriesInASpecificNamespace(namespace string, timeout time.Duration) error {
 	if err := h.KubeRest().DeleteAllOf(context.TODO(), &appservice.ComponentDetectionQuery{}, rclient.InNamespace(namespace)); err != nil {


### PR DESCRIPTION
Add StageCleanupSingle function to cleanup component and CDQ per user

# Description
Figure out how to properly do a cleanup in Stage
We noticed that StageCleanup(selectedUsers) after the load-test didn't clean the user's CDQ so
I have fixed the StageCleanup function executed after the load-tests, tht function delete all the user's applications and
CDQs in the user's namespace

Dependencies:
1. framework.AsKubeDeveloper.HasController.DeleteAllApplicationsOneByOneInASpecificNamespace - 
    a new function in pkg/utils/has/applications.go
2. framework.AsKubeDeveloper.HasController.DeleteAllComponentDetectionQueriesOneByOneInASpecificNamespace - 
    a new function I've created in pkg/utils/has/componentdetectionqueries.go
    
Both functions were needed because the deletecollection verb for the application, component, CDQ object isn't supported anymore (https://github.com/codeready-toolchain/toolchain-e2e/pull/774)    
So the new functions are using the supported list and delete verbs

## Issue ticket number and link
https://issues.redhat.com/browse/RHTAP-1337

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
By running the load-test in Stage and testing that the load-tests succeeded (because if the user's resources would not have been deleted before the load-test, the resource creation cycle would have failed 
After each load-test the user's CDQ are not deleted, but once the load-tests starts it specifically deletes all the user's components and CDQs 
The deletion of the components was to be on the safe side to delete the objects in their reverse creation order
Since the CDQ is created before the component, hence I made sure to delete the components before the CDQs 

Run the following command line to load-test on stage - 
export USERS_PER_THREAD=3                                                                                                                                                                                                                
export THREADS=3
export COMPONENT_REPO='https://github.com/naftalysh-org/devfile-sample-code-with-quarkus'
./run-stage.sh
 


# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
