### PR TITLE
fix: spi: repository name typo

### DIFF
--- a/tests/spi/quay-imagepullsecret-usage.go
+++ b/tests/spi/quay-imagepullsecret-usage.go
@@ -208,7 +208,7 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "quay-imagepullsecret-usag
 			It("creates taskrun", func() {
 				srcImageURL := fmt.Sprintf("docker://%s", TestQuayPrivateRepoURL)
 				destTag := fmt.Sprintf("spi-test-%s", strings.Replace(uuid.New().String(), "-", "", -1))
-				destImageURL := fmt.Sprintf("docker://%s/%s", QuayPrivateRepoURL, destTag)
+				destImageURL := fmt.Sprintf("docker://%s:%s", QuayPrivateRepoURL, destTag)
 
 				TaskRun, err = fw.AsKubeAdmin.TektonController.CreateTaskRunCopy(taskRunName, namespace, serviceAccountName, srcImageURL, destImageURL)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
# Description

this typo introduced in [this PR](https://github.com/redhat-appstudio/e2e-tests/pull/558/files#diff-187fb95c8b52e8469e782ef42317b23127605df981ac319badb89aaf5b5be682R211) resulted in hundreds of repositories being created in quay.io org account 🤦  

![Screenshot 2023-08-14 at 12 50 42](https://github.com/redhat-appstudio/e2e-tests/assets/4881144/9b7ade1f-b3f1-476d-bcb8-89d6772370cf)

I'm currently cleaning up these repositories from quay.io. After merging this PR (and rebasing other PRs) no other repos like this should get created anymore

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

N/A

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
