### PR TITLE
feat: Enable existing tests working with Pac+ Github App

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,28 @@ $ go mod vendor
 
 **It is recommended to use your fork of [infra-deployments repo](https://github.com/redhat-appstudio/infra-deployments) in your GitHub org instead** - you can change the GitHub organization with environment variable `export MY_GITHUB_ORG=<name-of-your-github-org>`.
 
+Some tests could require you have a Github App created in order to test Component builds via Pipelines as Code. 
+Such tests are [rhtap-demo](https://github.com/redhat-appstudio/e2e-tests/blob/main/tests/rhtap-demo/rhtap-demo.go) and [build](https://github.com/redhat-appstudio/e2e-tests/blob/main/tests/build/build.go).
+
+In this case, before you bootstrap a cluster, make sure you [created a Github App for your GitHub account](https://github.com/settings/apps). Fill in following details:
+* **GitHub App name**: unique app name
+* **Homepage URL**: some dummy URL (like https://example.com)
+* **Webhook**: mark as active and put some dummy URL to the **Webhook URL** field
+* **Permissions** and **Subscribe to events**: refer to [the guide in PaC documentation](https://pipelinesascode.com/docs/install/github_apps/#setup-manually)
+* **Where can this GitHub App be installed?**: Any account
+
+Hit create, make a note of the **App ID** and navigate to the **Private keys** section where you generate a private key that gets downloaded automatically. Then export following environment variables (or if you're using [.env file](default.env), update values of following variables):
+
+```
+export E2E_PAC_GITHUB_APP_ID='<YOUR_APP_ID>'
+
+export E2E_PAC_GITHUB_APP_PRIVATE_KEY=$(base64 < /PATH/TO/YOUR/DOWNLOADED/PRIVATE_KEY.pem)
+```
+
+Navigate back to [your GitHub App](https://github.com/settings/apps), select **Install App** and select your GitHub org (the one that you're using in `MY_GITHUB_ORG` env var). Feel free to install it to all repositories of that organization or the **forked repositories** currently used by [rhtap-demo](https://github.com/redhat-appstudio/e2e-tests/blob/main/tests/rhtap-demo/rhtap-demo.go) and [build](https://github.com/redhat-appstudio/e2e-tests/blob/main/tests/build/build.go) tests ([`hacbs-test-project`](https://github.com/redhat-appstudio-qe/hacbs-test-project) and [`devfile-sample-hello-world`](https://github.com/redhat-appstudio-qe/devfile-sample-hello-world)).
+
+For bootstrapping a cluster, run the following command:
+
    ```bash
       make local/cluster/prepare
    ```

--- a/default.env
+++ b/default.env
@@ -75,3 +75,13 @@ export KLOG_VERBOSITY='1'
 # Example: 5d
 # Required: no
 export IMAGE_TAG_EXPIRATION='6h'
+
+# A github appid used to set up Pac integerating with Github App
+# Note: how to get Github App ID https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation#using-octokitjs-to-authenticate-with-an-installation-id
+# Required: only for running tests that are using PaC (see README.md for more details)
+export E2E_PAC_GITHUB_APP_ID=''
+
+# A github private key in base64 format used to set up Pac integerating with Github App
+# Note: How to get private key https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps
+# Required: only for running tests that are using PaC (see README.md for more details)
+export E2E_PAC_GITHUB_APP_PRIVATE_KEY=''

--- a/magefiles/installation/install.go
+++ b/magefiles/installation/install.go
@@ -123,6 +123,8 @@ func (i *InstallAppStudio) setInstallationEnvironments() {
 	os.Setenv("IMAGE_CONTROLLER_QUAY_ORG", i.DefaultImageQuayOrg)
 	os.Setenv("IMAGE_CONTROLLER_QUAY_TOKEN", i.DefaultImageQuayOrgOAuth2Token)
 	os.Setenv("BUILD_SERVICE_IMAGE_TAG_EXPIRATION", i.DefaultImageTagExpiration)
+	os.Setenv("PAC_GITHUB_APP_ID", utils.GetEnv("E2E_PAC_GITHUB_APP_ID", ""))  // #nosec G104
+	os.Setenv("PAC_GITHUB_APP_PRIVATE_KEY", utils.GetEnv("E2E_PAC_GITHUB_APP_PRIVATE_KEY", "")) // #nosec G104
 }
 
 func (i *InstallAppStudio) cloneInfraDeployments() (*git.Remote, error) {

--- a/magefiles/sprayproxy.go
+++ b/magefiles/sprayproxy.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	routev1 "github.com/openshift/api/route/v1"
+	kubeCl "github.com/redhat-appstudio/e2e-tests/pkg/apis/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	SPRAYPROXY_NAMESPACE = "sprayproxy"
+	ROUTE_NAME            = "sprayproxy-route"
+	PAC_NAMESPACE = "openshift-pipelines"
+	PAC_ROUTE_NAME = "pipelines-as-code-controller"
+)
+
+type SprayProxy struct {
+	BaseURL    string
+	Token      string
+	HTTPClient *http.Client
+}
+
+func NewSprayProxy(url string, token string) *SprayProxy {
+	return &SprayProxy{
+		BaseURL: url,
+		Token:   token,
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					// #nosec G402
+					InsecureSkipVerify: true,
+				},
+			},
+		},
+	}
+}
+
+func (s *SprayProxy) RegisterServer(hostUrl string) (string, error) {
+	result, err := s.sendRequest(hostUrl, http.MethodPost)
+	if err != nil {
+		return "", err
+	}
+
+	return result, nil
+}
+
+func (s *SprayProxy) UnegisterServer(hostUrl string) (string, error) {
+	result, err := s.sendRequest(hostUrl, http.MethodDelete)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+func (s *SprayProxy) GetServers() (string, error) {
+	result, err := s.sendRequest("", http.MethodGet)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+func (s *SprayProxy) sendRequest(hostUrl string, httpMethod string) (string, error) {
+	requestURL := s.BaseURL + "/backends"
+
+	data := make(map[string]string)
+	data["url"] = hostUrl
+	bytesData, _ := json.Marshal(data)
+
+	req, err := http.NewRequest(httpMethod, requestURL, bytes.NewReader(bytesData))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.Token))
+	
+	res, err := s.HTTPClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to access SprayProxy server with status code: %d and\nbody: %s", res.StatusCode, string(body))
+	}
+
+	defer res.Body.Close()
+
+	return string(body), err
+}
+
+func GetPod() (*corev1.Pod, error) {
+	k8sClient, err := kubeCl.NewAdminKubernetesClient()
+	if err != nil {
+		return nil, err
+	}
+	podList, err := k8sClient.KubeInterface().CoreV1().Pods(SPRAYPROXY_NAMESPACE).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, pod := range podList.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			return &pod, nil
+		}
+	}
+	return nil, fmt.Errorf("no running pod found in namespace %s", SPRAYPROXY_NAMESPACE)
+}
+
+func GetPacRoute() (*routev1.Route, error) {
+	k8sClient, err := kubeCl.NewAdminKubernetesClient()
+	if err != nil {
+		return nil, err
+	}
+
+	namespaceName := types.NamespacedName{
+		Name:      PAC_ROUTE_NAME,
+		Namespace: PAC_NAMESPACE,
+	}
+
+	route := &routev1.Route{}
+	err = k8sClient.KubeRest().Get(context.TODO(), namespaceName, route)
+	if err != nil {
+		return &routev1.Route{}, err
+	}
+	return route, nil
+}

--- a/pkg/apis/github/pull_request.go
+++ b/pkg/apis/github/pull_request.go
@@ -46,3 +46,11 @@ func (g *Github) MergePullRequest(repository string, prNumber int) (*github.Pull
 
 	return mergeResult, nil
 }
+
+func (g *Github) ListCheckSuites(repository string, ref string) ([]*github.CheckSuite, error) {
+	checkSuiteResults, _, err := g.client.Checks.ListCheckSuitesForRef(context.Background(), g.organization, repository, ref, &github.ListCheckSuiteOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error when listing check suites for the repo %s: %v", repository, err)
+	}
+	return checkSuiteResults.CheckSuites, nil
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -126,6 +126,8 @@ const (
 	JsonStageUsersPath = "users.json"
 
 	SamplePrivateRepoName = "test-private-repo"
+	// Github App name is RHTAP-Qe-App. Note: this App ID is used in our CI and can't be used for local dev/testing.
+	DefaultPaCGitHubAppID = "310332"
 )
 
 var (

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -405,4 +406,14 @@ func GetContainerLogs(ki kubernetes.Interface, podName, containerName, namespace
 func ExtractGitRepositoryNameFromURL(url string) (name string) {
 	repoName := url[strings.LastIndex(url, "/")+1:]
 	return strings.TrimSuffix(repoName, ".git")
+}
+
+func GetGithubAppID() (int64, error) {
+	appIDStr := GetEnv("E2E_PAC_GITHUB_APP_ID", constants.DefaultPaCGitHubAppID)
+
+	id, err := strconv.ParseInt(appIDStr, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
 }

--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -68,7 +68,7 @@ const (
 	releasePollingInterval    = time.Second * 1
 )
 
-//var supportedRuntimes = []string{"Dockerfile", "Node.js", "Go", "Quarkus", "Python", "JavaScript", "springboot", "dotnet", "maven"}
+// var supportedRuntimes = []string{"Dockerfile", "Node.js", "Go", "Quarkus", "Python", "JavaScript", "springboot", "dotnet", "maven"}
 
 var _ = framework.RhtapDemoSuiteDescribe(Label("rhtap-demo"), func() {
 	defer GinkgoRecover()


### PR DESCRIPTION
# Description

This PR is to modify the exiting Pac test to adapt Github App  and add logics for registering/unregistering Pac server. It depends on the PRs [42057](https://github.com/openshift/release/pull/42057) , [2207](https://github.com/redhat-appstudio/infra-deployments/pull/2207) , [2267](https://github.com/redhat-appstudio/infra-deployments/pull/2267) and [42622](https://github.com/openshift/release/pull/42622) 


## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
