### PR TITLE
fix(load-test): Do not show respective progress bars when not waiting for pipelines, deployments or integration tests

### DIFF
--- a/cmd/loadTests.go
+++ b/cmd/loadTests.go
@@ -327,17 +327,26 @@ func setup(cmd *cobra.Command, args []string) {
 		return strutil.PadLeft(fmt.Sprintf("Creating AppStudio User Resources (%d/%d) [%d failed]", b.Current(), overallCount, sumFromArray(FailedResourceCreationsPerThread)), barLength, ' ')
 	})
 
-	PipelinesBar := uip.AddBar(overallCount).AppendCompleted().PrependFunc(func(b *uiprogress.Bar) string {
-		return strutil.PadLeft(fmt.Sprintf("Waiting for pipelines to finish (%d/%d) [%d failed]", b.Current(), overallCount, sumFromArray(FailedPipelineRunsPerThread)), barLength, ' ')
-	})
+	var PipelinesBar *uiprogress.Bar
+	if waitPipelines {
+		PipelinesBar = uip.AddBar(overallCount).AppendCompleted().PrependFunc(func(b *uiprogress.Bar) string {
+			return strutil.PadLeft(fmt.Sprintf("Waiting for pipelines to finish (%d/%d) [%d failed]", b.Current(), overallCount, sumFromArray(FailedPipelineRunsPerThread)), barLength, ' ')
+		})
+	}
 
-	IntegrationTestsPipelinesBar := uip.AddBar(overallCount).AppendCompleted().PrependFunc(func(b *uiprogress.Bar) string {
-		return strutil.PadLeft(fmt.Sprintf("Waiting for Integration Test pipelines to finish (%d/%d) [%d failed]", b.Current(), overallCount, sumFromArray(FailedIntegrationTestsPipelineRunsPerThread)), barLength, ' ')
-	})
+	var IntegrationTestsPipelinesBar *uiprogress.Bar
+	if waitIntegrationTestsPipelines {
+		IntegrationTestsPipelinesBar = uip.AddBar(overallCount).AppendCompleted().PrependFunc(func(b *uiprogress.Bar) string {
+			return strutil.PadLeft(fmt.Sprintf("Waiting for Integration Test pipelines to finish (%d/%d) [%d failed]", b.Current(), overallCount, sumFromArray(FailedIntegrationTestsPipelineRunsPerThread)), barLength, ' ')
+		})
+	}
 
-	DeploymentsBar := uip.AddBar(overallCount).AppendCompleted().PrependFunc(func(b *uiprogress.Bar) string {
-		return strutil.PadLeft(fmt.Sprintf("Waiting for deployments to finish (%d/%d) [%d failed]", b.Current(), overallCount, sumFromArray(FailedDeploymentsPerThread)), barLength, ' ')
-	})
+	var DeploymentsBar *uiprogress.Bar
+	if waitDeployments {
+		DeploymentsBar = uip.AddBar(overallCount).AppendCompleted().PrependFunc(func(b *uiprogress.Bar) string {
+			return strutil.PadLeft(fmt.Sprintf("Waiting for deployments to finish (%d/%d) [%d failed]", b.Current(), overallCount, sumFromArray(FailedDeploymentsPerThread)), barLength, ' ')
+		})
+	}
 
 	UserCreationTimeMaxPerThread = make([]time.Duration, threadCount)
 	ResourceCreationTimeMaxPerThread = make([]time.Duration, threadCount)

--- a/tests/load-tests/run-max-concurrency.sh
+++ b/tests/load-tests/run-max-concurrency.sh
@@ -15,7 +15,9 @@ load_test() {
         --component-repo "${COMPONENT_REPO:-https://github.com/nodeshift-starters/devfile-sample.git}" \
         --username "$USER_PREFIX-$index" \
         --users 1 \
-        -w \
+        -w="${WAIT_PIPELINES:-true}" \
+        -i="${WAIT_INTEGRATION_TESTS:-false}" \
+        -d="${WAIT_DEPLOYMENTS:-false}" \
         -l \
         -t "$threads" \
         --disable-metrics \

--- a/tests/load-tests/run-stage.sh
+++ b/tests/load-tests/run-stage.sh
@@ -6,10 +6,10 @@ go run loadtest.go \
     --test-scenario-revision "${TEST_SCENARIO_REVISION:-main}" \
     --test-scenario-path-in-repo "${TEST_SCENARIO_PATH_IN_REPO:-pipelines/integration_resolver_pipeline_pass.yaml}" \
     -s \
-    -w \
-    -i \
-    -d \
+    -w="${WAIT_PIPELINES:-true}" \
+    -i="${WAIT_INTEGRATION_TESTS:-true}" \
+    -d="${WAIT_DEPLOYMENTS:-true}" \
     -l \
     -t "${THREADS:-1}" \
     --disable-metrics \
-    --pipeline-skip-initial-checks="${PIPELINE_SKIP_INITIAL_CHECKS:-true}" 
+    --pipeline-skip-initial-checks="${PIPELINE_SKIP_INITIAL_CHECKS:-true}"

--- a/tests/load-tests/run.sh
+++ b/tests/load-tests/run.sh
@@ -40,16 +40,16 @@ else
         --test-scenario-git-url "${TEST_SCENARIO_GIT_URL:-https://github.com/redhat-appstudio/integration-examples.git}" \
         --test-scenario-revision "${TEST_SCENARIO_REVISION:-main}" \
         --test-scenario-path-in-repo "${TEST_SCENARIO_PATH_IN_REPO:-pipelines/integration_resolver_pipeline_pass.yaml}" \
-        -w \
-        -i \
-        -d \
+        -w="${WAIT_PIPELINES:-true}" \
+        -i="${WAIT_INTEGRATION_TESTS:-true}" \
+        -d="${WAIT_DEPLOYMENTS:-true}" \
         -l \
         -t "${THREADS:-1}" \
         --disable-metrics \
-        --pipeline-skip-initial-checks="${PIPELINE_SKIP_INITIAL_CHECKS:-true}" 
-        
+        --pipeline-skip-initial-checks="${PIPELINE_SKIP_INITIAL_CHECKS:-true}"
+
     DRY_RUN=false ./clear.sh "$USER_PREFIX"
-    
+
     if [ "${TEKTON_PERF_ENABLE_PROFILING:-}" == "true" ]; then
         echo "Waiting for the Tekton controller profiling to finish up to ${TEKTON_PERF_PROFILE_CPU_PERIOD}s"
         wait "$TEKTON_PROFILER_PID"


### PR DESCRIPTION
# Description

Currently, the progress bars are shown for deployments, integration tests and pipelines is shown and handled even when the load test is not set to wait for those.

With this PR the progress bars are only handled and shown for those phases, that are enabled.

That in case of max-concurrency scenario (that has the deployments and integration tests disabled) leads to failures and timeouts.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
