### PR TITLE
feat(RHTAP-1415): Make it possible to specify output directory for load test

### DIFF
--- a/cmd/loadTests.go
+++ b/cmd/loadTests.go
@@ -47,6 +47,7 @@ var (
 	threadCount                   int
 	pipelineSkipInitialChecks     bool
 	stage                         bool
+	outputDir                     string = "."
 )
 
 var (
@@ -202,6 +203,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&disableMetrics, "disable-metrics", false, "if you want to disable metrics gathering")
 	rootCmd.Flags().IntVarP(&threadCount, "threads", "t", 1, "number of concurrent threads to execute")
 	rootCmd.Flags().BoolVar(&pipelineSkipInitialChecks, "pipeline-skip-initial-checks", true, "if pipeline runs' initial checks are to be skipped")
+	rootCmd.Flags().StringVarP(&outputDir, "output-dir", "o", ".", "directory where output files such as load-tests.log or load-tests.json are stored")
 }
 
 func logError(errCode int, message string) {
@@ -250,7 +252,7 @@ func setup(cmd *cobra.Command, args []string) {
 	// waitIntegrationTestsPipelines sets waitPipelines=true implicitly
 	waitPipelines = waitPipelines || waitIntegrationTestsPipelines
 
-	logFile, err := os.Create("load-tests.log")
+	logFile, err := os.Create(fmt.Sprintf("%s/load-tests.log", outputDir))
 	if err != nil {
 		klog.Fatalf("Error creating log file: %v", err)
 	}
@@ -532,7 +534,7 @@ func setup(cmd *cobra.Command, args []string) {
 	logData.ErrorsTotal = len(logData.Errors)
 	klog.Infof("Total number of errors occured: %d", logData.ErrorsTotal)
 
-	err = createLogDataJSON("load-tests.json", logData)
+	err = createLogDataJSON(fmt.Sprintf("%s/load-tests.json", outputDir), logData)
 	if err != nil {
 		klog.Errorf("error while marshalling JSON: %v\n", err)
 	}

--- a/tests/load-tests/ci-scripts/collect-results.sh
+++ b/tests/load-tests/ci-scripts/collect-results.sh
@@ -9,13 +9,15 @@ source "/usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${1:
 
 pushd "${2:-.}"
 
+output_dir="${OUTPUT_DIR:-./tests/load-tests}"
+
 source "./tests/load-tests/ci-scripts/user-prefix.sh"
 
 echo "Collecting load test results"
 load_test_log=$ARTIFACT_DIR/load-tests.log
-cp -vf ./tests/load-tests/*.log "$ARTIFACT_DIR"
-cp -vf ./tests/load-tests/load-tests.json "$ARTIFACT_DIR"
-cp -vf ./tests/load-tests/gh-rate-limits-remaining.csv "$ARTIFACT_DIR"
+cp -vf $output_dir/*.log "$ARTIFACT_DIR"
+cp -vf $output_dir/load-tests.json "$ARTIFACT_DIR"
+cp -vf $output_dir/gh-rate-limits-remaining.csv "$ARTIFACT_DIR"
 
 pipelineruns_json=$ARTIFACT_DIR/pipelineruns.json
 taskruns_json=$ARTIFACT_DIR/taskruns.json
@@ -138,7 +140,7 @@ set -u
 ## Tekton prifiling data
 if [ "${TEKTON_PERF_ENABLE_PROFILING:-}" == "true" ]; then
     echo "Collecting profiling data from Tekton controller"
-    pprof_profile=tests/load-tests/cpu-profile.pprof
+    pprof_profile="$output_dir/cpu-profile.pprof"
     go tool pprof -text "$pprof_profile" >$ARTIFACT_DIR/cpu-profile.txt
     go tool pprof -svg -output="$ARTIFACT_DIR/cpu-profile.svg" "$pprof_profile"
 fi

--- a/tests/load-tests/ci-scripts/load-test.sh
+++ b/tests/load-tests/ci-scripts/load-test.sh
@@ -15,7 +15,7 @@ export QUAY_E2E_ORGANIZATION MY_GITHUB_ORG GITHUB_TOKEN TEKTON_PERF_ENABLE_PROFI
 QUAY_E2E_ORGANIZATION=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/quay-org)
 MY_GITHUB_ORG=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/github-org)
 
-rate_limits_csv=./gh-rate-limits-remaining.csv
+rate_limits_csv="${OUTPUT_DIR:-.}/gh-rate-limits-remaining.csv"
 
 echo "Starting a watch for GH rate limits remainig"
 IFS="," read -ra kvs <<<"$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/github_accounts)"

--- a/tests/load-tests/run-stage.sh
+++ b/tests/load-tests/run-stage.sh
@@ -10,6 +10,7 @@ go run loadtest.go \
     -i="${WAIT_INTEGRATION_TESTS:-true}" \
     -d="${WAIT_DEPLOYMENTS:-true}" \
     -l \
+    -o "${OUTPUT_DIR:-.}" \
     -t "${THREADS:-1}" \
     --disable-metrics \
     --pipeline-skip-initial-checks="${PIPELINE_SKIP_INITIAL_CHECKS:-true}"

--- a/tests/load-tests/run.sh
+++ b/tests/load-tests/run.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 export MY_GITHUB_ORG GITHUB_TOKEN
 
+output_dir="${OUTPUT_DIR:-.}"
+
 USER_PREFIX=${USER_PREFIX:-testuser}
 # Max length of compliant username is 20 characters. We add "-XXXX" suffix for the test users' name so max length of the prefix is 15.
 # See https://github.com/codeready-toolchain/toolchain-common/blob/master/pkg/usersignup/usersignup.go#L16
@@ -12,7 +14,7 @@ else
     if [ "${TEKTON_PERF_ENABLE_PROFILING:-}" == "true" ]; then
         echo "Starting CPU profiling with pprof"
         TEKTON_PERF_PROFILE_CPU_PERIOD=${TEKTON_PERF_PROFILE_CPU_PERIOD:-300}
-        oc exec -n openshift-pipelines $(oc get pods -n openshift-pipelines -l app=tekton-pipelines-controller -o name) -- bash -c "curl -SsL --max-time $((TEKTON_PERF_PROFILE_CPU_PERIOD + 10)) localhost:8008/debug/pprof/profile?seconds=${TEKTON_PERF_PROFILE_CPU_PERIOD} | base64" | base64 -d >cpu-profile.pprof &
+        oc exec -n openshift-pipelines $(oc get pods -n openshift-pipelines -l app=tekton-pipelines-controller -o name) -- bash -c "curl -SsL --max-time $((TEKTON_PERF_PROFILE_CPU_PERIOD + 10)) localhost:8008/debug/pprof/profile?seconds=${TEKTON_PERF_PROFILE_CPU_PERIOD} | base64" | base64 -d >"$output_dir/cpu-profile.pprof" &
         TEKTON_PROFILER_PID=$!
     fi
     ## Switch KubeScheduler Debugging on
@@ -29,7 +31,7 @@ else
         echo "Waiting for all kube scheduler pods to finish NodeInstallerProgressing"
         oc wait --for=condition=NodeInstallerProgressing=False kubescheduler/cluster -n openshift-kube-scheduler --timeout=900s
         echo "All kube scheduler pods are now at log level $KUBE_SCHEDULER_LOG_LEVEL, starting to capture logs"
-        oc logs -f -n openshift-kube-scheduler --prefix -l app=openshift-kube-scheduler --tail=-1 2>&1 >openshift-kube-scheduler.log &
+        oc logs -f -n openshift-kube-scheduler --prefix -l app=openshift-kube-scheduler --tail=-1 2>&1 >"$output_dir/openshift-kube-scheduler.log" &
         KUBE_SCHEDULER_LOG_PID=$!
     fi
     ## Run the actual load test
@@ -44,6 +46,7 @@ else
         -i="${WAIT_INTEGRATION_TESTS:-true}" \
         -d="${WAIT_DEPLOYMENTS:-true}" \
         -l \
+        -o "$output_dir" \
         -t "${THREADS:-1}" \
         --disable-metrics \
         --pipeline-skip-initial-checks="${PIPELINE_SKIP_INITIAL_CHECKS:-true}"


### PR DESCRIPTION
# Description

Currently, the output files generated by the load test (such as `load-tests.json`) are always stored under `tests/load-tests` directory.

This PR introduces `OUTPUT_DIR` env variable that can be used to specify the directory where those files are stored instead. That is useful in CI and makes it easy to [share the output files between steps](https://docs.ci.openshift.org/docs/architecture/step-registry/#sharing-data-between-steps) of the CI workflow.

That is necessary for [splitting the load test run and result collection in CI](https://github.com/openshift/release/pull/42332) each being part of a different step of the workflow (load-test in `test` step and collect-results in `post` step.

The default value of the `OUTPUT_DIR` is `.` which corresponds to the current behavior for backwards compatibility.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
