### PR TITLE
feat: Private image repo flow

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -124,11 +124,14 @@ const (
 	PipelineRunPollingInterval = 10 * time.Second
 
 	JsonStageUsersPath = "users.json"
+
+	SamplePrivateRepoName = "test-private-repo"
 )
 
 var (
-	ComponentDefaultLabel                      = map[string]string{"e2e-test": "true"}
-	ComponentPaCRequestAnnotation              = map[string]string{"build.appstudio.openshift.io/request": "configure-pac"}
-	ComponentTriggerSimpleBuildAnnotation      = map[string]string{"build.appstudio.openshift.io/request": "trigger-simple-build"}
-	ImageControllerAnnotationRequestPublicRepo = map[string]string{"image.redhat.com/generate": `{"visibility": "public"}`}
+	ComponentDefaultLabel                       = map[string]string{"e2e-test": "true"}
+	ComponentPaCRequestAnnotation               = map[string]string{"build.appstudio.openshift.io/request": "configure-pac"}
+	ComponentTriggerSimpleBuildAnnotation       = map[string]string{"build.appstudio.openshift.io/request": "trigger-simple-build"}
+	ImageControllerAnnotationRequestPublicRepo  = map[string]string{"image.redhat.com/generate": `{"visibility": "public"}`}
+	ImageControllerAnnotationRequestPrivateRepo = map[string]string{"image.redhat.com/generate": `{"visibility": "private"}`}
 )

--- a/pkg/utils/build/quay.go
+++ b/pkg/utils/build/quay.go
@@ -106,17 +106,10 @@ func DoesTagExistsInQuay(imageURL string) (bool, error) {
 }
 
 func IsImageRepoPublic(quayImageRepoName string) (bool, error) {
-	isPublic, err := quayClient.IsRepositoryPublic(quayOrg, quayImageRepoName)
-	if isPublic {
-		return true, nil
-	} else if !isPublic && err == nil {
-		return false, nil
-	} else {
-		return false, err
-	}
+	return quayClient.IsRepositoryPublic(quayOrg, quayImageRepoName)
 }
 
-func IsQuayOrgSupportsPrivateRepo() (bool, error) {
+func DoesQuayOrgSupportPrivateRepo() (bool, error) {
 	repositoryRequest := quay.RepositoryRequest{
 		Namespace:   quayOrg,
 		Visibility:  "private",
@@ -133,6 +126,11 @@ func IsQuayOrgSupportsPrivateRepo() (bool, error) {
 	}
 	if repo == nil {
 		return false, fmt.Errorf("%v repository created is nil", repo)
+	}
+	// Delete the created image repo
+	_, err = DeleteImageRepo(constants.SamplePrivateRepoName)
+	if err != nil {
+		return true, fmt.Errorf("error while deleting private image repo: %v", err)
 	}
 	return true, nil
 }

--- a/pkg/utils/has/components.go
+++ b/pkg/utils/has/components.go
@@ -159,7 +159,8 @@ func (h *HasController) CreateComponent(componentSpec appservice.ComponentSpec, 
 	}
 	if outputContainerImage != "" {
 		componentObject.Spec.ContainerImage = outputContainerImage
-	} else {
+	} else if componentObject.Annotations["image.redhat.com/generate"] == "" {
+		// Generate default public image repo since nothing is mentioned specifically
 		componentObject.Annotations = utils.MergeMaps(componentObject.Annotations, constants.ImageControllerAnnotationRequestPublicRepo)
 	}
 

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -61,7 +61,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				Skip("Using private cluster (not reachable from Github), skipping...")
 			}
 
-			supports, err := build.IsQuayOrgSupportsPrivateRepo()
+			supports, err := build.DoesQuayOrgSupportPrivateRepo()
 			Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("error while checking if quay org supports private repo: %+v", err))
 			if !supports {
 				Skip("Quay org does not support private quay repository creation, please add support for private repo creation before running this test")
@@ -131,9 +131,6 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			_, err = build.DeleteImageRepo(imageRepoName)
 			Expect(err).NotTo(HaveOccurred(), "Failed to delete image repo with error: %+v", err)
 
-			// Delete the sample private image repo created for checking inside build.IsQuayOrgSupportsPrivateRepo()
-			_, err = build.DeleteImageRepo(constants.SamplePrivateRepoName)
-			Expect(err).NotTo(HaveOccurred(), "Failed to delete sample private image repo with error: %+v", err)
 		})
 
 		When("a new component without specified branch is created and with visibility private", Label("pac-custom-default-branch"), func() {


### PR DESCRIPTION
# Description

This PR included tests step related to private repository requests by image-controller and switching between `public` to `private` after the image got created.

## Issue ticket number and link
https://issues.redhat.com/browse/STONEBLD-1601

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally using my quay org, subscribing to private organizations.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
