### PR TITLE
fix: replace deprecated annotations 

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -124,6 +124,6 @@ const (
 
 var (
 	ComponentDefaultLabel                      = map[string]string{"e2e-test": "true"}
-	ComponentPaCRequestAnnotation              = map[string]string{"appstudio.openshift.io/pac-provision": "request"}
+	ComponentPaCRequestAnnotation              = map[string]string{"build.appstudio.openshift.io/request": "configure-pac"}
 	ImageControllerAnnotationRequestPublicRepo = map[string]string{"image.redhat.com/generate": `{"visibility": "public"}`}
 )

--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -616,7 +616,7 @@ var _ = framework.RhtapDemoSuiteDescribe(Label("rhtap-demo"), func() {
 								BeforeAll(func() {
 									comp, err := fw.AsKubeAdmin.HasController.GetComponent(component.GetName(), fw.UserNamespace)
 									Expect(err).ShouldNot(HaveOccurred())
-									comp.Annotations["appstudio.openshift.io/pac-provision"] = "delete"
+									comp.Annotations["build.appstudio.openshift.io/request"] = "unconfigure-pac"
 									Expect(fw.AsKubeAdmin.CommonController.KubeRest().Update(context.TODO(), comp)).To(Succeed())
 								})
 								AfterAll(func() {


### PR DESCRIPTION
Use build.appstudio.openshift.io/request instead of the depracated appstudio.openshift.io/pac-provision

[STONEBLD-1315](https://issues.redhat.com//browse/STONEBLD-1315)

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
