### PR TITLE
refactor: tekton.VerifyEnterpriseContract

### DIFF
--- a/pkg/utils/tekton/controller.go
+++ b/pkg/utils/tekton/controller.go
@@ -363,7 +363,10 @@ func (k KubeController) GetTaskRunStatus(c crclient.Client, pr *v1beta1.Pipeline
 }
 
 func (k KubeController) RunPipeline(g PipelineRunGenerator, taskTimeout int) (*v1beta1.PipelineRun, error) {
-	pr := g.Generate()
+	pr, err := g.Generate()
+	if err != nil {
+		return nil, err
+	}
 	pvcs := k.Commonctrl.KubeInterface().CoreV1().PersistentVolumeClaims(pr.Namespace)
 	for _, w := range pr.Spec.Workspaces {
 		if w.PersistentVolumeClaim != nil {

--- a/pkg/utils/tekton/pipelines.go
+++ b/pkg/utils/tekton/pipelines.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strconv"
 
-	. "github.com/onsi/ginkgo/v2"
 	g "github.com/onsi/ginkgo/v2"
 
 	app "github.com/redhat-appstudio/application-api/api/v1alpha1"
@@ -19,8 +18,10 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const sslCertDir = "/var/run/secrets/kubernetes.io/serviceaccount"
+
 type PipelineRunGenerator interface {
-	Generate() *v1beta1.PipelineRun
+	Generate() (*v1beta1.PipelineRun, error)
 }
 
 type BuildahDemo struct {
@@ -31,12 +32,11 @@ type BuildahDemo struct {
 }
 
 // This is a demo pipeline to create test image and task signing
-func (g BuildahDemo) Generate() *v1beta1.PipelineRun {
-
+func (b BuildahDemo) Generate() (*v1beta1.PipelineRun, error) {
 	return &v1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      g.Name,
-			Namespace: g.Namespace,
+			Name:      b.Name,
+			Namespace: b.Namespace,
 		},
 		Spec: v1beta1.PipelineRunSpec{
 			Params: []v1beta1.Param{
@@ -46,7 +46,7 @@ func (g BuildahDemo) Generate() *v1beta1.PipelineRun {
 				},
 				{
 					Name:  "output-image",
-					Value: *v1beta1.NewArrayOrString(g.Image),
+					Value: *v1beta1.NewArrayOrString(b.Image),
 				},
 				{
 					Name:  "git-url",
@@ -59,7 +59,7 @@ func (g BuildahDemo) Generate() *v1beta1.PipelineRun {
 			},
 			PipelineRef: &v1beta1.PipelineRef{
 				Name:   "docker-build",
-				Bundle: g.Bundle, //nolint:all
+				Bundle: b.Bundle, //nolint:all
 			},
 			Workspaces: []v1beta1.WorkspaceBinding{
 				{
@@ -70,48 +70,31 @@ func (g BuildahDemo) Generate() *v1beta1.PipelineRun {
 				},
 			},
 		},
-	}
+	}, nil
 }
 
 type VerifyEnterpriseContract struct {
-	ApplicationName     string
-	Bundle              string
-	ComponentName       string
-	Image               string
+	Snapshot            app.SnapshotSpec
+	TaskBundle          string
 	Name                string
 	Namespace           string
 	PolicyConfiguration string
 	PublicKey           string
-	SSLCertDir          string
 	Strict              bool
 	EffectiveTime       string
 }
 
-func (p VerifyEnterpriseContract) Generate() *v1beta1.PipelineRun {
-	var snapshot app.SnapshotSpec
-	err := json.Unmarshal([]byte(p.Image), &snapshot)
+func (p VerifyEnterpriseContract) Generate() (*v1beta1.PipelineRun, error) {
+	var applicationSnapshotJSON, err = json.Marshal(p.Snapshot)
 	if err != nil {
-		fmt.Printf("Application Snapshot doesn't exist: %s\n", err)
-	}
-
-	if len(snapshot.Components) == 0 {
-		p.Image = `{
-			"application": "` + p.ApplicationName + `",
-			"components": [
-			  {
-				"name": "` + p.ComponentName + `",
-				"containerImage": "` + p.Image + `"
-			  }
-			]
-		  }`
+		return nil, err
 	}
 	return &v1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-run-", p.Name),
 			Namespace:    p.Namespace,
 			Labels: map[string]string{
-				"appstudio.openshift.io/application": p.ApplicationName,
-				"appstudio.openshift.io/component":   p.ComponentName,
+				"appstudio.openshift.io/application": p.Snapshot.Application,
 			},
 		},
 		Spec: v1beta1.PipelineRunSpec{
@@ -124,7 +107,7 @@ func (p VerifyEnterpriseContract) Generate() *v1beta1.PipelineRun {
 								Name: "IMAGES",
 								Value: v1beta1.ParamValue{
 									Type:      v1beta1.ParamTypeString,
-									StringVal: p.Image,
+									StringVal: string(applicationSnapshotJSON),
 								},
 							},
 							{
@@ -145,7 +128,7 @@ func (p VerifyEnterpriseContract) Generate() *v1beta1.PipelineRun {
 								Name: "SSL_CERT_DIR",
 								Value: v1beta1.ParamValue{
 									Type:      v1beta1.ParamTypeString,
-									StringVal: p.SSLCertDir,
+									StringVal: sslCertDir,
 								},
 							},
 							{
@@ -165,13 +148,27 @@ func (p VerifyEnterpriseContract) Generate() *v1beta1.PipelineRun {
 						},
 						TaskRef: &v1beta1.TaskRef{
 							Name:   "verify-enterprise-contract",
-							Bundle: p.Bundle,
+							Bundle: p.TaskBundle,
 						},
 					},
 				},
 			},
 		},
+	}, nil
+}
+
+func (p *VerifyEnterpriseContract) WithComponentImage(imageRef string) {
+	p.Snapshot.Components = []app.SnapshotComponent{
+		{
+			ContainerImage: imageRef,
+		},
 	}
+}
+
+func (p *VerifyEnterpriseContract) AppendComponentImage(imageRef string) {
+	p.Snapshot.Components = append(p.Snapshot.Components, app.SnapshotComponent{
+		ContainerImage: imageRef,
+	})
 }
 
 // GetFailedPipelineRunLogs gets the logs of the pipelinerun failed task
@@ -203,15 +200,15 @@ func StorePipelineRun(pipelineRun *v1beta1.PipelineRun, c crclient.Client, ki ku
 
 	pipelineRunYaml, prYamlErr := yaml.Marshal(pipelineRun)
 	if prYamlErr != nil {
-		GinkgoWriter.Printf("\nfailed to get pipelineRunYaml: %s\n", prYamlErr.Error())
+		g.GinkgoWriter.Printf("\nfailed to get pipelineRunYaml: %s\n", prYamlErr.Error())
 	}
 
 	err = os.MkdirAll(testLogsDir, os.ModePerm)
 
 	if err != nil {
-		GinkgoWriter.Printf("\n%s\nFailed pipelineRunLog:\n%s\n---END OF THE LOG---\n", pipelineRun.GetName(), pipelineRunLog)
+		g.GinkgoWriter.Printf("\n%s\nFailed pipelineRunLog:\n%s\n---END OF THE LOG---\n", pipelineRun.GetName(), pipelineRunLog)
 		if prYamlErr == nil {
-			GinkgoWriter.Printf("Failed pipelineRunYaml:\n%s\n", pipelineRunYaml)
+			g.GinkgoWriter.Printf("Failed pipelineRunYaml:\n%s\n", pipelineRunYaml)
 		}
 		return err
 	}
@@ -219,16 +216,16 @@ func StorePipelineRun(pipelineRun *v1beta1.PipelineRun, c crclient.Client, ki ku
 	filename := fmt.Sprintf("%s-pr-%s.log", pipelineRun.Namespace, pipelineRun.Name)
 	filePath := fmt.Sprintf("%s/%s", testLogsDir, filename)
 	if err := os.WriteFile(filePath, []byte(pipelineRunLog), 0644); err != nil {
-		GinkgoWriter.Printf("cannot write to %s: %+v\n", filename, err)
-		GinkgoWriter.Printf("\n%s\nFailed pipelineRunLog:\n%s\n", filename, pipelineRunLog)
+		g.GinkgoWriter.Printf("cannot write to %s: %+v\n", filename, err)
+		g.GinkgoWriter.Printf("\n%s\nFailed pipelineRunLog:\n%s\n", filename, pipelineRunLog)
 	}
 
 	if prYamlErr == nil {
 		filename = fmt.Sprintf("%s-pr-%s.yaml", pipelineRun.Namespace, pipelineRun.Name)
 		filePath = fmt.Sprintf("%s/%s", testLogsDir, filename)
 		if err := os.WriteFile(filePath, pipelineRunYaml, 0644); err != nil {
-			GinkgoWriter.Printf("cannot write to %s: %+v\n", filename, err)
-			GinkgoWriter.Printf("\n%s\nFailed pipelineRunYaml:\n%s\n", filename, pipelineRunYaml)
+			g.GinkgoWriter.Printf("cannot write to %s: %+v\n", filename, err)
+			g.GinkgoWriter.Printf("\n%s\nFailed pipelineRunYaml:\n%s\n", filename, pipelineRunYaml)
 		}
 	}
 

--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -10,6 +10,7 @@ import (
 	ecp "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/redhat-appstudio/application-api/api/v1alpha1"
 	kubeapi "github.com/redhat-appstudio/e2e-tests/pkg/apis/kubernetes"
 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
@@ -289,15 +290,20 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 					Expect(kubeController.CreateOrUpdatePolicyConfiguration(testNamespace, policy)).To(Succeed())
 
 					generator := tekton.VerifyEnterpriseContract{
-						ApplicationName:     applicationName,
-						Bundle:              verifyECTaskBundle,
-						ComponentName:       componentNames[i],
-						Image:               outputImage,
+						Snapshot: v1alpha1.SnapshotSpec{
+							Application: applicationName,
+							Components: []v1alpha1.SnapshotComponent{
+								{
+									Name:           componentNames[i],
+									ContainerImage: outputImage,
+								},
+							},
+						},
+						TaskBundle:          verifyECTaskBundle,
 						Name:                "verify-enterprise-contract",
 						Namespace:           testNamespace,
 						PolicyConfiguration: "ec-policy",
 						PublicKey:           fmt.Sprintf("k8s://%s/%s", testNamespace, publicSecretName),
-						SSLCertDir:          "/var/run/secrets/kubernetes.io/serviceaccount",
 						Strict:              true,
 						EffectiveTime:       "now",
 					}

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -174,16 +174,15 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 
 			BeforeEach(func() {
 				generator = tekton.VerifyEnterpriseContract{
-					Bundle:              verifyECTaskBundle,
-					Image:               imageWithDigest,
+					TaskBundle:          verifyECTaskBundle,
 					Name:                "verify-enterprise-contract",
 					Namespace:           namespace,
 					PolicyConfiguration: "ec-policy",
 					PublicKey:           fmt.Sprintf("k8s://%s/%s", namespace, publicSecretName),
-					SSLCertDir:          "/var/run/secrets/kubernetes.io/serviceaccount",
 					Strict:              true,
 					EffectiveTime:       "now",
 				}
+				generator.WithComponentImage(imageWithDigest)
 
 				// Since specs could update the config policy, make sure it has a consistent
 				// baseline at the start of each spec.
@@ -314,27 +313,6 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 		})
 	})
 })
-
-// func printPolicyConfiguration(policy ecp.EnterpriseContractPolicySpec) {
-// 	sources := ""
-// 	for i, s := range policy.Sources {
-// 		if i != 0 {
-// 			sources += "\n"
-// 		}
-// 		if s.GitRepository != nil {
-// 			if s.GitRepository.Revision != nil {
-// 				sources += fmt.Sprintf("[%d] repository: '%s', revision: '%s'", i, s.GitRepository.Repository, *s.GitRepository.Revision)
-// 			} else {
-// 				sources += fmt.Sprintf("[%d] repository: '%s'", i, s.GitRepository.Repository)
-// 			}
-// 		}
-// 	}
-// 	exceptions := "[]"
-// 	if policy.Exceptions != nil {
-// 		exceptions = fmt.Sprintf("%v", policy.Exceptions.NonBlocking)
-// 	}
-// 	GinkgoWriter.Printf("Configured sources: %s\nand non-blocking policies: %v\n", sources, exceptions)
-// }
 
 func printTaskRunStatus(tr *v1beta1.PipelineRunTaskRunStatus, namespace string, sc common.SuiteController) {
 	if tr.Status == nil {

--- a/tests/enterprise-contract/const.go
+++ b/tests/enterprise-contract/const.go
@@ -1,5 +1,0 @@
-package enterprisecontract
-
-const (
-	snapshotComponent = `{"components":[{"containerImage":"quay.io/redhat-appstudio/ec-golden-image:e2e-test-out-of-date-task"},{"containerImage":"quay.io/redhat-appstudio/ec-golden-image:e2e-test-unacceptable-task"}]}`
-)

--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -65,16 +65,15 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 	Context("ec-cli command verification", func() {
 		BeforeEach(func() {
 			generator = tekton.VerifyEnterpriseContract{
-				Bundle:              verifyECTaskBundle,
-				Image:               imageWithDigest,
+				TaskBundle:          verifyECTaskBundle,
 				Name:                "verify-enterprise-contract",
 				Namespace:           namespace,
 				PolicyConfiguration: "ec-policy",
 				PublicKey:           fmt.Sprintf("k8s://%s/%s", namespace, publicSecretName),
-				SSLCertDir:          "/var/run/secrets/kubernetes.io/serviceaccount",
 				Strict:              false,
 				EffectiveTime:       "now",
 			}
+			generator.WithComponentImage(imageWithDigest)
 			pipelineRunTimeout = int(time.Duration(5) * time.Minute)
 			baselinePolicies := ecp.EnterpriseContractPolicySpec{
 				Configuration: policyConfig,
@@ -138,7 +137,8 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 				},
 			}
 			Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
-			generator.Image = snapshotComponent
+			generator.WithComponentImage("quay.io/redhat-appstudio/ec-golden-image:e2e-test-out-of-date-task")
+			generator.AppendComponentImage("quay.io/redhat-appstudio/ec-golden-image:e2e-test-unacceptable-task")
 			pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
@@ -167,16 +167,15 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 			GinkgoWriter.Println("Update public key to verify golden images")
 			Expect(kubeController.CreateOrUpdateSigningSecret(goldenImagePublicKey, secretName, namespace)).To(Succeed())
 			generator = tekton.VerifyEnterpriseContract{
-				Bundle:              verifyECTaskBundle,
-				Image:               imageWithDigest,
+				TaskBundle:          verifyECTaskBundle,
 				Name:                "verify-enterprise-contract",
 				Namespace:           namespace,
 				PolicyConfiguration: "ec-policy",
 				PublicKey:           fmt.Sprintf("k8s://%s/%s", namespace, secretName),
-				SSLCertDir:          "/var/run/secrets/kubernetes.io/serviceaccount",
 				Strict:              false,
 				EffectiveTime:       "now",
 			}
+			generator.WithComponentImage(imageWithDigest)
 			pipelineRunTimeout = int(time.Duration(5) * time.Minute)
 		})
 
@@ -189,7 +188,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 			}
 			Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
 
-			generator.Image = "quay.io/redhat-appstudio/ec-golden-image:e2e-test-unacceptable-task"
+			generator.WithComponentImage("quay.io/redhat-appstudio/ec-golden-image:e2e-test-unacceptable-task")
 			pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
@@ -222,7 +221,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 			}
 			Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
 
-			generator.Image = "quay.io/redhat-appstudio/ec-golden-image:e2e-test-out-of-date-task"
+			generator.WithComponentImage("quay.io/redhat-appstudio/ec-golden-image:e2e-test-out-of-date-task")
 			generator.EffectiveTime = "2023-03-31T00:00:00Z"
 			pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
 			Expect(err).NotTo(HaveOccurred())
@@ -267,7 +266,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 			}
 			Expect(kubeController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
 
-			generator.Image = "quay.io/redhat-appstudio-qe/enterprise-contract-tests:e2e-test-unpinned-task-bundle"
+			generator.WithComponentImage("quay.io/redhat-appstudio-qe/enterprise-contract-tests:e2e-test-unpinned-task-bundle")
 			pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())


### PR DESCRIPTION
# Description

 - tekton.VerifyEnterpriseContract now has a top-level app.SnapshotSpec (Snapshot) field
 - two new helper methods on tekton.VerifyEnterpriseContract: - WithComponentImage - AppendComponentImage
 - tekton.VerifyEnterpriseContract.Bundle renamed to tekton.VerifyEnterpriseContract.TaskBundle
 - tekton.PipelineRunGenerator returns an error from Generate method
 - SSLCertDir set to a fixed value, less repetition this way
 - commented out code removed

## Issue ticket number and link

Ref. https://issues.redhat.com/browse/HACBS-2200


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run tests against quickcluster instance

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
