### PR TITLE
feat: test that EC Task is run in Release pipeline

### DIFF
--- a/tests/release/const.go
+++ b/tests/release/const.go
@@ -20,6 +20,7 @@ const (
 	releaseStrategyPolicy               = "policy"
 	environment                         = "test-environment"
 	releaseStrategyServiceAccount       = constants.DefaultPipelineServiceAccount
+	verifyEnterpriseContractTaskName    = "verify-enterprise-contract"
 
 	releasePipelineNameDefault           string = "release"
 	applicationNameDefault               string = "appstudio"


### PR DESCRIPTION
# Description

In [HACBS-2472](https://issues.redhat.com/browse/HACBS-2472) we realized a gap in the testing putting the Release pipeline at risk if the `verify-enterprise-task` changes in an incompatible way with the Release pipeline.

This adds a coverage to test that `verify-enterprise-task` is included in the Release PipelineRun and that it has succeeded.

The success is assumed by the release PipelineRun succeeding, though there is no check to make sure that `verify-enterprise-task` is included and that it succeeds individually.

Currently it is not possible to ignore errors from Tasks in PipelineRuns so this safeguards in case TEP-0050 gets implemented.

[1] https://github.com/tektoncd/community/blob/fe0c2bbedb0754cd6b4352eab5d344683a73c296/teps/0050-ignore-task-failures.md

## Issue ticket number and link

Ref. https://issues.redhat.com/browse/HACBS-2472

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
