### PR TITLE
fix: use request annotation for trigger-simple-build

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -92,8 +92,6 @@ const (
 
 	BuildTaskRunName = "build-container"
 
-	ComponentInitialBuildAnnotationKey = "appstudio.openshift.io/component-initial-build"
-
 	ReleasePipelineImageRef = "quay.io/hacbs-release/pipeline-release:0.15"
 
 	StrategyConfigsRepo          = "strategy-configs"
@@ -125,5 +123,6 @@ const (
 var (
 	ComponentDefaultLabel                      = map[string]string{"e2e-test": "true"}
 	ComponentPaCRequestAnnotation              = map[string]string{"build.appstudio.openshift.io/request": "configure-pac"}
+	ComponentTriggerSimpleBuildAnnotation      = map[string]string{"build.appstudio.openshift.io/request": "trigger-simple-build"}
 	ImageControllerAnnotationRequestPublicRepo = map[string]string{"image.redhat.com/generate": `{"visibility": "public"}`}
 )

--- a/pkg/utils/has/components.go
+++ b/pkg/utils/has/components.go
@@ -334,7 +334,7 @@ func (h *HasController) RetriggerComponentPipelineRun(component *appservice.Comp
 			if err != nil {
 				return fmt.Errorf("failed to get component for PipelineRun %q in %q namespace: %+v", pr.GetName(), pr.GetNamespace(), err)
 			}
-			delete(component.Annotations, constants.ComponentInitialBuildAnnotationKey)
+			component.Annotations = utils.MergeMaps(component.Annotations, constants.ComponentTriggerSimpleBuildAnnotation)
 			if err = h.KubeRest().Update(context.Background(), component); err != nil {
 				return fmt.Errorf("failed to update Component %q in %q namespace", component.GetName(), component.GetNamespace())
 			}

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -309,8 +309,7 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 			component, err := f.AsKubeAdmin.HasController.GetComponent(componentName, testNamespace)
 			Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("could not get component %s/%s", testNamespace, componentName))
 
-			annotations := component.GetAnnotations()
-			delete(annotations, constants.ComponentInitialBuildAnnotationKey)
+			annotations := utils.MergeMaps(component.GetAnnotations(), constants.ComponentTriggerSimpleBuildAnnotation)
 			component.SetAnnotations(annotations)
 			Expect(f.AsKubeAdmin.CommonController.KubeRest().Update(context.TODO(), component, &client.UpdateOptions{})).To(Succeed())
 


### PR DESCRIPTION
Instead of deletion of component-initial-build annotation, use build.appstudio.openshift.io/request annotation.

RHTAPBUGS-729

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
