### PR TITLE
feat: Test EC pipelines

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -22,6 +22,12 @@ const (
 	// The quay.io token to perform container builds and push. The token must be correlated with the QUAY_OAUTH_USER environment
 	QUAY_OAUTH_TOKEN_ENV string = "QUAY_OAUTH_TOKEN" // #nosec
 
+	// The git repo url for the EC pipelines.
+	EC_PIPELINES_REPO_URL_ENV string = "EC_PIPELINES_REPO_URL"
+
+	// The git repo revision for the EC pipelines.
+	EC_PIPELINES_REPO_REVISION_ENV string = "EC_PIPELINES_REPO_REVISION"
+
 	// The private devfile sample git repository to use in certain HAS e2e tests
 	PRIVATE_DEVFILE_SAMPLE string = "PRIVATE_DEVFILE_SAMPLE" // #nosec
 

--- a/pkg/utils/tekton/controller.go
+++ b/pkg/utils/tekton/controller.go
@@ -324,7 +324,7 @@ func (k KubeController) WatchPipelineRunSucceeded(pipelineRunName string, taskTi
 	return utils.WaitUntil(k.Tektonctrl.CheckPipelineRunSucceeded(pipelineRunName, k.Namespace), time.Duration(taskTimeout)*time.Second)
 }
 
-func (k KubeController) GetTaskRunResult(c crclient.Client, pr *v1beta1.PipelineRun, pipelineTaskName string, result string) (string, error) {
+func (k KubeController) GetTaskRunFromPipelineRun(c crclient.Client, pr *v1beta1.PipelineRun, pipelineTaskName string) (*v1beta1.TaskRun, error) {
 	for _, chr := range pr.Status.ChildReferences {
 		if chr.PipelineTaskName != pipelineTaskName {
 			continue
@@ -333,14 +333,24 @@ func (k KubeController) GetTaskRunResult(c crclient.Client, pr *v1beta1.Pipeline
 		taskRun := &v1beta1.TaskRun{}
 		taskRunKey := types.NamespacedName{Namespace: pr.Namespace, Name: chr.Name}
 		if err := c.Get(context.TODO(), taskRunKey, taskRun); err != nil {
-			return "", err
+			return nil, err
 		}
+		return taskRun, nil
+	}
 
-		for _, trResult := range taskRun.Status.TaskRunResults {
-			if trResult.Name == result {
-				// for some reason the result might contain \n suffix
-				return strings.TrimSuffix(trResult.Value.StringVal, "\n"), nil
-			}
+	return nil, fmt.Errorf("task %q not found in PipelineRun %q/%q", pipelineTaskName, pr.Namespace, pr.Name)
+}
+
+func (k KubeController) GetTaskRunResult(c crclient.Client, pr *v1beta1.PipelineRun, pipelineTaskName string, result string) (string, error) {
+	taskRun, err := k.GetTaskRunFromPipelineRun(c, pr, pipelineTaskName)
+	if err != nil {
+		return "", err
+	}
+
+	for _, trResult := range taskRun.Status.TaskRunResults {
+		if trResult.Name == result {
+			// for some reason the result might contain \n suffix
+			return strings.TrimSuffix(trResult.Value.StringVal, "\n"), nil
 		}
 	}
 	return "", fmt.Errorf(

--- a/pkg/utils/tekton/pipelines.go
+++ b/pkg/utils/tekton/pipelines.go
@@ -171,6 +171,44 @@ func (p *VerifyEnterpriseContract) AppendComponentImage(imageRef string) {
 	})
 }
 
+type ECIntegrationTestScenario struct {
+	Image                 string
+	Name                  string
+	Namespace             string
+	PipelineGitURL        string
+	PipelineGitRevision   string
+	PipelineGitPathInRepo string
+}
+
+func (p ECIntegrationTestScenario) Generate() (*v1beta1.PipelineRun, error) {
+
+	snapshot := `{"components": [
+		{"containerImage": "` + p.Image + `"}
+	]}`
+
+	return &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "ec-integration-test-scenario-run-",
+			Namespace:    p.Namespace,
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{
+				ResolverRef: v1beta1.ResolverRef{
+					Resolver: "git",
+					Params: []v1beta1.Param{
+						{Name: "url", Value: *v1beta1.NewStructuredValues(p.PipelineGitURL)},
+						{Name: "revision", Value: *v1beta1.NewStructuredValues(p.PipelineGitRevision)},
+						{Name: "pathInRepo", Value: *v1beta1.NewStructuredValues(p.PipelineGitPathInRepo)},
+					},
+				},
+			},
+			Params: []v1beta1.Param{
+				{Name: "SNAPSHOT", Value: *v1beta1.NewStructuredValues(snapshot)},
+			},
+		},
+	}, nil
+}
+
 // GetFailedPipelineRunLogs gets the logs of the pipelinerun failed task
 func GetFailedPipelineRunLogs(c crclient.Client, ki kubernetes.Interface, pipelineRun *v1beta1.PipelineRun) (string, error) {
 	var d *utils.FailedPipelineRunDetails

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -1,7 +1,9 @@
 package build
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/devfile/library/v2/pkg/util"
@@ -14,30 +16,47 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
+	kubeapi "github.com/redhat-appstudio/e2e-tests/pkg/apis/kubernetes"
 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils/build"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/common"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
 )
 
 var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HACBS"), func() {
 	defer GinkgoRecover()
-	var fwk *framework.Framework
-	var err error
+
 	var namespace string
+	var kubeClient *framework.ControllerHub
+	var fwk *framework.Framework
+
 	AfterEach(framework.ReportFailure(&fwk))
 
 	BeforeAll(func() {
-		fwk, err = framework.NewFramework(utils.GetGeneratedNamespace(constants.TEKTON_CHAINS_E2E_USER))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(fwk.UserNamespace).NotTo(BeNil(), "failed to create sandbox user")
-		namespace = fwk.UserNamespace
+		// Allow the use of a custom namespace for testing.
+		namespace = os.Getenv(constants.E2E_APPLICATIONS_NAMESPACE_ENV)
+		if len(namespace) > 0 {
+			adminClient, err := kubeapi.NewAdminKubernetesClient()
+			Expect(err).ShouldNot(HaveOccurred())
+			kubeClient, err = framework.InitControllerHub(adminClient)
+			Expect(err).ShouldNot(HaveOccurred())
+			_, err = kubeClient.CommonController.CreateTestNamespace(namespace)
+			Expect(err).ShouldNot(HaveOccurred())
+		} else {
+			var err error
+			fwk, err = framework.NewFramework(utils.GetGeneratedNamespace(constants.TEKTON_CHAINS_E2E_USER))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fwk.UserNamespace).NotTo(BeNil(), "failed to create sandbox user")
+			namespace = fwk.UserNamespace
+			kubeClient = fwk.AsKubeAdmin
+		}
 	})
 
 	Context("infrastructure is running", Label("pipeline"), func() {
 		It("verifies if the chains controller is running", func() {
-			err := fwk.AsKubeAdmin.CommonController.WaitForPodSelector(fwk.AsKubeAdmin.CommonController.IsPodRunning, constants.TEKTON_CHAINS_NS, "app", "tekton-chains-controller", 60, 100)
+			err := kubeClient.CommonController.WaitForPodSelector(kubeClient.CommonController.IsPodRunning, constants.TEKTON_CHAINS_NS, "app", "tekton-chains-controller", 60, 100)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -54,8 +73,8 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 
 		BeforeAll(func() {
 			kubeController = tekton.KubeController{
-				Commonctrl: *fwk.AsKubeAdmin.CommonController,
-				Tektonctrl: *fwk.AsKubeAdmin.TektonController,
+				Commonctrl: *kubeClient.CommonController,
+				Tektonctrl: *kubeClient.TektonController,
 				Namespace:  namespace,
 			}
 
@@ -104,7 +123,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 			// an image that has been signed by Tekton Chains. Trigger a demo task to fulfill
 			// this purpose.
 
-			bundles, err := fwk.AsKubeAdmin.TektonController.NewBundles()
+			bundles, err := kubeClient.TektonController.NewBundles()
 			Expect(err).ShouldNot(HaveOccurred())
 			dockerBuildBundle := bundles.DockerBuildBundle
 			Expect(dockerBuildBundle).NotTo(Equal(""), "Can't continue without a docker-build pipeline got from selector config")
@@ -121,9 +140,9 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify TaskRun has the type hinting required by Tekton Chains
-			digest, err := kubeController.GetTaskRunResult(fwk.AsKubeAdmin.CommonController.KubeRest(), pr, "build-container", "IMAGE_DIGEST")
+			digest, err := kubeController.GetTaskRunResult(kubeClient.CommonController.KubeRest(), pr, "build-container", "IMAGE_DIGEST")
 			Expect(err).NotTo(HaveOccurred())
-			i, err := kubeController.GetTaskRunResult(fwk.AsKubeAdmin.CommonController.KubeRest(), pr, "build-container", "IMAGE_URL")
+			i, err := kubeController.GetTaskRunResult(kubeClient.CommonController.KubeRest(), pr, "build-container", "IMAGE_URL")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(i).To(Equal(image))
 
@@ -207,9 +226,9 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
 				Expect(err).NotTo(HaveOccurred())
 
-				tr, err := kubeController.GetTaskRunStatus(fwk.AsKubeAdmin.CommonController.KubeRest(), pr, "verify-enterprise-contract")
+				tr, err := kubeController.GetTaskRunStatus(kubeClient.CommonController.KubeRest(), pr, "verify-enterprise-contract")
 				Expect(err).NotTo(HaveOccurred())
-				printTaskRunStatus(tr, namespace, *fwk.AsKubeAdmin.CommonController)
+				printTaskRunStatus(tr, namespace, *kubeClient.CommonController)
 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s succeeded\n", tr.PipelineTaskName, pr.Name)
 				Expect(tekton.DidTaskSucceed(tr)).To(BeTrue())
 				GinkgoWriter.Printf("Make sure result for TaskRun %q succeeded\n", tr.PipelineTaskName)
@@ -240,10 +259,10 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
 				Expect(err).NotTo(HaveOccurred())
 
-				tr, err := kubeController.GetTaskRunStatus(fwk.AsKubeAdmin.CommonController.KubeRest(), pr, "verify-enterprise-contract")
+				tr, err := kubeController.GetTaskRunStatus(kubeClient.CommonController.KubeRest(), pr, "verify-enterprise-contract")
 				Expect(err).NotTo(HaveOccurred())
 
-				printTaskRunStatus(tr, namespace, *fwk.AsKubeAdmin.CommonController)
+				printTaskRunStatus(tr, namespace, *kubeClient.CommonController)
 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s succeeded\n", tr.PipelineTaskName, pr.Name)
 				Expect(tekton.DidTaskSucceed(tr)).To(BeTrue())
 				GinkgoWriter.Printf("Make sure result for TaskRun %q succeeded\n", tr.PipelineTaskName)
@@ -275,10 +294,10 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
 				Expect(err).NotTo(HaveOccurred())
 
-				tr, err := kubeController.GetTaskRunStatus(fwk.AsKubeAdmin.CommonController.KubeRest(), pr, "verify-enterprise-contract")
+				tr, err := kubeController.GetTaskRunStatus(kubeClient.CommonController.KubeRest(), pr, "verify-enterprise-contract")
 				Expect(err).NotTo(HaveOccurred())
 
-				printTaskRunStatus(tr, namespace, *fwk.AsKubeAdmin.CommonController)
+				printTaskRunStatus(tr, namespace, *kubeClient.CommonController)
 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s failed\n", tr.PipelineTaskName, pr.Name)
 				Expect(tekton.DidTaskSucceed(tr)).To(BeFalse())
 				// Because the task fails, no results are created
@@ -302,14 +321,84 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 				pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
 				Expect(err).NotTo(HaveOccurred())
 
-				tr, err := kubeController.GetTaskRunStatus(fwk.AsKubeAdmin.CommonController.KubeRest(), pr, "verify-enterprise-contract")
+				tr, err := kubeController.GetTaskRunStatus(kubeClient.CommonController.KubeRest(), pr, "verify-enterprise-contract")
 				Expect(err).NotTo(HaveOccurred())
 
-				printTaskRunStatus(tr, namespace, *fwk.AsKubeAdmin.CommonController)
+				printTaskRunStatus(tr, namespace, *kubeClient.CommonController)
 				GinkgoWriter.Printf("Make sure TaskRun %s of PipelineRun %s failed\n", tr.PipelineTaskName, pr.Name)
 				Expect(tekton.DidTaskSucceed(tr)).To(BeFalse())
 				// Because the task fails, no results are created
 			})
+		})
+
+		Context("build-definitions ec pipelines", func() {
+			ecPipelines := []string{
+				"pipelines/enterprise-contract.yaml",
+				"pipelines/enterprise-contract-everything.yaml",
+				"pipelines/enterprise-contract-redhat.yaml",
+				"pipelines/enterprise-contract-slsa1.yaml",
+				"pipelines/enterprise-contract-slsa2.yaml",
+				"pipelines/enterprise-contract-slsa3.yaml",
+			}
+
+			gitRevision := os.Getenv(constants.EC_PIPELINES_REPO_REVISION_ENV)
+			if len(gitRevision) == 0 {
+				gitRevision = "main"
+			}
+
+			gitURL := os.Getenv(constants.EC_PIPELINES_REPO_URL_ENV)
+			if len(gitURL) == 0 {
+				gitURL = "https://github.com/redhat-appstudio/build-definitions"
+			}
+
+			for _, pathInRepo := range ecPipelines {
+				pathInRepo := pathInRepo
+				It(fmt.Sprintf("runs ec pipeline %s", pathInRepo), func() {
+					generator := tekton.ECIntegrationTestScenario{
+						Image:                 imageWithDigest,
+						Namespace:             namespace,
+						PipelineGitURL:        gitURL,
+						PipelineGitRevision:   gitRevision,
+						PipelineGitPathInRepo: pathInRepo,
+					}
+
+					pr, err := kubeController.RunPipeline(generator, pipelineRunTimeout)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(kubeController.WatchPipelineRun(pr.Name, pipelineRunTimeout)).To(Succeed())
+
+					// Refresh our copy of the PipelineRun for latest results
+					pr, err = kubeController.Tektonctrl.GetPipelineRun(pr.Name, pr.Namespace)
+					Expect(err).NotTo(HaveOccurred())
+
+					// The UI uses this label to display additional information.
+					Expect(pr.Labels["build.appstudio.redhat.com/pipeline"]).To(Equal("enterprise-contract"))
+
+					// The UI uses this label to display additional information.
+					tr, err := kubeController.GetTaskRunFromPipelineRun(kubeClient.CommonController.KubeRest(), pr, "verify")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(tr.Labels["build.appstudio.redhat.com/pipeline"]).To(Equal("enterprise-contract"))
+
+					logs, err := kubeController.Tektonctrl.GetTaskRunLogs(pr.Name, "verify", pr.Namespace)
+					Expect(err).NotTo(HaveOccurred())
+
+					// The logs from the report step are used by the UI to display validation
+					// details. Let's make sure it has valid YAML.
+					reportLogs := logs["step-report"]
+					Expect(reportLogs).NotTo(BeEmpty())
+					var reportYAML any
+					err = yaml.Unmarshal([]byte(reportLogs), &reportYAML)
+					Expect(err).NotTo(HaveOccurred())
+
+					// The logs from the summary step are used by the UI to display an overview of
+					// the validation.
+					summaryLogs := logs["step-summary"]
+					Expect(summaryLogs).NotTo(BeEmpty())
+					var summary build.TestOutput
+					err = json.Unmarshal([]byte(summaryLogs), &summary)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(summary).NotTo(Equal(build.TestOutput{}))
+				})
+			}
 		})
 	})
 })


### PR DESCRIPTION
# Description

The EC pipelines from the build-definitions repository are used by the auto-created IntegrationTestScenario. This adds test coverage to those Tekton pipelines.

By default it tests the pipelines from the main branch of the build-definitions repo. The branch as well as the repository url can be overwritten via environment variables. This will be used in the future to test pull requests in the build-definitions repository.

## Issue ticket number and link

https://issues.redhat.com/browse/HACBS-2475

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with clusterbot.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
