### PR TITLE
feat: Allow EC pipeline tests from fork PR

### DIFF
--- a/pkg/apis/github/pull_request.go
+++ b/pkg/apis/github/pull_request.go
@@ -8,6 +8,14 @@ import (
 	"github.com/google/go-github/v44/github"
 )
 
+func (g *Github) GetPullRequest(repository string, id int) (*github.PullRequest, error) {
+	pr, _, err := g.client.PullRequests.Get(context.Background(), g.organization, repository, id)
+	if err != nil {
+		return nil, err
+	}
+	return pr, nil
+}
+
 func (g *Github) ListPullRequests(repository string) ([]*github.PullRequest, error) {
 	prs, _, err := g.client.PullRequests.List(context.Background(), g.organization, repository, &github.PullRequestListOptions{})
 	if err != nil {


### PR DESCRIPTION
# Description

This change allows the EC pipeline tests to be executed against the source of a pull request in the build-definitions repo. This allows us to run these tests as part of the CI of the build-definitions repo in order to catch issues in the EC pipelines.

## Issue ticket number and link

https://issues.redhat.com/browse/HACBS-2475

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Cluster in resourcehub.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
