### PR TITLE
fix: use custom label for ec pipelines

### DIFF
--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -27,7 +27,7 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
 )
 
-var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HACBS"), func() {
+var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "ec-pipelines", "HACBS"), func() {
 	defer GinkgoRecover()
 
 	var namespace string


### PR DESCRIPTION
# Description

The EC pipelines tests are expected to be used by the build-definitions CI. When it runs there, it runs directly on the prod cluster. The tests in `tests/enterprise-contract/contract.go` don't work with that setup. Also, they are not really related to changes in build-definitions.

This commit adds a new label, `ec-pipelines-e2e`, so the build-definitions CI can include just the relevant tests.

## Issue ticket number and link

https://issues.redhat.com/browse/HACBS-2475

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Dev cluster.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
