### PR TITLE
fix: move ec-pipelines label

### DIFF
--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -27,7 +27,7 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
 )
 
-var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "ec-pipelines", "HACBS"), func() {
+var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HACBS"), func() {
 	defer GinkgoRecover()
 
 	var namespace string
@@ -63,7 +63,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "ec
 		})
 	})
 
-	Context("test creating and signing an image and task", Label("pipeline"), func() {
+	Context("test creating and signing an image and task", Label("pipeline", "ec-pipelines"), func() {
 		// Make the PipelineRun name and namespace predictable. For convenience, the name of the
 		// PipelineRun that builds an image, is the same as the repository where the image is
 		// pushed to.


### PR DESCRIPTION
# Description

Need to exclude the test that verifies the Chains controller is running because the build-definitions CI doesn't have access to do so.

## Issue ticket number and link

https://issues.redhat.com/browse/HACBS-2475

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Dev cluster in resourcehub

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
