### PR TITLE
test: RHTAPBUGS-556 added timeout flag to curl command

### DIFF
--- a/tests/spi/access-control.go
+++ b/tests/spi/access-control.go
@@ -221,6 +221,8 @@ spec:
 					"-H 'Authorization: Bearer %s' \\"+
 					"-X POST \\"+
 					"-H 'Content-Type: application/yaml' \\"+
+					"--connect-timeout 30 \\"+
+					"--max-time 1200 \\"+
 					"-d '%s'",
 				fmt.Sprintf("%s/apis/appstudio.redhat.com/v1beta1/namespaces/%s/spifilecontentrequests", primaryUser.WorkspaceURL, primaryUser.Framework.UserNamespace),
 				guestUser.Framework.UserToken,
@@ -259,8 +261,8 @@ spec:
 				Stdout: buffer,
 				Stderr: errBuffer,
 			})
-			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("reason: %v", err))
-			Expect(errBuffer.String()).To(BeEmpty(), fmt.Sprintf("reason: %v", errBuffer.String()))
+			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error: %v", err))
+			Expect(errBuffer.String()).To(BeEmpty(), fmt.Sprintf("stderr: %v", errBuffer.String()))
 			Expect(buffer.String()).NotTo(BeEmpty())
 		}
 

--- a/tests/spi/access-control.go
+++ b/tests/spi/access-control.go
@@ -222,7 +222,7 @@ spec:
 					"-X POST \\"+
 					"-H 'Content-Type: application/yaml' \\"+
 					"--connect-timeout 30 \\"+
-					"--max-time 1200 \\"+
+					"--max-time 300 \\"+
 					"-d '%s'",
 				fmt.Sprintf("%s/apis/appstudio.redhat.com/v1beta1/namespaces/%s/spifilecontentrequests", primaryUser.WorkspaceURL, primaryUser.Framework.UserNamespace),
 				guestUser.Framework.UserToken,


### PR DESCRIPTION
# Description

Unfortunately, some jobs are failing with an empty buffer string when the guest user makes a POST request to `spifilecontentrequests`, from within a pod. The "interesting aspect" is that returns no error. 

I was not able to reproduce locally but I hope that adding a timeout flag could help to understand what is going on.

## Issue ticket number and link
[RHTAPBUGS-556](https://issues.redhat.com/browse/RHTAPBUGS-556)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
