### PR TITLE
fix: Typo in JSON field name, alligning with the rest

### DIFF
--- a/cmd/loadTests.go
+++ b/cmd/loadTests.go
@@ -158,7 +158,7 @@ type LogData struct {
 	UserCreationFailureRate         float64 `json:"createUserFailureRate"`
 	ApplicationCreationSuccessCount int64   `json:"createApplicationsSuccesses"`
 	ApplicationCreationFailureCount int64   `json:"createApplicationsFailures"`
-	ApplicationCreationFailureRate  float64 `json:"createsApplictionsFailureRate"`
+	ApplicationCreationFailureRate  float64 `json:"createApplicationsFailureRate"`
 	CDQCreationSuccessCount         int64   `json:"createCDQsSuccesses"`
 	CDQCreationFailureCount         int64   `json:"createCDQsFailures"`
 	CDQCreationFailureRate          float64 `json:"createCDQsFailureRate"`

--- a/tests/load-tests/load-tests-example.json
+++ b/tests/load-tests/load-tests-example.json
@@ -31,7 +31,7 @@
   "createUserFailureRate": 0,
   "createApplicationsSuccesses": 30,
   "createApplicationsFailures": 0,
-  "createsApplictionsFailureRate": 0,
+  "createApplicationsFailureRate": 0,
   "createCDQsSuccesses": 30,
   "createCDQsFailures": 0,
   "createCDQsFailureRate": 0,


### PR DESCRIPTION
# Description

Fixing typo in JSON field name, alligning with the rest

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

No test

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
