### PR TITLE
feat: RHTAPBUGS-540 archive artifacts when DeleteAllComponentsInASpecificNamespace fails.

### DIFF
--- a/pkg/framework/utils.go
+++ b/pkg/framework/utils.go
@@ -1,0 +1,30 @@
+package framework
+
+import "fmt"
+
+func (c *ControllerHub) StoreAllArtifactsForNamespace(namespace string) error {
+	var finalError string
+	finalError = appendErrorToString(finalError, c.HasController.StoreAllApplications(namespace))
+	finalError = appendErrorToString(finalError, c.HasController.StoreAllComponents(namespace))
+	finalError = appendErrorToString(finalError, c.HasController.StoreAllComponentDetectionQueries(namespace))
+	finalError = appendErrorToString(finalError, c.IntegrationController.StoreAllSnapshots(namespace))
+	finalError = appendErrorToString(finalError, c.TektonController.StoreAllPipelineRuns(namespace))
+	finalError = appendErrorToString(finalError, c.CommonController.StoreAllPods(namespace))
+	finalError = appendErrorToString(finalError, c.CommonController.StoreAllSnapshotEnvironmentBindings(namespace))
+	finalError = appendErrorToString(finalError, c.GitOpsController.StoreAllDeploymentTargetClaims(namespace))
+	finalError = appendErrorToString(finalError, c.GitOpsController.StoreAllDeploymentTargetClasses(namespace))
+	finalError = appendErrorToString(finalError, c.GitOpsController.StoreAllDeploymentTargets(namespace))
+	finalError = appendErrorToString(finalError, c.GitOpsController.StoreAllEnvironments(namespace))
+	finalError = appendErrorToString(finalError, c.GitOpsController.StoreAllGitOpsDeployments(namespace))
+	if len(finalError) > 0 {
+		return fmt.Errorf(finalError)
+	}
+	return nil
+}
+
+func appendErrorToString(baseString string, err error) string {
+	if err != nil {
+		return fmt.Sprintf("%s\n%s", baseString, err)
+	}
+	return baseString
+}

--- a/pkg/logs/utils.go
+++ b/pkg/logs/utils.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	. "github.com/redhat-appstudio/e2e-tests/pkg/utils"
-
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	"sigs.k8s.io/yaml"
 )
 

--- a/pkg/utils/gitops/gitopsdeployments.go
+++ b/pkg/utils/gitops/gitopsdeployments.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/redhat-appstudio/e2e-tests/pkg/logs"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend/apis/managed-gitops/v1alpha1"
@@ -25,32 +24,4 @@ func (g *GitopsController) DeleteAllGitOpsDeploymentsInASpecificNamespace(namesp
 		}
 		return len(gdList.Items) == 0, nil
 	}, timeout)
-}
-
-// ListAllGitOpsDeployments returns a list of all GitOpsDeployments in a given namespace.
-func (g *GitopsController) ListAllGitOpsDeployments(namespace string) (*managedgitopsv1alpha1.GitOpsDeploymentList, error) {
-	gitOpsDeploymentList := &managedgitopsv1alpha1.GitOpsDeploymentList{}
-	err := g.KubeRest().List(context.Background(), gitOpsDeploymentList, &client.ListOptions{Namespace: namespace})
-
-	return gitOpsDeploymentList, err
-}
-
-// StoreGitOpsDeployment stores a given GitOpsDeployment as an artifact.
-func (g *GitopsController) StoreGitOpsDeployment(gitOpsDeployment *managedgitopsv1alpha1.GitOpsDeployment) error {
-	return logs.StoreResourceYaml(gitOpsDeployment, "gitOpsDeployment-"+gitOpsDeployment.Name)
-}
-
-// StoreAllGitOpsDeployments stores all GitOpsDeployments in a given namespace.
-func (g *GitopsController) StoreAllGitOpsDeployments(namespace string) error {
-	gitOpsDeploymentList, err := g.ListAllGitOpsDeployments(namespace)
-	if err != nil {
-		return err
-	}
-
-	for _, gitOpsDeployment := range gitOpsDeploymentList.Items {
-		if err := g.StoreGitOpsDeployment(&gitOpsDeployment); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/pkg/utils/gitops/gitopsdeployments.go
+++ b/pkg/utils/gitops/gitopsdeployments.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/redhat-appstudio/e2e-tests/pkg/logs"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend/apis/managed-gitops/v1alpha1"
@@ -24,4 +25,32 @@ func (g *GitopsController) DeleteAllGitOpsDeploymentsInASpecificNamespace(namesp
 		}
 		return len(gdList.Items) == 0, nil
 	}, timeout)
+}
+
+// ListAllGitOpsDeployments returns a list of all GitOpsDeployments in a given namespace.
+func (g *GitopsController) ListAllGitOpsDeployments(namespace string) (*managedgitopsv1alpha1.GitOpsDeploymentList, error) {
+	gitOpsDeploymentList := &managedgitopsv1alpha1.GitOpsDeploymentList{}
+	err := g.KubeRest().List(context.Background(), gitOpsDeploymentList, &client.ListOptions{Namespace: namespace})
+
+	return gitOpsDeploymentList, err
+}
+
+// StoreGitOpsDeployment stores a given GitOpsDeployment as an artifact.
+func (g *GitopsController) StoreGitOpsDeployment(gitOpsDeployment *managedgitopsv1alpha1.GitOpsDeployment) error {
+	return logs.StoreResourceYaml(gitOpsDeployment, "gitOpsDeployment-"+gitOpsDeployment.Name+".yaml")
+}
+
+// StoreAllGitOpsDeployments stores all GitOpsDeployments in a given namespace.
+func (g *GitopsController) StoreAllGitOpsDeployments(namespace string) error {
+	gitOpsDeploymentList, err := g.ListAllGitOpsDeployments(namespace)
+	if err != nil {
+		return err
+	}
+
+	for _, gitOpsDeployment := range gitOpsDeploymentList.Items {
+		if err := g.StoreGitOpsDeployment(&gitOpsDeployment); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/utils/has/applications.go
+++ b/pkg/utils/has/applications.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	appservice "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	"github.com/redhat-appstudio/e2e-tests/pkg/logs"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -126,32 +125,4 @@ func (h *HasController) refreshApplicationForErrorDebug(application *appservice.
 	}
 
 	return retApp
-}
-
-// ListAllApplications returns a list of all Applications in a given namespace.
-func (h *HasController) ListAllApplications(namespace string) (*appservice.ApplicationList, error) {
-	applicationList := &appservice.ApplicationList{}
-	err := h.KubeRest().List(context.Background(), applicationList, &rclient.ListOptions{Namespace: namespace})
-
-	return applicationList, err
-}
-
-// StoreApplication stores a given Application as an artifact.
-func (h *HasController) StoreApplication(application *appservice.Application) error {
-	return logs.StoreResourceYaml(application, "application-"+application.Name)
-}
-
-// StoreAllApplications stores all Applications in a given namespace.
-func (h *HasController) StoreAllApplications(namespace string) error {
-	applicationList, err := h.ListAllApplications(namespace)
-	if err != nil {
-		return err
-	}
-
-	for _, application := range applicationList.Items {
-		if err := h.StoreApplication(&application); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/pkg/utils/has/applications.go
+++ b/pkg/utils/has/applications.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	appservice "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/e2e-tests/pkg/logs"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -125,4 +126,32 @@ func (h *HasController) refreshApplicationForErrorDebug(application *appservice.
 	}
 
 	return retApp
+}
+
+// ListAllApplications returns a list of all Applications in a given namespace.
+func (h *HasController) ListAllApplications(namespace string) (*appservice.ApplicationList, error) {
+	applicationList := &appservice.ApplicationList{}
+	err := h.KubeRest().List(context.Background(), applicationList, &rclient.ListOptions{Namespace: namespace})
+
+	return applicationList, err
+}
+
+// StoreApplication stores a given Application as an artifact.
+func (h *HasController) StoreApplication(application *appservice.Application) error {
+	return logs.StoreResourceYaml(application, "application-"+application.Name+".yaml")
+}
+
+// StoreAllApplications stores all Applications in a given namespace.
+func (h *HasController) StoreAllApplications(namespace string) error {
+	applicationList, err := h.ListAllApplications(namespace)
+	if err != nil {
+		return err
+	}
+
+	for _, application := range applicationList.Items {
+		if err := h.StoreApplication(&application); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/utils/tekton/pipelineruns.go
+++ b/pkg/utils/tekton/pipelineruns.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 
@@ -20,7 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
 
 	g "github.com/onsi/ginkgo/v2"
 )

--- a/tests/byoc/byoc.go
+++ b/tests/byoc/byoc.go
@@ -112,7 +112,12 @@ var _ = framework.E2ESuiteDescribe(Label("byoc"), Ordered, func() {
 			// Remove all resources created by the tests in case the suite was successfull
 			AfterAll(func() {
 				if !CurrentSpecReport().Failed() {
-					Expect(fw.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(fw.UserNamespace, 30*time.Second)).To(Succeed())
+					if err := fw.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(fw.UserNamespace, 30*time.Second); err != nil {
+						if err := fw.AsKubeAdmin.StoreAllArtifactsForNamespace(fw.UserNamespace); err != nil {
+							Fail(fmt.Sprintf("error archiving artifacts:\n%s", err))
+						}
+						Fail(fmt.Sprintf("error deleting all componentns in namespace:\n%s", err))
+					}
 					Expect(fw.AsKubeAdmin.HasController.DeleteAllApplicationsInASpecificNamespace(fw.UserNamespace, 30*time.Second)).To(Succeed())
 					Expect(fw.AsKubeAdmin.CommonController.DeleteAllSnapshotEnvBindingsInASpecificNamespace(fw.UserNamespace, 30*time.Second)).To(Succeed())
 					Expect(fw.AsKubeAdmin.IntegrationController.DeleteAllSnapshotsInASpecificNamespace(fw.UserNamespace, 30*time.Second)).To(Succeed())

--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -108,6 +108,18 @@ var _ = framework.RhtapDemoSuiteDescribe(Label("rhtap-demo"), func() {
 
 				// Remove all resources created by the tests
 				AfterAll(func() {
+					fw.AsKubeAdmin.CommonController.StoreAllPods(namespace)
+					fw.AsKubeAdmin.HasController.StoreAllComponents(namespace)
+					fw.AsKubeAdmin.HasController.StoreAllComponentDetectionQueries(namespace)
+					fw.AsKubeAdmin.HasController.StoreAllApplications(namespace)
+					fw.AsKubeAdmin.CommonController.StoreAllSnapshotEnvironmentBindings(namespace)
+					fw.AsKubeAdmin.IntegrationController.StoreAllSnapshots(namespace)
+					fw.AsKubeAdmin.GitOpsController.StoreAllEnvironments(namespace)
+					fw.AsKubeAdmin.TektonController.StoreAllPipelineRuns(namespace)
+					fw.AsKubeAdmin.GitOpsController.StoreAllGitOpsDeployments(namespace)
+					fw.AsKubeAdmin.GitOpsController.StoreAllDeploymentTargets(namespace)
+					fw.AsKubeAdmin.GitOpsController.StoreAllDeploymentTargetClaims(namespace)
+					fw.AsKubeAdmin.GitOpsController.StoreAllDeploymentTargetClasses(namespace)
 					// collect SPI ResourceQuota metrics (temporary)
 					err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("rhtap-demo", namespace, "appstudio-crds-spi")
 					Expect(err).NotTo(HaveOccurred())

--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -108,18 +108,6 @@ var _ = framework.RhtapDemoSuiteDescribe(Label("rhtap-demo"), func() {
 
 				// Remove all resources created by the tests
 				AfterAll(func() {
-					fw.AsKubeAdmin.CommonController.StoreAllPods(namespace)
-					fw.AsKubeAdmin.HasController.StoreAllComponents(namespace)
-					fw.AsKubeAdmin.HasController.StoreAllComponentDetectionQueries(namespace)
-					fw.AsKubeAdmin.HasController.StoreAllApplications(namespace)
-					fw.AsKubeAdmin.CommonController.StoreAllSnapshotEnvironmentBindings(namespace)
-					fw.AsKubeAdmin.IntegrationController.StoreAllSnapshots(namespace)
-					fw.AsKubeAdmin.GitOpsController.StoreAllEnvironments(namespace)
-					fw.AsKubeAdmin.TektonController.StoreAllPipelineRuns(namespace)
-					fw.AsKubeAdmin.GitOpsController.StoreAllGitOpsDeployments(namespace)
-					fw.AsKubeAdmin.GitOpsController.StoreAllDeploymentTargets(namespace)
-					fw.AsKubeAdmin.GitOpsController.StoreAllDeploymentTargetClaims(namespace)
-					fw.AsKubeAdmin.GitOpsController.StoreAllDeploymentTargetClasses(namespace)
 					// collect SPI ResourceQuota metrics (temporary)
 					err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("rhtap-demo", namespace, "appstudio-crds-spi")
 					Expect(err).NotTo(HaveOccurred())

--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -113,7 +113,12 @@ var _ = framework.RhtapDemoSuiteDescribe(Label("rhtap-demo"), func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					if !CurrentSpecReport().Failed() {
-						Expect(fw.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
+						if err := fw.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(namespace, 30*time.Second); err != nil {
+							if err := fw.AsKubeAdmin.StoreAllArtifactsForNamespace(namespace); err != nil {
+								Fail(fmt.Sprintf("error archiving artifacts:\n%s", err))
+							}
+							Fail(fmt.Sprintf("error deleting all componentns in namespace:\n%s", err))
+						}
 						Expect(fw.AsKubeAdmin.HasController.DeleteAllApplicationsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
 						Expect(fw.AsKubeAdmin.CommonController.DeleteAllSnapshotEnvBindingsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
 						Expect(fw.AsKubeAdmin.IntegrationController.DeleteAllSnapshotsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())


### PR DESCRIPTION
# Description
This PR is based on top of https://github.com/redhat-appstudio/e2e-tests/pull/745. It addressed the one change request I had there (as @jsmid1 is not working this week).
It also (which is the main part of this PR) stores (hopefully) all relevant (and some probably unrelevant) artifacts when `DeleteAllComponentsInASpecificNamespace` fails. This should help with investigation of [RHTAPBUGS-540](https://issues.redhat.com//browse/RHTAPBUGS-540).

## Issue ticket number and link
https://issues.redhat.com/browse/RHTAPBUGS-540
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

For a while I had a commit that would trigger the archivation logic for each afterall in `rhtap-demo.go`. This is the result: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/redhat-appstudio_e2e-tests/757/pull-ci-redhat-appstudio-e2e-tests-main-redhat-appstudio-e2e/1700142909791145984/artifacts/redhat-appstudio-e2e/redhat-appstudio-e2e/artifacts/rp_preproc/attachments/xunit/

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
