### PR TITLE
feat(STONEINTG-398): this is a follow-up enhancement PR

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -126,8 +126,13 @@ const (
 	JsonStageUsersPath = "users.json"
 
 	SamplePrivateRepoName = "test-private-repo"
+
 	// Github App name is RHTAP-Qe-App. Note: this App ID is used in our CI and can't be used for local dev/testing.
 	DefaultPaCGitHubAppID = "310332"
+
+	// Error string constants for Namespace-backed environment test suite
+	SEBAbsenceErrorString = "no SnapshotEnvironmentBinding found in environment"
+	EphemeralEnvAbsenceErrorString = "no matching Ephemeral Environment found"
 )
 
 var (

--- a/pkg/utils/common/snapshot_environment_bindings.go
+++ b/pkg/utils/common/snapshot_environment_bindings.go
@@ -12,7 +12,7 @@ import (
 	rclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetComponentPipeline returns the pipeline for a given component labels
+// GetSnapshotEnvironmentBinding returns the SnapshotEnvironmentBinding related to the given App and Environment
 func (s *SuiteController) GetSnapshotEnvironmentBinding(applicationName string, namespace string, environment *appservice.Environment) (*appservice.SnapshotEnvironmentBinding, error) {
 	snapshotEnvironmentBindingList := &appservice.SnapshotEnvironmentBindingList{}
 	opts := []client.ListOption{

--- a/pkg/utils/gitops/environments.go
+++ b/pkg/utils/gitops/environments.go
@@ -33,7 +33,7 @@ func (g *GitopsController) GetEnvironmentsList(namespace string) (*appservice.En
 
 // GetEphemeralEnvironment returns the Ephemeral Environment in the namespace and nil if it's not found
 // It will search for the Environment based on the Snapshot and Scneario name present in its labels,
-// and also look for environment containing the tag "ephemeral".
+// and also look for environment containing the "ephemeral" tag.
 func (g *GitopsController) GetEphemeralEnvironment(applicationName, snapshotName, integrationTestScenarioName, namespace string) (*appservice.Environment, error) {
 	opts := []client.ListOption{
 		client.InNamespace(namespace),

--- a/pkg/utils/gitops/environments.go
+++ b/pkg/utils/gitops/environments.go
@@ -51,7 +51,7 @@ func (g *GitopsController) GetEphemeralEnvironment(applicationName, snapshotName
 		}
 	}
 
-	return nil, fmt.Errorf("no matching ephemeral environment found %s", utils.GetAdditionalInfo(applicationName, namespace))
+	return nil, fmt.Errorf("no matching Ephemeral Environment found %s", utils.GetAdditionalInfo(applicationName, namespace))
 }
 
 /*

--- a/pkg/utils/integration/pipelineruns.go
+++ b/pkg/utils/integration/pipelineruns.go
@@ -14,6 +14,7 @@ import (
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,26 +58,19 @@ func (i *IntegrationController) CreateIntegrationPipelineRun(snapshotName, names
 }
 
 // GetComponentPipeline returns the pipeline for a given component labels.
+// In case of failure, this function retries till it gets timed out.
 func (i *IntegrationController) GetBuildPipelineRun(componentName, applicationName, namespace string, pacBuild bool, sha string) (*tektonv1beta1.PipelineRun, error) {
 	var pipelineRun *tektonv1beta1.PipelineRun
 
 	err := wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 20*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		pipelineRunLabels := map[string]string{"appstudio.openshift.io/component": componentName, "appstudio.openshift.io/application": applicationName, "pipelines.appstudio.openshift.io/type": "build"}
-		opts := []client.ListOption{
-			client.InNamespace(namespace),
-			client.MatchingLabels{
-				"pipelines.appstudio.openshift.io/type": "build",
-				"appstudio.openshift.io/application":    applicationName,
-				"appstudio.openshift.io/component":      componentName,
-			},
-		}
 
         if sha != "" {
 			pipelineRunLabels["pipelinesascode.tekton.dev/sha"] = sha
         }
 
         list := &tektonv1beta1.PipelineRunList{}
-        err = i.KubeRest().List(context.TODO(), list, opts...)
+        err = i.KubeRest().List(context.TODO(), list, &client.ListOptions{LabelSelector: labels.SelectorFromSet(pipelineRunLabels), Namespace: namespace})
 
         if err != nil && !k8sErrors.IsNotFound(err) {
             GinkgoWriter.Printf("error listing pipelineruns in %s namespace: %v", namespace, err)
@@ -122,7 +116,29 @@ func (i *IntegrationController) GetIntegrationPipelineRun(integrationTestScenari
 	return &tektonv1beta1.PipelineRun{}, fmt.Errorf("no pipelinerun found for integrationTestScenario %s (snapshot: %s, namespace: %s)", integrationTestScenarioName, snapshotName, namespace)
 }
 
+// WaitForIntegrationPipelineToGetStarted wait for given integration pipeline to get started.
+// In case of failure, this function retries till it gets timed out.
+func (i *IntegrationController) WaitForIntegrationPipelineToGetStarted(testScenarioName, snapshotName, appNamespace string) (*tektonv1beta1.PipelineRun, error) {
+	var testPipelinerun *tektonv1beta1.PipelineRun
+
+	err := wait.PollUntilContextTimeout(context.Background(), time.Second*2, time.Minute*5, true, func(ctx context.Context) (done bool, err error) {
+		testPipelinerun, err = i.GetIntegrationPipelineRun(testScenarioName, snapshotName, appNamespace)
+		if err != nil {
+			GinkgoWriter.Println("PipelineRun has not been created yet for test scenario %s and snapshot %s/%s", testScenarioName, appNamespace, snapshotName)
+			return false, nil
+		}
+		if !testPipelinerun.HasStarted() {
+			GinkgoWriter.Println("pipelinerun %s/%s hasn't started yet", testPipelinerun.GetNamespace(), testPipelinerun.GetName())
+			return false, nil
+		}
+		return true, nil
+	})
+	
+	return testPipelinerun, err
+}
+
 // WaitForIntegrationPipelineToBeFinished wait for given integration pipeline to finish.
+// In case of failure, this function retries till it gets timed out.
 func (i *IntegrationController) WaitForIntegrationPipelineToBeFinished(testScenario *integrationv1beta1.IntegrationTestScenario, snapshot *appstudioApi.Snapshot, appNamespace string) error {
 	return wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 20*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		pipelineRun, err := i.GetIntegrationPipelineRun(testScenario.Name, snapshot.Name, appNamespace)
@@ -166,6 +182,7 @@ func (i *IntegrationController) WaitForAllIntegrationPipelinesToBeFinished(testN
 }
 
 // WaitForBuildPipelineRunToBeSigned waits for given build pipeline to get signed.
+// In case of failure, this function retries till it gets timed out.
 func (i *IntegrationController) WaitForBuildPipelineRunToBeSigned(testNamespace, applicationName, componentName string) error {
 	return wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		pipelineRun, err := i.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
@@ -191,6 +208,7 @@ func (i *IntegrationController) GetAnnotationIfExists(testNamespace, application
 }
 
 // WaitForBuildPipelineRunToGetAnnotated waits for given build pipeline to get annotated with a specific annotation.
+// In case of failure, this function retries till it gets timed out.
 func (i *IntegrationController) WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, annotationKey string) error {
 	return wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		pipelineRun, err := i.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")

--- a/pkg/utils/integration/snapshots.go
+++ b/pkg/utils/integration/snapshots.go
@@ -137,7 +137,7 @@ func (i *IntegrationController) WaitForSnapshotToGetCreated(snapshotName, pipeli
 	err := wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		snapshot, err = i.GetSnapshot(snapshotName, pipelinerunName, componentName, testNamespace)
 		if err != nil {
-			GinkgoWriter.Printf("unable to get the Snapshot for Build PipelineRun %s/%s. Error: %v", testNamespace, pipelinerunName, err)
+			GinkgoWriter.Printf("unable to get the Snapshot within the namespace %s. Error: %v", testNamespace, err)
 			return false, nil
 		}
 

--- a/tests/integration-service/namespace-backed-environments.go
+++ b/tests/integration-service/namespace-backed-environments.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/devfile/library/v2/pkg/util"
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -34,7 +33,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment 
 
 	var applicationName, componentName, testNamespace string
 	var pipelineRun, testPipelinerun *v1beta1.PipelineRun
-	var timeout, interval time.Duration
 	var originalComponent *appstudioApi.Component
 	var snapshot, snapshot_push *appstudioApi.Snapshot
 	var integrationTestScenario *integrationv1beta1.IntegrationTestScenario
@@ -42,216 +40,167 @@ var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment 
 	var snapshotEnvironmentBinding *appstudioApi.SnapshotEnvironmentBinding
 	AfterEach(framework.ReportFailure(&f))
 
-	Describe("the component with git source (GitHub) is created", Ordered, func() {
-		createApp := func() {
-			applicationName = fmt.Sprintf("integ-app-%s", util.GenerateRandomString(4))
-
-			app, err := f.AsKubeAdmin.HasController.CreateApplication(applicationName, testNamespace)
+	Describe("with happy path for Namespace-backed environments", Ordered, func() {
+		BeforeAll(func() {
+			// Initialize the tests controllers
+			f, err = framework.NewFramework(utils.GetGeneratedNamespace("nbe-e2e"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(utils.WaitUntil(f.AsKubeAdmin.HasController.ApplicationGitopsRepoExists(app.Status.Devfile), 30*time.Second)).To(
-				Succeed(), fmt.Sprintf("timed out waiting for gitops content to be created for app %s in namespace %s: %+v", app.Name, app.Namespace, err),
-			)
-		}
+			testNamespace = f.UserNamespace
 
-		createComponent := func() {
-			componentName = fmt.Sprintf("integration-suite-test-component-git-source-%s", util.GenerateRandomString(4))
-			// Create a component with Git Source URL being defined
-			// using cdq since git ref is not known
-			cdq, err := f.AsKubeAdmin.HasController.CreateComponentDetectionQuery(componentName, testNamespace, componentRepoURL, "", "", "", false)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(cdq.Status.ComponentDetected).To(HaveLen(1), "Expected length of the detected Components was not 1")
+			applicationName = createApp(*f, testNamespace)
+			componentName, originalComponent = createComponent(*f, testNamespace, applicationName)
 
-			for _, compDetected := range cdq.Status.ComponentDetected {
-				originalComponent, err = f.AsKubeAdmin.HasController.CreateComponent(compDetected.ComponentStub, testNamespace, "", "", applicationName, true, map[string]string{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(originalComponent).NotTo(BeNil())
-				componentName = originalComponent.Name
-			}
-		}
+			dtcls, err := f.AsKubeAdmin.GitOpsController.CreateDeploymentTargetClass()
+			Expect(dtcls).ToNot(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
-		cleanup := func() {
+			userPickedEnvironment, err = f.AsKubeAdmin.GitOpsController.CreatePocEnvironment(EnvNameForNBE, testNamespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenarioWithEnvironment(applicationName, testNamespace, gitURLForNBE, revisionForNBE, pathInRepoForNBE, userPickedEnvironment)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		AfterAll(func() {
 			if !CurrentSpecReport().Failed() {
-				Expect(f.AsKubeAdmin.HasController.DeleteApplication(applicationName, testNamespace, false)).To(Succeed())
-				Expect(f.AsKubeAdmin.HasController.DeleteComponent(componentName, testNamespace, false)).To(Succeed())
-				integrationTestScenarios, err := f.AsKubeAdmin.IntegrationController.GetIntegrationTestScenarios(applicationName, testNamespace)
-				Expect(err).ShouldNot(HaveOccurred())
-
-				for _, testScenario := range *integrationTestScenarios {
-					Expect(f.AsKubeAdmin.IntegrationController.DeleteIntegrationTestScenario(&testScenario, testNamespace)).To(Succeed())
-				}
-				Expect(f.SandboxController.DeleteUserSignup(f.UserName)).To(BeTrue())
+				cleanup(*f, testNamespace, applicationName, componentName)
 			}
-		}
 
-		Describe("with happy path for Namespace-backed environments", Ordered, func() {
-			BeforeAll(func() {
-				// Initialize the tests controllers
-				f, err = framework.NewFramework(utils.GetGeneratedNamespace("nbe-e2e"))
-				Expect(err).NotTo(HaveOccurred())
-				testNamespace = f.UserNamespace
+			Expect(f.AsKubeAdmin.GitOpsController.DeleteDeploymentTargetClass()).To(Succeed())
+		})
 
-				createApp()
-				createComponent()
+		It("triggers a build PipelineRun", Label("integration-service"), func() {
+			pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+			Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", 2, f.AsKubeAdmin.TektonController)).To(Succeed())
+			Expect(pipelineRun.Annotations["appstudio.openshift.io/snapshot"]).To(Equal(""))
+		})
 
-				dtcls, err := f.AsKubeAdmin.GitOpsController.CreateDeploymentTargetClass()
-				Expect(dtcls).ToNot(BeNil())
+		When("the build pipelineRun run succeeded", func() {
+			It("checks if the BuildPipelineRun is signed", func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToBeSigned(testNamespace, applicationName, componentName)).To(Succeed())
+			})
+
+			It("checks if the Snapshot is created", func() {
+				snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", componentName, testNamespace)
 				Expect(err).ToNot(HaveOccurred())
-
-				userPickedEnvironment, err = f.AsKubeAdmin.GitOpsController.CreatePocEnvironment(EnvNameForNBE, testNamespace)
-				Expect(err).ToNot(HaveOccurred())
-
-				integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenarioWithEnvironment(applicationName, testNamespace, gitURLForNBE, revisionForNBE, pathInRepoForNBE, userPickedEnvironment)
-				Expect(err).ShouldNot(HaveOccurred())
 			})
 
-			AfterAll(func() {
-				if !CurrentSpecReport().Failed() {
-					cleanup()
-				}
-
-				Expect(f.AsKubeAdmin.GitOpsController.DeleteDeploymentTargetClass()).To(Succeed())
-			})
-
-			It("triggers a build PipelineRun", Label("integration-service"), func() {
-				pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
-				Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", 2, f.AsKubeAdmin.TektonController)).To(Succeed())
-				Expect(pipelineRun.Annotations["appstudio.openshift.io/snapshot"]).To(Equal(""))
-			})
-
-			When("the build pipelineRun run succeeded", func() {
-				It("checks if the BuildPipelineRun is signed", func() {
-					Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToBeSigned(testNamespace, applicationName, componentName)).To(Succeed())
-				})
-
-				It("checks if the Snapshot is created", func() {
-					snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", componentName, testNamespace)
-					Expect(err).ToNot(HaveOccurred())
-				})
-
-				It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
-					Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, "appstudio.openshift.io/snapshot")).To(Succeed())
-				})
-			})
-
-			It("creates an Ephemeral Environment", func() {
-				ephemeralEnvironment, err = f.AsKubeAdmin.GitOpsController.GetEphemeralEnvironment(snapshot.Spec.Application, snapshot.Name, integrationTestScenario.Name, testNamespace)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(ephemeralEnvironment.Name).ToNot(BeEmpty())
-			})
-
-			It("should find the related Integration Test PipelineRun", func() {
-				timeout = time.Minute * 5
-				interval = time.Second * 2
-				Eventually(func() error {
-					testPipelinerun, err = f.AsKubeAdmin.IntegrationController.GetIntegrationPipelineRun(integrationTestScenario.Name, snapshot.Name, testNamespace)
-					if err != nil {
-						GinkgoWriter.Printf("failed to get Integration test PipelineRun for a snapshot '%s' in '%s' namespace: %+v\n", snapshot.Name, testNamespace, err)
-						return err
-					}
-					if !testPipelinerun.HasStarted() {
-						return fmt.Errorf("pipelinerun %s/%s hasn't started yet", testPipelinerun.GetNamespace(), testPipelinerun.GetName())
-					}
-					return nil
-				}, timeout, interval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the Integration PipelineRun to start for the IntegrationTestScenario/Snapshot : %s/%s", integrationTestScenario.Name, snapshot.Name))
-				Expect(testPipelinerun.Labels["appstudio.openshift.io/snapshot"]).To(ContainSubstring(snapshot.Name))
-				Expect(testPipelinerun.Labels["test.appstudio.openshift.io/scenario"]).To(ContainSubstring(integrationTestScenario.Name))
-				Expect(testPipelinerun.Labels["appstudio.openshift.io/environment"]).To(ContainSubstring(ephemeralEnvironment.Name))
-			})
-
-			When("Integration Test PipelineRun is created", func() {
-				It("should eventually complete successfully", func() {
-					Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenario, snapshot, testNamespace)).To(Succeed(), fmt.Sprintf("Error when waiting for a integration pipeline for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
-				})
-			})
-
-			When("Integration Test PipelineRun completes successfully", func() {
-				It("should lead to Snapshot CR being marked as passed", FlakeAttempts(3), func() {
-					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot("", pipelineRun.Name, "", testNamespace)
-					Expect(err).ShouldNot(HaveOccurred())
-					Expect(f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)).To(BeTrue(), fmt.Sprintf("tests have not succeeded for snapshot %s/%s", snapshot.GetNamespace(), snapshot.GetName()))
-				})
-
-				It("should lead to SnapshotEnvironmentBinding getting deleted", func() {
-					Eventually(func() bool {
-						snapshotEnvironmentBinding, err = f.AsKubeAdmin.CommonController.GetSnapshotEnvironmentBinding(applicationName, testNamespace, ephemeralEnvironment)
-						return snapshotEnvironmentBinding == nil
-					}, time.Minute*3, time.Second*2).Should(BeTrue(), fmt.Sprintf("timed out when waiting for SnapshotEnvironmentBinding to be deleted for application %s/%s", testNamespace, applicationName))
-				})
-
-				It("should lead to ephemeral environment getting deleted", func() {
-					Eventually(func() bool {
-						ephemeralEnvironment, err = f.AsKubeAdmin.GitOpsController.GetEphemeralEnvironment(snapshot.Spec.Application, snapshot.Name, integrationTestScenario.Name, testNamespace)
-						return ephemeralEnvironment == nil
-					}, time.Minute*3, time.Second*1).Should(BeTrue(), fmt.Sprintf("timed out when waiting for the Ephemeral Environment %s to be deleted", ephemeralEnvironment.Name))
-				})
+			It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, "appstudio.openshift.io/snapshot")).To(Succeed())
 			})
 		})
 
-		Describe("when valid DeploymentTargetClass doesn't exist", Ordered, func() {
-			var integrationTestScenario *integrationv1beta1.IntegrationTestScenario
-			BeforeAll(func() {
-				// Initialize the tests controllers
-				f, err = framework.NewFramework(utils.GetGeneratedNamespace("nbe-neg"))
-				Expect(err).NotTo(HaveOccurred())
-				testNamespace = f.UserNamespace
+		It("creates an Ephemeral Environment", func ()  {
+			Eventually(func() bool {
+				ephemeralEnvironment, err = f.AsKubeAdmin.GitOpsController.GetEphemeralEnvironment(snapshot.Spec.Application, snapshot.Name, integrationTestScenario.Name, testNamespace)
+				return ephemeralEnvironment != nil
+			}, time.Minute*3, time.Second*1).Should(BeTrue(), fmt.Sprintf("timed out when waiting for the deletion of Ephemeral Environment related to snapshot %s", snapshot.Name))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ephemeralEnvironment.Name).ToNot(BeEmpty())
+		})
 
-				createApp()
-				createComponent()
+		It("should find the related Integration Test PipelineRun", func() {
+			testPipelinerun, err = f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToGetStarted(integrationTestScenario.Name, snapshot.Name, testNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(testPipelinerun.Labels["appstudio.openshift.io/snapshot"]).To(ContainSubstring(snapshot.Name))
+			Expect(testPipelinerun.Labels["test.appstudio.openshift.io/scenario"]).To(ContainSubstring(integrationTestScenario.Name))
+			Expect(testPipelinerun.Labels["appstudio.openshift.io/environment"]).To(ContainSubstring(ephemeralEnvironment.Name))
+		})
 
-				env, err = f.AsKubeAdmin.GitOpsController.CreatePocEnvironment(EnvNameForNBE, testNamespace)
+		When("Integration Test PipelineRun is created", func() {
+			It("should eventually complete successfully", func() {
+				Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenario, snapshot, testNamespace)).To(Succeed(), fmt.Sprintf("Error when waiting for a integration pipeline for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
+			})
+		})
+
+		When("Integration Test PipelineRun completes successfully", func() {
+			It("should lead to Snapshot CR being marked as passed", FlakeAttempts(3), func() {
+				snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot("", pipelineRun.Name, "", testNamespace)
 				Expect(err).ShouldNot(HaveOccurred())
-				integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenarioWithEnvironment(applicationName, testNamespace, gitURLForNBE, revisionForNBE, pathInRepoForNBE, env)
+				Expect(f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)).To(BeTrue(), fmt.Sprintf("tests have not succeeded for snapshot %s/%s", snapshot.GetNamespace(), snapshot.GetName()))
+			})
+
+			It("should lead to SnapshotEnvironmentBinding getting deleted", func() {
+				Eventually(func() bool {
+					snapshotEnvironmentBinding, err = f.AsKubeAdmin.CommonController.GetSnapshotEnvironmentBinding(applicationName, testNamespace, ephemeralEnvironment)
+					return snapshotEnvironmentBinding == nil
+				}, time.Minute*3, time.Second*2).Should(BeTrue(), fmt.Sprintf("timed out when waiting for SnapshotEnvironmentBinding to be deleted for application %s/%s", testNamespace, applicationName))
+			})
+
+			It("should lead to ephemeral environment getting deleted", func() {
+				Eventually(func() bool {
+					ephemeralEnvironment, err = f.AsKubeAdmin.GitOpsController.GetEphemeralEnvironment(snapshot.Spec.Application, snapshot.Name, integrationTestScenario.Name, testNamespace)
+					return ephemeralEnvironment == nil
+				}, time.Minute*3, time.Second*1).Should(BeTrue(), fmt.Sprintf("timed out when waiting for the Ephemeral Environment %s to be deleted", ephemeralEnvironment.Name))
+			})
+		})
+	})
+
+	Describe("when valid DeploymentTargetClass doesn't exist", Ordered, func() {
+		var integrationTestScenario *integrationv1beta1.IntegrationTestScenario
+		BeforeAll(func() {
+			// Initialize the tests controllers
+			f, err = framework.NewFramework(utils.GetGeneratedNamespace("nbe-neg"))
+			Expect(err).NotTo(HaveOccurred())
+			testNamespace = f.UserNamespace
+
+			applicationName = createApp(*f, testNamespace)
+			componentName, originalComponent = createComponent(*f, testNamespace, applicationName)
+
+			env, err = f.AsKubeAdmin.GitOpsController.CreatePocEnvironment(EnvNameForNBE, testNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenarioWithEnvironment(applicationName, testNamespace, gitURLForNBE, revisionForNBE, pathInRepoForNBE, env)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			if !CurrentSpecReport().Failed() {
+				cleanup(*f, testNamespace, applicationName, componentName)
+
+				Expect(f.AsKubeAdmin.GitOpsController.DeleteAllEnvironmentsInASpecificNamespace(testNamespace, 30*time.Second)).To(Succeed())
+				Expect(f.AsKubeAdmin.IntegrationController.DeleteSnapshot(snapshot_push, testNamespace)).To(Succeed())
+			}
+		})
+
+		It("valid deploymentTargetClass doesn't exist", func() {
+			validDTCLS, err := f.AsKubeAdmin.GitOpsController.HaveAvailableDeploymentTargetClassExist()
+			Expect(validDTCLS).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("creates a snapshot of push event", func() {
+			sampleImage := "quay.io/redhat-appstudio/sample-image@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
+			snapshot_push, err = f.AsKubeAdmin.IntegrationController.CreateSnapshotWithImage(componentName, applicationName, testNamespace, sampleImage)
+			Expect(err).ToNot(HaveOccurred())
+			GinkgoWriter.Printf("snapshot %s is found\n", snapshot_push.Name)
+		})
+
+		When("nonexisting valid deploymentTargetClass", func() {
+			It("check no GitOpsCR is created for the dtc with nonexisting deploymentTargetClass", func() {
+				spaceRequestList, err := f.AsKubeAdmin.GitOpsController.GetSpaceRequests(testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(spaceRequestList.Items).To(BeEmpty())
+
+				deploymentTargetList, err := f.AsKubeAdmin.GitOpsController.GetDeploymentTargetsList(testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(deploymentTargetList.Items).To(BeEmpty())
+
+				deploymentTargetClaimList, err := f.AsKubeAdmin.GitOpsController.GetDeploymentTargetClaimsList(testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(deploymentTargetClaimList.Items).To(BeEmpty())
+
+				environmentList, err := f.AsKubeAdmin.GitOpsController.GetEnvironmentsList(testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(environmentList.Items)).ToNot(BeNumerically(">", 2))
+
+				pipelineRun, err := f.AsKubeAdmin.IntegrationController.GetIntegrationPipelineRun(integrationTestScenario.Name, snapshot_push.Name, testNamespace)
+				Expect(pipelineRun.Name == "" && strings.Contains(err.Error(), "no pipelinerun found")).To(BeTrue())
+			})
+
+			It("checks if snapshot is not marked as passed", func() {
+				snapshot, err := f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot_push.Name, "", "", testNamespace)
 				Expect(err).ShouldNot(HaveOccurred())
-			})
-
-			AfterAll(func() {
-				if !CurrentSpecReport().Failed() {
-					cleanup()
-
-					Expect(f.AsKubeAdmin.GitOpsController.DeleteAllEnvironmentsInASpecificNamespace(testNamespace, 30*time.Second)).To(Succeed())
-					Expect(f.AsKubeAdmin.IntegrationController.DeleteSnapshot(snapshot_push, testNamespace)).To(Succeed())
-				}
-			})
-
-			It("valid deploymentTargetClass doesn't exist", func() {
-				validDTCLS, err := f.AsKubeAdmin.GitOpsController.HaveAvailableDeploymentTargetClassExist()
-				Expect(validDTCLS).To(BeNil())
-				Expect(err).ToNot(HaveOccurred())
-			})
-
-			It("creates a snapshot of push event", func() {
-				sampleImage := "quay.io/redhat-appstudio/sample-image@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
-				snapshot_push, err = f.AsKubeAdmin.IntegrationController.CreateSnapshotWithImage(componentName, applicationName, testNamespace, sampleImage)
-				Expect(err).ToNot(HaveOccurred())
-				GinkgoWriter.Printf("snapshot %s is found\n", snapshot_push.Name)
-			})
-
-			When("nonexisting valid deploymentTargetClass", func() {
-				It("check no GitOpsCR is created for the dtc with nonexisting deploymentTargetClass", func() {
-					spaceRequestList, err := f.AsKubeAdmin.GitOpsController.GetSpaceRequests(testNamespace)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(spaceRequestList.Items).To(BeEmpty())
-
-					deploymentTargetList, err := f.AsKubeAdmin.GitOpsController.GetDeploymentTargetsList(testNamespace)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(deploymentTargetList.Items).To(BeEmpty())
-
-					deploymentTargetClaimList, err := f.AsKubeAdmin.GitOpsController.GetDeploymentTargetClaimsList(testNamespace)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(deploymentTargetClaimList.Items).To(BeEmpty())
-
-					environmentList, err := f.AsKubeAdmin.GitOpsController.GetEnvironmentsList(testNamespace)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(len(environmentList.Items)).ToNot(BeNumerically(">", 2))
-
-					pipelineRun, err := f.AsKubeAdmin.IntegrationController.GetIntegrationPipelineRun(integrationTestScenario.Name, snapshot_push.Name, testNamespace)
-					Expect(pipelineRun.Name == "" && strings.Contains(err.Error(), "no pipelinerun found")).To(BeTrue())
-				})
-				It("checks if snapshot is not marked as passed", func() {
-					snapshot, err := f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot_push.Name, "", "", testNamespace)
-					Expect(err).ShouldNot(HaveOccurred())
-					Expect(f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)).To(BeFalse())
-				})
+				Expect(f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)).To(BeFalse())
 			})
 		})
 	})


### PR DESCRIPTION
# Description

This is an enhancement PR for the [previously merged PR](https://github.com/redhat-appstudio/e2e-tests/pull/496), because https://github.com/redhat-appstudio/e2e-tests/pull/496 got merged too soon before I could address the non-blocking review comments.

The test suite still works fine without this PR but this is just an attempt to make this test suite even more readable, concise, and resilient. This PR:
* Removes the top-level Describe block from both the files
* Moves 3 functions out of the Describe blocks to reduce code duplication
* Adds a util function to wait for PLR to get started to make test suites slimmer
* Adds a retry logic within the test suite where the GetEphemeralEnvironment function gets called
* Ensures each test uses a unique test namespace
* Improves the Eventually blocks to return an error instead of a bool

## Issue ticket number and link

[STONEINTG-398](https://issues.redhat.com//browse/STONEINTG-398)

## Type of change

- [x] Test

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
