### PR TITLE
feat(RHTAP-1566): Add more metadata to our status data JSON

### DIFF
--- a/tests/load-tests/cluster_read_config.yaml
+++ b/tests/load-tests/cluster_read_config.yaml
@@ -77,3 +77,45 @@
 - name: measurements.node_disk_io_time_seconds_total
   monitoring_query: sum(irate(node_disk_io_time_seconds_total{cluster="",namespace=~".*"}[5m]))
   monitoring_step: 15
+
+# Interesting CI environment variables
+{% for var in [
+  'BUILD_ID',
+  'HOSTNAME',
+  'JOB_NAME',
+  'OPENSHIFT_API',
+  'PROW_JOB_ID',
+  'PULL_BASE_REF',
+  'PULL_BASE_SHA',
+  'PULL_HEAD_REF',
+  'PULL_NUMBER',
+  'PULL_PULL_SHA',
+  'PULL_REFS',
+  'REPO_NAME',
+  'REPO_OWNER',
+  'SCENARIO',
+] %}
+- name: metadata.env.{{ var }}
+  env_variable: {{ var }}
+{% endfor %}
+
+# Cluster nodes info
+- name: metadata.cluster.control-plane.count
+  command: oc get nodes -l node-role.kubernetes.io/master -o name | wc -l
+
+- name: metadata.cluster.control-plane.flavor
+  command: oc get nodes -l node-role.kubernetes.io/master -o json | jq --raw-output '.items | map(.metadata.labels."beta.kubernetes.io/instance-type") | unique | sort | join(",")'
+
+- name: metadata.cluster.control-plane.nodes
+  command: oc get nodes -l node-role.kubernetes.io/master -o json | jq '.items | map(.metadata.name)'
+  output: json
+
+- name: metadata.cluster.compute-nodes.count
+  command: oc get nodes -l node-role.kubernetes.io/worker -o name | wc -l
+
+- name: metadata.cluster.compute-nodes.flavor
+  command: oc get nodes -l node-role.kubernetes.io/worker -o json | jq --raw-output '.items | map(.metadata.labels."beta.kubernetes.io/instance-type") | unique | sort | join(",")'
+
+- name: metadata.cluster.compute-nodes.nodes
+  command: oc get nodes -l node-role.kubernetes.io/master -o json | jq '.items | map(.metadata.name)'
+  output: json

--- a/tests/load-tests/cluster_read_config.yaml
+++ b/tests/load-tests/cluster_read_config.yaml
@@ -119,3 +119,6 @@
 - name: metadata.cluster.compute-nodes.nodes
   command: oc get nodes -l node-role.kubernetes.io/master -o json | jq '.items | map(.metadata.name)'
   output: json
+
+- name: metadata.scenarioContent
+  command: cat /usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${SCENARIO}

--- a/tests/load-tests/cluster_read_config.yaml
+++ b/tests/load-tests/cluster_read_config.yaml
@@ -117,7 +117,7 @@
   command: oc get nodes -l node-role.kubernetes.io/worker -o json | jq --raw-output '.items | map(.metadata.labels."beta.kubernetes.io/instance-type") | unique | sort | join(",")'
 
 - name: metadata.cluster.compute-nodes.nodes
-  command: oc get nodes -l node-role.kubernetes.io/master -o json | jq '.items | map(.metadata.name)'
+  command: oc get nodes -l node-role.kubernetes.io/worker -o json | jq '.items | map(.metadata.name)'
   output: json
 
 - name: metadata.scenarioContent


### PR DESCRIPTION
Fixes [RHTAP-1566](https://issues.redhat.com//browse/RHTAP-1566).

PR adds this to the status data JSON:

    "parameters": {
        "cluster": {
            "compute-nodes": {
                "count": "5",
                "flavor": "m6a.2xlarge",
                "nodes": [
                    "ip-10-0-153-208.ec2.internal",
                    "ip-10-0-181-118.ec2.internal",
                    "ip-10-0-204-39.ec2.internal"
                ]
            },
            "control-plane": {
                "count": "3",
                "flavor": "m6a.8xlarge",
                "nodes": [
                    "ip-10-0-153-208.ec2.internal",
                    "ip-10-0-181-118.ec2.internal",
                    "ip-10-0-204-39.ec2.internal"
                ]
            }
        },
        "env": {
            "BUILD_ID": "1701573181531230208",
            "HOSTNAME": "load-test-ci-10u-10t-nodejs-redhat-appstudio-load-test",
            "JOB_NAME": "pull-ci-redhat-appstudio-e2e-tests-main-load-test-ci-10u-10t-nodejs",
            "OPENSHIFT_API": "https://api.ci-op-ftk8sjn2-1c995.origin-ci-int-aws.dev.rhcloud.com:6443",
            "PROW_JOB_ID": "0c82ff09-2b8c-4204-bd48-6f7eefbc65d0",
            "PULL_BASE_REF": "main",
            "PULL_BASE_SHA": "507f69fa2efb3ed40271d5cc8436580265e24255",
            "PULL_HEAD_REF": "fix9",
            "PULL_NUMBER": "761",
            "PULL_PULL_SHA": "a95112da6def2f1354e982ec53423cb5674a6838",
            "PULL_REFS": "main:507f69fa2efb3ed40271d5cc8436580265e24255,761:a95112da6def2f1354e982ec53423cb5674a6838",
            "SCENARIO": "ci-10u-10t-nodejs"
        }
    },

We need these data to make sure we compare only same tests and only tests that were running on same AWS EC2 instance types.