### PR TITLE
feat: RHTAPBUGS-540 archive artifacts when DeleteAllComponentsInASpecificNamespace fails.

### DIFF
--- a/pkg/framework/utils.go
+++ b/pkg/framework/utils.go
@@ -1,0 +1,30 @@
+package framework
+
+import "fmt"
+
+func (c *ControllerHub) StoreAllArtifactsForNamespace(namespace string) error {
+	var finalError string
+	finalError = appendErrorToString(finalError, c.HasController.StoreAllApplications(namespace))
+	finalError = appendErrorToString(finalError, c.HasController.StoreAllComponents(namespace))
+	finalError = appendErrorToString(finalError, c.HasController.StoreAllComponentDetectionQueries(namespace))
+	finalError = appendErrorToString(finalError, c.IntegrationController.StoreAllSnapshots(namespace))
+	finalError = appendErrorToString(finalError, c.TektonController.StoreAllPipelineRuns(namespace))
+	finalError = appendErrorToString(finalError, c.CommonController.StoreAllPods(namespace))
+	finalError = appendErrorToString(finalError, c.CommonController.StoreAllSnapshotEnvironmentBindings(namespace))
+	finalError = appendErrorToString(finalError, c.GitOpsController.StoreAllDeploymentTargetClaims(namespace))
+	finalError = appendErrorToString(finalError, c.GitOpsController.StoreAllDeploymentTargetClasses(namespace))
+	finalError = appendErrorToString(finalError, c.GitOpsController.StoreAllDeploymentTargets(namespace))
+	finalError = appendErrorToString(finalError, c.GitOpsController.StoreAllEnvironments(namespace))
+	finalError = appendErrorToString(finalError, c.GitOpsController.StoreAllGitOpsDeployments(namespace))
+	if len(finalError) > 0 {
+		return fmt.Errorf(finalError)
+	}
+	return nil
+}
+
+func appendErrorToString(baseString string, err error) string {
+	if err != nil {
+		return fmt.Sprintf("%s\n%s", baseString, err)
+	}
+	return baseString
+}

--- a/pkg/logs/utils.go
+++ b/pkg/logs/utils.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	. "github.com/redhat-appstudio/e2e-tests/pkg/utils"
-
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	"sigs.k8s.io/yaml"
 )
 

--- a/tests/byoc/byoc.go
+++ b/tests/byoc/byoc.go
@@ -112,7 +112,12 @@ var _ = framework.E2ESuiteDescribe(Label("byoc"), Ordered, func() {
 			// Remove all resources created by the tests in case the suite was successfull
 			AfterAll(func() {
 				if !CurrentSpecReport().Failed() {
-					Expect(fw.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(fw.UserNamespace, 30*time.Second)).To(Succeed())
+					if err := fw.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(fw.UserNamespace, 60*time.Second); err != nil {
+						if err := fw.AsKubeAdmin.StoreAllArtifactsForNamespace(fw.UserNamespace); err != nil {
+							Fail(fmt.Sprintf("error archiving artifacts:\n%s", err))
+						}
+						Fail(fmt.Sprintf("error deleting all componentns in namespace:\n%s", err))
+					}
 					Expect(fw.AsKubeAdmin.HasController.DeleteAllApplicationsInASpecificNamespace(fw.UserNamespace, 30*time.Second)).To(Succeed())
 					Expect(fw.AsKubeAdmin.CommonController.DeleteAllSnapshotEnvBindingsInASpecificNamespace(fw.UserNamespace, 30*time.Second)).To(Succeed())
 					Expect(fw.AsKubeAdmin.IntegrationController.DeleteAllSnapshotsInASpecificNamespace(fw.UserNamespace, 30*time.Second)).To(Succeed())

--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -113,7 +113,12 @@ var _ = framework.RhtapDemoSuiteDescribe(Label("rhtap-demo"), func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					if !CurrentSpecReport().Failed() {
-						Expect(fw.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
+						if err := fw.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(namespace, 60*time.Second); err != nil {
+							if err := fw.AsKubeAdmin.StoreAllArtifactsForNamespace(namespace); err != nil {
+								Fail(fmt.Sprintf("error archiving artifacts:\n%s", err))
+							}
+							Fail(fmt.Sprintf("error deleting all componentns in namespace:\n%s", err))
+						}
 						Expect(fw.AsKubeAdmin.HasController.DeleteAllApplicationsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
 						Expect(fw.AsKubeAdmin.CommonController.DeleteAllSnapshotEnvBindingsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())
 						Expect(fw.AsKubeAdmin.IntegrationController.DeleteAllSnapshotsInASpecificNamespace(namespace, 30*time.Second)).To(Succeed())


### PR DESCRIPTION
# Description
This PR is based on top of https://github.com/redhat-appstudio/e2e-tests/pull/745. It addressed the one change request I had there (as @jsmid1 is not working this week).
It also (which is the main part of this PR) stores (hopefully) all relevant (and some probably unrelevant) artifacts when `DeleteAllComponentsInASpecificNamespace` fails. This should help with investigation of [RHTAPBUGS-540](https://issues.redhat.com//browse/RHTAPBUGS-540).

## Issue ticket number and link
https://issues.redhat.com/browse/RHTAPBUGS-540
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

For a while I had a commit that would trigger the archivation logic for each afterall in `rhtap-demo.go`. This is the result: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/redhat-appstudio_e2e-tests/757/pull-ci-redhat-appstudio-e2e-tests-main-redhat-appstudio-e2e/1700142909791145984/artifacts/redhat-appstudio-e2e/redhat-appstudio-e2e/artifacts/rp_preproc/attachments/xunit/

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
