### PR TITLE
fix(RHTAPBUGS-769): Enable the namespace-backed-environments test again

### DIFF
--- a/tests/integration-service/namespace-backed-environments.go
+++ b/tests/integration-service/namespace-backed-environments.go
@@ -43,9 +43,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment 
 	AfterEach(framework.ReportFailure(&f))
 
 	Describe("the component with git source (GitHub) is created", Ordered, func() {
-		BeforeAll(func() {
-			Skip(fmt.Sprintln("test skipped"))
-		})
 		createApp := func() {
 			applicationName = fmt.Sprintf("integ-app-%s", util.GenerateRandomString(4))
 


### PR DESCRIPTION
## Description
This PR enables the test that was skipped (https://github.com/redhat-appstudio/e2e-tests/pull/764), because the [fix for the change](https://github.com/redhat-appstudio/infra-deployments/pull/2402) now has been merged and has solved the issue (see the green CI).


## Issue ticket number and link
[RHTAPBUGS-769](https://issues.redhat.com/browse/RHTAPBUGS-769)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I've tested this locally in my cluster.
