### PR TITLE
fix: fail pac-build tests for redhat-appstudio-qe org if private image repo creation fails

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -66,10 +66,15 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 				Skip("Using private cluster (not reachable from Github), skipping...")
 			}
 
+			quayOrg := utils.GetEnv("DEFAULT_QUAY_ORG", "")
 			supports, err := build.DoesQuayOrgSupportPrivateRepo()
 			Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("error while checking if quay org supports private repo: %+v", err))
 			if !supports {
-				Skip("Quay org does not support private quay repository creation, please add support for private repo creation before running this test")
+				if quayOrg == "redhat-appstudio-qe" {
+					Fail("Failed to create private image repo in redhat-appstudio-qe org")
+				} else {
+					Skip("Quay org does not support private quay repository creation, please add support for private repo creation before running this test")
+				}
 			}
 			Expect(err).ShouldNot(HaveOccurred())
 


### PR DESCRIPTION
# Description

pac-build test was skipped if the private image repo creation failed, it should be skipped when running locally but should fail the tests in case private repo creation does not work

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
