### PR TITLE
fix(load-test): replace scenarioContent string with a key=value set in the output JSON

### DIFF
--- a/tests/load-tests/cluster_read_config.yaml
+++ b/tests/load-tests/cluster_read_config.yaml
@@ -120,5 +120,6 @@
   command: oc get nodes -l node-role.kubernetes.io/worker -o json | jq '.items | map(.metadata.name)'
   output: json
 
-- name: metadata.scenarioContent
-  command: cat /usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${SCENARIO}
+- name: metadata.scenario
+  command: cat /usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${SCENARIO} | sed 's/\\ /,/g' | sed 's/[^ ]* \([^= ]*\)=\([^= ]*\)/"\1":"\2",/g' | sed 's/\(.*\),$/{\1}/g'
+  output: json

--- a/tests/load-tests/run-max-concurrency.sh
+++ b/tests/load-tests/run-max-concurrency.sh
@@ -39,7 +39,7 @@ if [ ${#USER_PREFIX} -gt 10 ]; then
     exit 1
 else
     output="$output_dir/load-tests.max-concurrency.json"
-    IFS=" " read -r -a maxConcurrencySteps <<<"${MAX_CONCURRENCY_STEPS:-1 5 10 25 50 100 150 200}"
+    IFS="," read -r -a maxConcurrencySteps <<<"$(echo "${MAX_CONCURRENCY_STEPS:-1\ 5\ 10\ 25\ 50\ 100\ 150\ 200}" | sed 's/ /,/g')"
     maxThreads=${MAX_THREADS:-10}
     threshold=${THRESHOLD:-300}
     echo '{"startTimestamp":"'$(date +%FT%T%:z)'", "maxThreads": '"$maxThreads"', "maxConcurrencySteps": "'"${maxConcurrencySteps[*]}"'", "threshold": '"$threshold"', "maxConcurrencyReached": 0, "endTimestamp": ""}' | jq >"$output"

--- a/tests/load-tests/run.sh
+++ b/tests/load-tests/run.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 export MY_GITHUB_ORG GITHUB_TOKEN
 
-
 # Check if the RANDOM_STRING environment variable is declared. If it's declared, include the -r flag when invoking loadtest.go
 if [ -n "${RANDOM_PREFIX+x}" ]; then
     RANDOM_PREFIX_FLAG="-r"
@@ -12,19 +11,19 @@ fi
 output_dir="${OUTPUT_DIR:-.}"
 USER_PREFIX=${USER_PREFIX:-testuser}
 # Max length of compliant username is 20 characters. We add -"-XXXXX-XXXX" suffix for the test users' name so max length of the prefix is 9.
-# Random string addition will not apply for Openshift-CI load tests 
-# Therefore: the "-XXXXXX" addition to user prefix will be the PR number for OpenShift Presubmit jobs  
+# Random string addition will not apply for Openshift-CI load tests
+# Therefore: the "-XXXXXX" addition to user prefix will be the PR number for OpenShift Presubmit jobs
 # The same addition will be for the 5 chars long random string for non OpenShift-CI load tests
 # The last "XXXX" would be for the suffix running index added to the test users in cmd/loadTests.go
 # Comment: run-max-concurrency.sh is used for max-concurrency type of Open-Shift-CI jobs and it wasn't changed
 # See https://github.com/codeready-toolchain/toolchain-common/blob/master/pkg/usersignup/usersignup.go#L16
 
 # If adding random prefix we can allow only up to 9 characters long user prefix
-if [ ${#USER_PREFIX} -gt 9 -a RANDOM_PREFIX_FLAG="-r"]; then
+if [ ${#USER_PREFIX} -gt 9 -a RANDOM_PREFIX_FLAG="-r" ]; then
     echo "Maximal allowed length of user prefix is 9 characters. The '$USER_PREFIX' length of ${#USER_PREFIX} exceeds the limit."
     exit 1
-# If adding not adding random prefix we can allow only up to 15 characters long user prefix    
-elif [ ${#USER_PREFIX} -gt 15 -a RANDOM_PREFIX_FLAG=""]; then
+# If adding not adding random prefix we can allow only up to 15 characters long user prefix
+elif [ ${#USER_PREFIX} -gt 15 -a RANDOM_PREFIX_FLAG="" ]; then
     echo "Maximal allowed length of user prefix is 15 characters. The '$USER_PREFIX' length of ${#USER_PREFIX} exceeds the limit."
 else
     ## Enable profiling in Tekton controller


### PR DESCRIPTION
# Description

Currently, the load test output JSON contains the `.metadata.stringContent` field with the content of the `SCENARIO` variable set by the CI. However, since the variable is provided by the CI as secret, the actual value in the JSON is censored by the CI (assuming the `SCENARIO` value is `export USER_PREFIX=ci-quarkus USERS_PER_THREAD=10 THREADS=10`):
```
...
  "metadata": {
    ...
    "env": {
      ...
      "SCENARIO": "ci-daily-10u-10t"
    },
    "scenarioContent": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
  },
...
```

This PR replaces the `.metadata.scenarioContent` string value with a parsed set of key=value pairs found in the `SCENARIO` variable (since the content format is `export env=value env2=value2 ...`) and renames the field to `.metadata.scenario`

So, with this PR the respective part of the JSON looks like:
```
...
  "metadata": {
    ...
    "env": {
      ...
      "SCENARIO": "ci-daily-10u-10t"
    },
    "scenario": {
      "THREADS": 10",
      "USER_PREFIX": "ci-quarkus",
      "USERS_PER_THREAD": "10"
    }
  },
...
```

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
