### PR TITLE
test: skip get-file-content test

### DIFF
--- a/tests/spi/get-file-content.go
+++ b/tests/spi/get-file-content.go
@@ -19,7 +19,9 @@ import (
  * Description: SVPI-402 - Get file content from a private Github repository
  */
 
-var _ = framework.SPISuiteDescribe(Label("spi-suite", "get-file-content"), func() {
+// pending because https://github.com/redhat-appstudio/service-provider-integration-operator/pull/706 will break the tests
+// we will need to update the current test after merging the PR
+var _ = framework.SPISuiteDescribe(Label("spi-suite", "get-file-content"), Pending, func() {
 
 	defer GinkgoRecover()
 


### PR DESCRIPTION
# Description

https://github.com/redhat-appstudio/service-provider-integration-operator/pull/706 will break the `get-file-content` test. Skipping it temporarily until the PR is merge and the test rewrite

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
