### PR TITLE
fix: register PaC proxy server in nightly job

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -288,11 +288,10 @@ func PreflightChecks() error {
 
 func (ci CI) setRequiredEnvVars() error {
 
-	if strings.Contains(jobName, "hacbs-e2e-periodic") {
-		os.Setenv("E2E_TEST_SUITE_LABEL", "HACBS")
-		return nil
-	} else if strings.Contains(jobName, "appstudio-e2e-deployment-periodic") {
-		os.Setenv("E2E_TEST_SUITE_LABEL", "!HACBS")
+	// RHTAP Nightly E2E job
+	// The job name is taken from https://github.com/openshift/release/blob/f03153fa4ad36c0e10050d977e7f0f7619d2163a/ci-operator/config/redhat-appstudio/infra-deployments/redhat-appstudio-infra-deployments-main.yaml#L59C7-L59C35
+	if strings.Contains(jobName, "appstudio-e2e-tests-periodic") {
+		requiresSprayProxyRegistering = true
 		return nil
 	}
 


### PR DESCRIPTION
# Description

Since PaC tests [now require Github App](https://github.com/redhat-appstudio/e2e-tests/pull/703), we need to register every PaC server (that's created by every e2e job) to the [PaC spray proxy server](https://github.com/redhat-appstudio/e2e-tests/pull/703/files#diff-d7a1577b2d546e34aaf816bdd1b83edef28a66a555f049767bafa83268b7efbbR228) in every e2e-tests job that is configured to run PaC tests (you can find more details about this in [the linked PR](https://github.com/redhat-appstudio/e2e-tests/pull/703))

This was not done for periodic jobs which explains why PaC tests were failing to register a PipelineRuns for created Components.

## Issue ticket number and link
https://issues.redhat.com/browse/RHTAPBUGS-841

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

it has to be tested in a periodic job

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
