### PR TITLE
feat: check Chains signing secret is present

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -37,6 +37,9 @@ const (
 	// User for running the end-to-end Tekton Chains tests
 	TEKTON_CHAINS_E2E_USER string = "chains-e2e"
 
+	// Name of the Secret Tekton Chains uses to read signing key
+	TEKTON_CHAINS_SIGNING_SECRETS_NAME = "signing-secrets"
+
 	//Cluster Registration namespace
 	CLUSTER_REG_NS string = "cluster-reg-config" // #nosec
 

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -71,7 +71,7 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 				_, password := config.Data["cosign.password"]
 
 				return private && public && password
-			}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting Tekton Chains signing secret %q to be present in %q namespace", constants.TEKTON_CHAINS_SIGNING_SECRETS_NAME, constants.TEKTON_CHAINS_NS))
+			}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for Tekton Chains signing secret %q to be present in %q namespace", constants.TEKTON_CHAINS_SIGNING_SECRETS_NAME, constants.TEKTON_CHAINS_NS))
 		})
 	})
 

--- a/tests/build/chains.go
+++ b/tests/build/chains.go
@@ -57,6 +57,22 @@ var _ = framework.ChainsSuiteDescribe("Tekton Chains E2E tests", Label("ec", "HA
 			err := kubeClient.CommonController.WaitForPodSelector(kubeClient.CommonController.IsPodRunning, constants.TEKTON_CHAINS_NS, "app", "tekton-chains-controller", 60, 100)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		It("verifies the signing secret is present", func() {
+			timeout := time.Minute * 5
+			interval := time.Second * 1
+
+			Eventually(func() bool {
+				config, err := kubeClient.CommonController.GetSecret(constants.TEKTON_CHAINS_NS, constants.TEKTON_CHAINS_SIGNING_SECRETS_NAME)
+				Expect(err).NotTo(HaveOccurred())
+
+				_, private := config.Data["cosign.key"]
+				_, public := config.Data["cosign.pub"]
+				_, password := config.Data["cosign.password"]
+
+				return private && public && password
+			}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting Tekton Chains signing secret %q to be present in %q namespace", constants.TEKTON_CHAINS_SIGNING_SECRETS_NAME, constants.TEKTON_CHAINS_NS))
+		})
 	})
 
 	Context("test creating and signing an image and task", Label("pipeline"), func() {


### PR DESCRIPTION
# Description

Adds a test to check if the Tekton Chains signing secret required to generate image and attestation signatures is present.

## Issue ticket number and link

Ref. https://issues.redhat.com/browse/HACBS-2623

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

We'll see on the test run

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
