### PR TITLE
feat: To detect KPI, let's use whole workload as deployment might take tenths of seconds as well

### DIFF
--- a/cmd/loadTests.go
+++ b/cmd/loadTests.go
@@ -177,6 +177,8 @@ type LogData struct {
 	IntegrationTestsPipelineRunFailureCount int64   `json:"integrationTestsRunPipelineFailures"`
 	IntegrationTestsPipelineRunFailureRate  float64 `json:"integrationTestsRunPipelineFailureRate"`
 
+	WorkloadKPI float64 `json:"workloadKPI"`
+
 	ErrorCounts []ErrorCount      `json:"errorCounts"`
 	Errors      []ErrorOccurrence `json:"errors"`
 	ErrorsTotal int               `json:"errorsTotal"`
@@ -623,12 +625,17 @@ func setup(cmd *cobra.Command, args []string) {
 	deploymentFailureRate := float64(deploymentFailureCount) / float64(overallCount)
 	logData.DeploymentFailureRate = deploymentFailureRate
 
+	workloadKPI := logData.AverageTimeToCreateApplications + logData.AverageTimeToCreateCDQs + logData.AverageTimeToCreateComponents + logData.AverageTimeToRunPipelineSucceeded + logData.AverageTimeToDeploymentSucceeded
+	logData.WorkloadKPI = workloadKPI
 	if stage {
 		StageCleanup(selectedUsers)
 	}
 
 	klog.Infof("🏁 Load Test Completed!")
 	klog.Infof("📈 Results 📉")
+
+	klog.Infof("Workload KPI: %.2f", workloadKPI)
+
 	klog.Infof("Avg/max time to spin up users: %.2f s/%.2f s", averageTimeToSpinUpUsers, logData.MaxTimeToSpinUpUsers)
 	klog.Infof("Avg/max time to create application: %.2f s/%.2f s", averageTimeToCreateApplications, logData.MaxTimeToCreateApplications)
 	klog.Infof("Avg/max time to create cdq: %.2f s/%.2f s", averageTimeToCreateCDQs, logData.MaxTimeToCreateCDQs)

--- a/tests/load-tests/ci-scripts/max-concurrency/collect-results.sh
+++ b/tests/load-tests/ci-scripts/max-concurrency/collect-results.sh
@@ -67,6 +67,7 @@ dt_format='"%Y-%m-%dT%H:%M:%SZ"'
 ## Max concurrency scalability
 max_concurrency_csv=$ARTIFACT_DIR/max-concurrency.csv
 echo "Threads\
+${csv_delim}WorkloadKPI\
 ${csv_delim}Errors\
 ${csv_delim}UserAvgTime\
 ${csv_delim}UserMaxTime\
@@ -103,6 +104,7 @@ mc_files=$(find "$output_dir" -type f -name 'load-tests.max-concurrency.*.json')
 if [ -n "$mc_files" ]; then
     cat $mc_files |
         jq -rc "(.threads | tostring) \
+        + $csv_delim_quoted + (.workloadKPI | tostring) \
         + $csv_delim_quoted + (.errorsTotal | tostring) \
         + $csv_delim_quoted + (.createUserTimeAvg | tostring) \
         + $csv_delim_quoted + (.createUserTimeMax | tostring) \

--- a/tests/load-tests/ci-scripts/max-concurrency/collect-results.sh
+++ b/tests/load-tests/ci-scripts/max-concurrency/collect-results.sh
@@ -92,7 +92,7 @@ ${csv_delim}TokenPoolRateSecondaryAvg\
 ${csv_delim}ClusterPipelineRunCountAvg\
 ${csv_delim}ClusterPipelineWorkqueueDepthAvg\
 ${csv_delim}ClusterPipelineScheduleFirstPodAvg\
-${csv_delim}ClusterTaskrunThrottledByNodeResourcesAvg\
+${csv_delim}ClusterTaskRunThrottledByNodeResourcesAvg\
 ${csv_delim}ClusterTaskRunThrottledByDefinedQuotaAvg\
 ${csv_delim}EtcdRequestDurationSecondsAvg\
 ${csv_delim}ClusterNetworkBytesTotalAvg\

--- a/tests/load-tests/ci-scripts/max-concurrency/collect-results.sh
+++ b/tests/load-tests/ci-scripts/max-concurrency/collect-results.sh
@@ -79,6 +79,10 @@ ${csv_delim}ComponentsAvgTime\
 ${csv_delim}ComponentsMaxTime\
 ${csv_delim}PipelineRunAvgTime\
 ${csv_delim}PipelineRunMaxTime\
+${csv_delim}integrationTestsRunPipelineSucceededTimeAvg\
+${csv_delim}integrationTestsRunPipelineSucceededTimeMax\
+${csv_delim}deploymentSucceededTimeAvg\
+${csv_delim}deploymentSucceededTimeMax\
 ${csv_delim}ClusterCPUUsageAvg\
 ${csv_delim}ClusterDiskUsageAvg\
 ${csv_delim}ClusterMemoryUsageAvg\
@@ -116,6 +120,10 @@ if [ -n "$mc_files" ]; then
         + $csv_delim_quoted + (.createComponentsTimeMax | tostring) \
         + $csv_delim_quoted + (.runPipelineSucceededTimeAvg | tostring) \
         + $csv_delim_quoted + (.runPipelineSucceededTimeMax | tostring) \
+        + $csv_delim_quoted + (.integrationTestsRunPipelineSucceededTimeAvg | tostring) \
+        + $csv_delim_quoted + (.integrationTestsRunPipelineSucceededTimeMax | tostring) \
+        + $csv_delim_quoted + (.deploymentSucceededTimeAvg | tostring) \
+        + $csv_delim_quoted + (.deploymentSucceededTimeMax | tostring) \
         + $csv_delim_quoted + (.measurements.cluster_cpu_usage_seconds_total_rate.mean | tostring) \
         + $csv_delim_quoted + (.measurements.cluster_disk_throughput_total.mean | tostring) \
         + $csv_delim_quoted + (.measurements.cluster_memory_usage_rss_total.mean | tostring) \

--- a/tests/load-tests/run-max-concurrency.sh
+++ b/tests/load-tests/run-max-concurrency.sh
@@ -80,6 +80,8 @@ else
         else
             jq ".maxConcurrencyReached = $t" "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"
             jq '.endTimestamp = "'$(date +%FT%T%:z)'"' "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"
+            errorsTotal=$(jq '.errorsTotal' "$output_dir/load-tests.json")
+            jq ".errorsTotalLast = $errorsTotal" "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"
         fi
     done
     DRY_RUN=false ./clear.sh "$USER_PREFIX"

--- a/tests/load-tests/run-max-concurrency.sh
+++ b/tests/load-tests/run-max-concurrency.sh
@@ -73,10 +73,9 @@ else
         index=$(printf "%04d" "$t")
         cp -vf "$output_dir/load-tests.json" "$output_dir/load-tests.max-concurrency.$index.json"
         cp -vf "$output_dir/load-tests.log" "$output_dir/load-tests.max-concurrency.$index.log"
-        pipelineRunThresholdExceeded=$(jq -rc ".runPipelineSucceededTimeMax > $threshold" "$output_dir/load-tests.json")
-        pipelineRunKPI=$(jq -rc ".runPipelineSucceededTimeMax" "$output_dir/load-tests.json")
-        if [ "$pipelineRunThresholdExceeded" = "true" ]; then
-            echo "The maximal time a pipeline run took to succeed (${pipelineRunKPI}s) has exceeded a threshold of ${threshold}s with $t threads."
+        workloadKPI=$(jq '.createApplicationsTimeAvg + .createCDQsTimeAvg + .createComponentsTimeAvg + .integrationTestsRunPipelineSucceededTimeAvg + .runPipelineSucceededTimeAvg + .deploymentSucceededTimeAvg' "$output_dir/load-tests.json")
+        if [ "$workloadKPI" -gt "$threshold" ]; then
+            echo "The average time a workload took to succeed (${workloadKPI}s) has exceeded a threshold of ${threshold}s with $t threads."
             break
         else
             jq ".maxConcurrencyReached = $t" "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"

--- a/tests/load-tests/run-max-concurrency.sh
+++ b/tests/load-tests/run-max-concurrency.sh
@@ -76,14 +76,14 @@ else
         workloadKPI=$(jq '.workloadKPI' "$output_dir/load-tests.json")
         if awk "BEGIN { exit !($workloadKPI > $threshold)}"; then
             echo "The average time a workload took to succeed (${workloadKPI}s) has exceeded a threshold of ${threshold}s with $t threads."
-            indexOld=$(printf "%04d" "$(($t - 1))")
-            workloadKPIOld=$(jq '.workloadKPI' "$output_dir/load-tests.max-concurrency.$indexOld.json")
-            threadsOld=$(jq '.maxConcurrencyReached' "$output_dir/load-tests.max-concurrency.$indexOld.json")
+            workloadKPIOld=$(jq '.workloadKPI' "$output")
+            threadsOld=$(jq '.maxConcurrencyReached' "$output")
             computedConcurrency=$(python -c "import sys; t = float(sys.argv[1]); a = float(sys.argv[2]); b = float(sys.argv[3]); c = float(sys.argv[4]); d = float(sys.argv[5]); print((t - b) / ((d - b) / (c - a)) + a)" "$threshold" "$threadsOld" "$workloadKPIOld" "$t" "$workloadKPI")
             jq ".computedConcurrency = $computedConcurrency" "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"
             break
         else
             jq ".maxConcurrencyReached = $t" "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"
+            jq ".workloadKPI = $workloadKPI" "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"
             jq '.endTimestamp = "'$(date +%FT%T%:z)'"' "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"
             errorsTotal=$(jq '.errorsTotal' "$output_dir/load-tests.json")
             jq ".errorsTotal = $errorsTotal" "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"

--- a/tests/load-tests/run-max-concurrency.sh
+++ b/tests/load-tests/run-max-concurrency.sh
@@ -84,6 +84,7 @@ else
         else
             jq ".maxConcurrencyReached = $t" "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"
             jq ".workloadKPI = $workloadKPI" "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"
+            jq ".computedConcurrency = $t" "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"
             jq '.endTimestamp = "'$(date +%FT%T%:z)'"' "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"
             errorsTotal=$(jq '.errorsTotal' "$output_dir/load-tests.json")
             jq ".errorsTotal = $errorsTotal" "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"

--- a/tests/load-tests/run-max-concurrency.sh
+++ b/tests/load-tests/run-max-concurrency.sh
@@ -76,6 +76,11 @@ else
         workloadKPI=$(jq '.workloadKPI' "$output_dir/load-tests.json")
         if awk "BEGIN { exit !($workloadKPI > $threshold)}"; then
             echo "The average time a workload took to succeed (${workloadKPI}s) has exceeded a threshold of ${threshold}s with $t threads."
+            indexOld=$(printf "%04d" "$(($t - 1))")
+            workloadKPIOld=$(jq '.workloadKPI' "$output_dir/load-tests.max-concurrency.$indexOld.json")
+            threadsOld=$(jq '.maxConcurrencyReached' "$output_dir/load-tests.max-concurrency.$indexOld.json")
+            computedConcurrency=$(python -c "import sys; t = float(sys.argv[1]); a = float(sys.argv[2]); b = float(sys.argv[3]); c = float(sys.argv[4]); d = float(sys.argv[5]); print((t - b) / ((d - b) / (c - a)) + a)" "$threshold" "$threadsOld" "$workloadKPIOld" "$t" "$workloadKPI")
+            jq ".computedConcurrency = $computedConcurrency" "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"
             break
         else
             jq ".maxConcurrencyReached = $t" "$output" >"$output_dir/$$.json" && mv -f "$output_dir/$$.json" "$output"

--- a/tests/load-tests/run-max-concurrency.sh
+++ b/tests/load-tests/run-max-concurrency.sh
@@ -43,7 +43,7 @@ else
     IFS="," read -r -a maxConcurrencySteps <<<"$(echo "${MAX_CONCURRENCY_STEPS:-1\ 5\ 10\ 25\ 50\ 100\ 150\ 200}" | sed 's/ /,/g')"
     maxThreads=${MAX_THREADS:-10}
     threshold=${THRESHOLD:-300}
-    echo '{"startTimestamp":"'$(date +%FT%T%:z)'", "maxThreads": '"$maxThreads"', "maxConcurrencySteps": "'"${maxConcurrencySteps[*]}"'", "threshold": '"$threshold"', "maxConcurrencyReached": 0, "endTimestamp": "", "errorsTotal": -1}' | jq >"$output"
+    echo '{"startTimestamp":"'$(date +%FT%T%:z)'", "maxThreads": '"$maxThreads"', "maxConcurrencySteps": "'"${maxConcurrencySteps[*]}"'", "threshold": '"$threshold"', "maxConcurrencyReached": 0, "computedConcurrency": 0, "workloadKPI": 0, "endTimestamp": "", "errorsTotal": -1}' | jq >"$output"
     for t in "${maxConcurrencySteps[@]}"; do
         if (("$t" > "$maxThreads")); then
             break


### PR DESCRIPTION
# Description

To detect KPI, let's use whole workload as deployment might take tenths of seconds as well. This approach is also used when I measure Stage KPI.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Going to test this in CI in this PR

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
