### PR TITLE
fix: build: validating PaC checks status

### DIFF
--- a/pkg/apis/github/pull_request.go
+++ b/pkg/apis/github/pull_request.go
@@ -54,3 +54,11 @@ func (g *Github) ListCheckSuites(repository string, ref string) ([]*github.Check
 	}
 	return checkSuiteResults.CheckSuites, nil
 }
+
+func (g *Github) GetCheckSuite(repository string, id int64) (*github.CheckSuite, error) {
+	checkSuite, _, err := g.client.Checks.GetCheckSuite(context.Background(), g.organization, repository, id)
+	if err != nil {
+		return nil, fmt.Errorf("error when getting check suite with id %d for the repo %s: %v", id, repository, err)
+	}
+	return checkSuite, nil
+}


### PR DESCRIPTION
# Description

* fix for [RHTAPBUGS-844](https://issues.redhat.com//browse/RHTAPBUGS-844)
* removed superfluous code related to PaC
  * getting PaC controller route from `pipelines-as-code` namespace
  * deleting GitHub webhooks after the test is finished

## Issue ticket number and link
https://issues.redhat.com/browse/RHTAPBUGS-844

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
ginkgo -v --label-filter='pac-build' ./cmd/
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
