### PR TITLE
fix: compatibility with OSP 1.12

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -1136,7 +1136,10 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 			pr, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(pr.Spec.PipelineRef.Bundle).To(Equal(dummyPipelineBundleRef)) //nolint:all
+			Expect(pr.Spec.PipelineRef.Params).To(ContainElement(v1beta1.Param{
+				Name:  "bundle",
+				Value: v1beta1.ParamValue{StringVal: dummyPipelineBundleRef, Type: "string"}},
+			))
 			Expect(pr.Spec.Params).To(ContainElement(v1beta1.Param{
 				Name:  expectedAdditionalPipelineParam.Name,
 				Value: v1beta1.ParamValue{StringVal: expectedAdditionalPipelineParam.Value, Type: "string"}},


### PR DESCRIPTION
# Description

[version bump to OSP 1.12](https://github.com/redhat-appstudio/infra-deployments/pull/2521) caused one test to fail due to API incompatibility. this PR fixes it

## Issue ticket number and link
https://issues.redhat.com/browse/RHTAPBUGS-872

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI 🤷 

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
