### PR TITLE
fix: use CheckRuns for validating PaC build result

### DIFF
--- a/pkg/apis/github/pull_request.go
+++ b/pkg/apis/github/pull_request.go
@@ -47,18 +47,18 @@ func (g *Github) MergePullRequest(repository string, prNumber int) (*github.Pull
 	return mergeResult, nil
 }
 
-func (g *Github) ListCheckSuites(repository string, ref string) ([]*github.CheckSuite, error) {
-	checkSuiteResults, _, err := g.client.Checks.ListCheckSuitesForRef(context.Background(), g.organization, repository, ref, &github.ListCheckSuiteOptions{})
+func (g *Github) ListCheckRuns(repository string, ref string) ([]*github.CheckRun, error) {
+	checkRunResults, _, err := g.client.Checks.ListCheckRunsForRef(context.Background(), g.organization, repository, ref, &github.ListCheckRunsOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error when listing check suites for the repo %s: %v", repository, err)
+		return nil, fmt.Errorf("error when listing check runs for the repo %s and ref %s: %v", repository, ref, err)
 	}
-	return checkSuiteResults.CheckSuites, nil
+	return checkRunResults.CheckRuns, nil
 }
 
-func (g *Github) GetCheckSuite(repository string, id int64) (*github.CheckSuite, error) {
-	checkSuite, _, err := g.client.Checks.GetCheckSuite(context.Background(), g.organization, repository, id)
+func (g *Github) GetCheckRun(repository string, id int64) (*github.CheckRun, error) {
+	checkRun, _, err := g.client.Checks.GetCheckRun(context.Background(), g.organization, repository, id)
 	if err != nil {
-		return nil, fmt.Errorf("error when getting check suite with id %d for the repo %s: %v", id, repository, err)
+		return nil, fmt.Errorf("error when getting check run with id %d for the repo %s: %v", id, repository, err)
 	}
-	return checkSuite, nil
+	return checkRun, nil
 }


### PR DESCRIPTION
# Description

this PR fixes a bug that is caused by a missing feature in spray-proxy - more details here: [PLNSRVCE-1488](https://issues.redhat.com//browse/PLNSRVCE-1488)

the test is updated to validate a status of individual [checkrun](https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28) instead of checksuite. it is still a proper way to test the PaC functionality and at the same time it's a workaround for the spray-proxy issue.

## Issue ticket number and link
https://issues.redhat.com/browse/RHTAPBUGS-848

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested on 2 different clusters to reproduce the issue with spray proxy and verify that the test works as expected
```
ginkgo -v --label-filter='custom-branch' ./cmd/
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
