### PR TITLE
fix(RHTAPBUGS-880): missing source metadata in snapshot

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -292,6 +292,13 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 								{
 									Name:           componentNames[i],
 									ContainerImage: imageWithDigest,
+									Source: v1alpha1.ComponentSource{
+										ComponentSourceUnion: v1alpha1.ComponentSourceUnion{
+											GitSource: &v1alpha1.GitSource{
+												URL: gitUrl,
+											},
+										},
+									},
 								},
 							},
 						},


### PR DESCRIPTION
# Description

e2e test must generate snapshot with git source otherwise EC returns warning about missing sources instead of expected "success" result.

## Issue ticket number and link
[RHTAPBUGS-880](https://issues.redhat.com/browse/RHTAPBUGS-880)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
