### PR TITLE
fix(RHTAPBUGS-883): make sure revision is set

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -285,6 +285,11 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 					}
 					Expect(kubeadminClient.TektonController.CreateOrUpdatePolicyConfiguration(testNamespace, policy)).To(Succeed())
 
+					pipelineRun, err := kubeadminClient.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, "")
+					Expect(err).ToNot(HaveOccurred())
+
+					rev := pipelineRun.Annotations["pipelinesascode.tekton.dev/sha"]
+
 					generator := tekton.VerifyEnterpriseContract{
 						Snapshot: v1alpha1.SnapshotSpec{
 							Application: applicationName,
@@ -295,7 +300,8 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 									Source: v1alpha1.ComponentSource{
 										ComponentSourceUnion: v1alpha1.ComponentSourceUnion{
 											GitSource: &v1alpha1.GitSource{
-												URL: gitUrl,
+												URL:      gitUrl,
+												Revision: rev,
 											},
 										},
 									},


### PR DESCRIPTION
# Description

In fixing [RHTAPBUGS-880](https://issues.redhat.com//browse/RHTAPBUGS-880) we found out that the policy did not correctly handle undefined source revision, which lead to [RHTAPBUGS-883](https://issues.redhat.com//browse/RHTAPBUGS-883).

Before we merge [RHTAPBUGS-883](https://issues.redhat.com//browse/RHTAPBUGS-883) we need to make sure that the revision is passed via the parameters to EC so that the change for fixing [RHTAPBUGS-883](https://issues.redhat.com//browse/RHTAPBUGS-883) doesn't break e2e tests.

## Issue ticket number and link

[RHTAPBUGS-883](https://issues.redhat.com//browse/RHTAPBUGS-883), relates to [RHTAPBUGS-880](https://issues.redhat.com//browse/RHTAPBUGS-880)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Prow will take care of this... :crossed_fingers: 

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
