### PR TITLE
fix: remove faulty EC test

### DIFF
--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -98,25 +98,6 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 			Expect(reportLog).Should(ContainSubstring("No image attestations found matching the given public key"))
 		})
 
-		It("verifies ec cli supports the current policy config fields used by the ec-policies rego rules", func() {
-			pr, err := fwk.AsKubeAdmin.TektonController.RunPipeline(generator, namespace, pipelineRunTimeout)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(fwk.AsKubeAdmin.TektonController.WatchPipelineRun(pr.Name, namespace, pipelineRunTimeout)).To(Succeed())
-
-			pr, err = fwk.AsKubeAdmin.TektonController.GetPipelineRun(pr.Name, pr.Namespace)
-			Expect(err).NotTo(HaveOccurred())
-
-			tr, err := fwk.AsKubeAdmin.TektonController.GetTaskRunStatus(fwk.AsKubeAdmin.CommonController.KubeRest(), pr, "verify-enterprise-contract")
-			Expect(err).NotTo(HaveOccurred())
-
-			//Get container step-report log details from pod
-			reportLog, err := utils.GetContainerLogs(fwk.AsKubeAdmin.CommonController.KubeInterface(), tr.Status.PodName, "step-report", namespace)
-			GinkgoWriter.Printf("*** Logs from pod '%s', container '%s':\n----- START -----%s----- END -----\n", tr.Status.PodName, "step-report", reportLog)
-			Expect(err).NotTo(HaveOccurred())
-			//assert ec cli support policy config include field
-			Expect(reportLog).Should(ContainSubstring("include"))
-		})
-
 		It("verifies ec validate accepts a list of image references", func() {
 			secretName := fmt.Sprintf("golden-image-public-key%s", util.GenerateRandomString(10))
 			GinkgoWriter.Println("Update public key to verify golden images")


### PR DESCRIPTION
# Description

The test "ec cli supports the current policy config fields" looks at the output of the verify ec task and looks for the presence of a certain string. This is taken as a way to verify the policy config is being propagated to the task properly. This is a weak assertion because the particular string may appear somewhere else. Also, this is checking a very specific behavior of the EC cli and not an integration test. There is already sufficient test coverage on the EC cli's own tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
