### PR TITLE
fix: only require the inspect-image task for FBC PLRs

### DIFF
--- a/pkg/utils/build/task_results.go
+++ b/pkg/utils/build/task_results.go
@@ -38,8 +38,10 @@ type Vulnerabilities struct {
 
 func ValidateBuildPipelineTestResults(pipelineRun *v1beta1.PipelineRun, c crclient.Client) error {
 	for _, taskName := range taskNames {
-		// The inspect-image task is only required for FBC pipelines
-		if taskName == "inspect-image" && !strings.Contains(strings.ToLower(pipelineRun.GetName()),"fbc") {
+		// The inspect-image task is only required for FBC pipelines which we can infer by the component name
+		prLabels := pipelineRun.GetLabels()
+		componentName := prLabels["appstudio.openshift.io/component"]
+		if taskName == "inspect-image" && !strings.HasPrefix(strings.ToLower(componentName),"fbc-") {
 			continue
 		}
 		results, err := fetchTaskRunResults(c, pipelineRun, taskName)

--- a/pkg/utils/build/task_results.go
+++ b/pkg/utils/build/task_results.go
@@ -3,6 +3,7 @@ package build
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"fmt"
 
 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
@@ -37,6 +38,10 @@ type Vulnerabilities struct {
 
 func ValidateBuildPipelineTestResults(pipelineRun *v1beta1.PipelineRun, c crclient.Client) error {
 	for _, taskName := range taskNames {
+		// The inspect-image task is only required for FBC pipelines
+		if taskName == "inspect-image" && !strings.Contains(strings.ToLower(pipelineRun.GetName()),"fbc") {
+			continue
+		}
 		results, err := fetchTaskRunResults(c, pipelineRun, taskName)
 		if err != nil {
 			return err


### PR DESCRIPTION
# Description

In https://github.com/redhat-appstudio/build-definitions/pull/630, I am removing the inspect-image task from all but the FBC pipeline. This requires the current e2e tests to fail as it was previously required for all pipeline definitions. Removing the requirement for all but FBC pipelines.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source")~
- ~[ ] I have updated labels (if needed)~
