### PR TITLE
fix: wrong func call

### DIFF
--- a/pkg/utils/has/components.go
+++ b/pkg/utils/has/components.go
@@ -91,7 +91,7 @@ func (h *HasController) WaitForComponentPipelineToBeFinished(component *appservi
 			pr, err = h.GetComponentPipelineRun(component.GetName(), app, component.GetNamespace(), sha)
 
 			if err != nil {
-				GinkgoWriter.Printf("PipelineRun has not been created yet for the Component %s/%s\n", component.GetNamespace, component.GetName())
+				GinkgoWriter.Printf("PipelineRun has not been created yet for the Component %s/%s\n", component.GetNamespace(), component.GetName())
 				return false, nil
 			}
 


### PR DESCRIPTION
# Description

This line is logged `PipelineRun has not been created yet for the Component %!s(func() string=0x20c3060)/pip-e2e-test-6dbg`


## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Observed this issue from logs [build-definitions-pull-request-2sdjq.log](https://github.com/redhat-appstudio/e2e-tests/files/13188398/build-definitions-pull-request-2sdjq.log)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
