### PR TITLE
fix: build-templates: get valid git revision

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -236,7 +236,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 				Expect(build.ValidateBuildPipelineTestResults(pr, kubeadminClient.CommonController.KubeRest())).To(Succeed())
 			})
 
-			When(fmt.Sprintf("the container image for component with Git source URL %s is created and pushed to container registry", gitUrl), Label("sbom", "slow"), Pending, func() {
+			When(fmt.Sprintf("the container image for component with Git source URL %s is created and pushed to container registry", gitUrl), Label("sbom", "slow"), func() {
 				var imageWithDigest string
 				var pr *v1beta1.PipelineRun
 
@@ -288,7 +288,8 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 					pipelineRun, err := kubeadminClient.HasController.GetComponentPipelineRun(componentNames[i], applicationName, testNamespace, "")
 					Expect(err).ToNot(HaveOccurred())
 
-					rev := pipelineRun.Annotations["pipelinesascode.tekton.dev/sha"]
+					revision := pipelineRun.Annotations["build.appstudio.redhat.com/commit_sha"]
+					Expect(revision).ToNot(BeEmpty())
 
 					generator := tekton.VerifyEnterpriseContract{
 						Snapshot: v1alpha1.SnapshotSpec{
@@ -301,7 +302,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 										ComponentSourceUnion: v1alpha1.ComponentSourceUnion{
 											GitSource: &v1alpha1.GitSource{
 												URL:      gitUrl,
-												Revision: rev,
+												Revision: revision,
 											},
 										},
 									},


### PR DESCRIPTION
# Description

`pipelinesascode.tekton.dev/sha` was not a correct PipelineRun annotation to get the revision from, because build-templates test doesn't run PaC type of build.

`build.appstudio.redhat.com/commit_sha` annotation is valid for both simple and custom (PaC) type of builds

## Issue ticket number and link
https://issues.redhat.com/browse/RHTAPBUGS-930

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
ginkgo --focus-file tests/build/build_templates.go --v ./cmd
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
