### PR TITLE
feat(RHTAP-1726): Fix-GitHub-action-against-Stage

### DIFF
--- a/.github/workflows/loadtest.yaml
+++ b/.github/workflows/loadtest.yaml
@@ -46,8 +46,9 @@ jobs:
     - name: Collect results
       working-directory: ./tests/load-tests
       env:
-        OCP_TOKEN: ${{ secrets.OCP_TOKEN }}
         STAGE_MEMBER_CLUSTER: ${{ secrets.STAGE_MEMBER_CLUSTER }}
+        PROMETHEUS_HOST: ${{ secrets.PROMETHEUS_HOST }}
+        OCP_PROMETHEUS_TOKEN: ${{ secrets.OCP_PROMETHEUS_TOKEN }}
       run: |
         ./ci-scripts/stage/collect-results.sh .
 

--- a/.github/workflows/loadtest.yaml
+++ b/.github/workflows/loadtest.yaml
@@ -47,7 +47,6 @@ jobs:
       working-directory: ./tests/load-tests
       env:
         STAGE_MEMBER_CLUSTER: ${{ secrets.STAGE_MEMBER_CLUSTER }}
-        PROMETHEUS_HOST: ${{ secrets.PROMETHEUS_HOST }}
         OCP_PROMETHEUS_TOKEN: ${{ secrets.OCP_PROMETHEUS_TOKEN }}
       run: |
         ./ci-scripts/stage/collect-results.sh .

--- a/tests/load-tests/ci-scripts/stage/collect-results.sh
+++ b/tests/load-tests/ci-scripts/stage/collect-results.sh
@@ -4,10 +4,9 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-# Login to the stage member cluster with the OCP_TOKEN credentials
-TOKEN=$(echo ${OCP_TOKEN} | base64 -d)
+# Login to the stage member cluster with the OCP_PROMETHEUS_TOKEN credentials
+TOKEN=${OCP_PROMETHEUS_TOKEN}
 oc login --token="$TOKEN" --server="$STAGE_MEMBER_CLUSTER"
-
 
 ARTIFACT_DIR=${ARTIFACT_DIR:-.artifacts}
 mkdir -p ${ARTIFACT_DIR}
@@ -32,7 +31,7 @@ python3 -m pip install -e "git+https://github.com/redhat-performance/opl.git#egg
 echo "Collecting monitoring data..."
 mstart=$(date --utc --date "$(status_data.py --status-data-file "$monitoring_collection_data" --get timestamp)" --iso-8601=seconds)
 mend=$(date --utc --date "$(status_data.py --status-data-file "$monitoring_collection_data" --get endTimestamp)" --iso-8601=seconds)
-mhost=$(oc -n openshift-monitoring get route -l app.kubernetes.io/name=thanos-query -o json | jq --raw-output '.items[0].spec.host')
+mhost=${PROMETHEUS_HOST}
 
 status_data.py \
     --status-data-file "$monitoring_collection_data" \

--- a/tests/load-tests/ci-scripts/stage/collect-results.sh
+++ b/tests/load-tests/ci-scripts/stage/collect-results.sh
@@ -4,6 +4,11 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+# construct $PROMETHEUS_HOST by extracting BASE_URL from $STAGE_MEMBER_CLUSTER
+BASE_URL=$(echo $STAGE_MEMBER_CLUSTER | grep -oP 'https://api\.\K[^:]+')  
+PROMETHEUS_HOST="thanos-querier-openshift-monitoring.apps.$BASE_URL"
+
+
 # Login to the stage member cluster with the OCP_PROMETHEUS_TOKEN credentials
 TOKEN=${OCP_PROMETHEUS_TOKEN}
 oc login --token="$TOKEN" --server="$STAGE_MEMBER_CLUSTER"
@@ -31,7 +36,7 @@ python3 -m pip install -e "git+https://github.com/redhat-performance/opl.git#egg
 echo "Collecting monitoring data..."
 mstart=$(date --utc --date "$(status_data.py --status-data-file "$monitoring_collection_data" --get timestamp)" --iso-8601=seconds)
 mend=$(date --utc --date "$(status_data.py --status-data-file "$monitoring_collection_data" --get endTimestamp)" --iso-8601=seconds)
-mhost=${PROMETHEUS_HOST}
+mhost=$PROMETHEUS_HOST
 
 status_data.py \
     --status-data-file "$monitoring_collection_data" \


### PR DESCRIPTION
# Description
This PR implements the needed updates per the usage of the new Stage Prometheus SA created by Jan
The SA secret will be used as a token to login to the Stage member cluster hence having the authorization to query Stage Prometheus service

OCP_PROMETHEUS_TOKEN env var is the perf-team-prometheus-reader-cluster-sa Prometheus service account secret
Added PROMETHEUS_HOST env var into logic and as new secret

## Tested the GITHUB Action load_test workflow successfully 

## Issue ticket number and link
https://issues.redhat.com/browse/RHTAP-1726 - Fix GitHub action against Stage

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
1. Renamed OCP_TOKEN GITHUB Actions secret to OCP_PROMETHEUS_TOKEN and populated it with the Stage Prometheus SA secret
    a. Get your personal token for Staging member cluster (https://console-openshift-console.apps.stone-stg-m01.7ayg.p1.openshiftapps.com/dashboards) and login with your personal OCP Token into the cluster
    b. Get the OCP_PROMETHEUS_TOKEN and update the OCP_PROMETHEUS_TOKEN GITHUB Action secret
         oc -n perf-team-prometheus-reader get secret/perf-team-prometheus-reader-cluster-sa-token-cjxsc -o json | jq --raw-output '.data.token | @base64d'
         
2. Get the Prometheus host and store it in a new GITHUB Action secret (PROMETHEUS_HOST)
    oc -n openshift-monitoring get route -l app.kubernetes.io/name=thanos-query -o json | jq --raw-output '.items[0].spec.host' 
    
3. Test the GITHUB Action load_test workflow- https://github.com/naftalysh/e2e-tests/actions/workflows/loadtest.yaml
    And observed it succeeded 
    
4. Access the artifacts section and download the loadtest workflow artifacts
    https://github.com/naftalysh/e2e-tests/suites/17785727671/artifacts/1019209134
    

# How to reproduce:
Run the loadtest in my fork before this PR is merged or in redhat-appstudio org e2e-tests repo when the PR is merged
https://github.com/naftalysh/e2e-tests/actions/workflows/loadtest.yaml

# Checklist:

- [X] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
