### PR TITLE
chore: Get rid of GitOpsRepo check from Load test

### DIFF
--- a/cmd/loadTests.go
+++ b/cmd/loadTests.go
@@ -940,27 +940,6 @@ func userJourneyThread(frameworkMap *sync.Map, threadWaitGroup *sync.WaitGroup, 
 
 			increaseBar(applicationsBar, applicationsBarMutex)
 
-			gitopsRepoInterval := 5 * time.Second
-			gitopsRepoTimeout := 60 * time.Minute
-			repoUrl := utils.ObtainGitOpsRepositoryUrl(app.Status.Devfile)
-			if err := utils.WaitUntilWithInterval(func() (done bool, err error) {
-				resp, err := http.Get(repoUrl)
-				if err != nil {
-					return false, fmt.Errorf("unable to request gitops repo %s: %+v", repoUrl, err)
-				}
-				defer resp.Body.Close()
-				if resp.StatusCode == 404 {
-					return false, nil
-				} else if resp.StatusCode == 200 {
-					return true, nil
-				} else {
-					return false, fmt.Errorf("unexpected response code when requesting gitop repo %s: %v", repoUrl, err)
-				}
-			}, gitopsRepoInterval, gitopsRepoTimeout); err != nil {
-				logError(4, fmt.Sprintf("Unable to create application %s gitops repo within %v: %v", ApplicationName, gitopsRepoTimeout, err))
-				continue
-			}
-
 			/*
 				This part adds the Integration test scenario part
 				It's considered also as part of the resources creation since Integration test scenarios are resources as well

--- a/cmd/loadTests.go
+++ b/cmd/loadTests.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"net/http"
 	"os"
 	"runtime"
 	"strconv"


### PR DESCRIPTION
# Description

Removing GitOpsRepo check from Load test, instead, we'll rely on Application CR conditions

[RHTAP-1531](https://issues.redhat.com//browse/RHTAP-1531): https://issues.redhat.com/browse/RHTAP-1531

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
