### PR TITLE
fix: RHTAPBUGS-939 reenable "SPITokenBinding should be in Injected phase"

### DIFF
--- a/tests/spi/oauth.go
+++ b/tests/spi/oauth.go
@@ -180,7 +180,6 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "gh-oauth-flow"), func() {
 
 		})
 
-		// Pending until: https://issues.redhat.com/browse/RHTAPBUGS-939
 		It("SPITokenBinding should be in Injected phase", func() {
 			Eventually(func() bool {
 				SPITokenBinding, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessTokenBinding(SPITokenBinding.Name, namespace)

--- a/tests/spi/oauth.go
+++ b/tests/spi/oauth.go
@@ -138,7 +138,7 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "gh-oauth-flow"), func() {
 							Name:    cypressPodName,
 							Image:   "quay.io/redhat-appstudio-qe/cypress/included:latest",
 							Command: []string{"/bin/sh", "-c"},
-							Args:    []string{"git clone https://github.com/redhat-appstudio-qe/cypress-browser-oauth-flow; cd cypress-browser-oauth-flow; npm install; cypress run --spec cypress/e2e/spec.cy.js; tail -f /dev/null;"},
+							Args:    []string{"git clone https://github.com/rsoaresd/cypress-browser-oauth-flow; cd cypress-browser-oauth-flow; npm install; cypress run --spec cypress/e2e/spec.cy.js; tail -f /dev/null;"},
 							Env: []corev1.EnvVar{
 								{
 									Name:  "CYPRESS_GH_USER",
@@ -181,7 +181,7 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "gh-oauth-flow"), func() {
 		})
 
 		// Pending until: https://issues.redhat.com/browse/RHTAPBUGS-939
-		It("SPITokenBinding should be in Injected phase", Pending, func() {
+		It("SPITokenBinding should be in Injected phase", func() {
 			Eventually(func() bool {
 				SPITokenBinding, err = fw.AsKubeDeveloper.SPIController.GetSPIAccessTokenBinding(SPITokenBinding.Name, namespace)
 				Expect(err).NotTo(HaveOccurred())

--- a/tests/spi/oauth.go
+++ b/tests/spi/oauth.go
@@ -138,7 +138,7 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "gh-oauth-flow"), func() {
 							Name:    cypressPodName,
 							Image:   "quay.io/redhat-appstudio-qe/cypress/included:latest",
 							Command: []string{"/bin/sh", "-c"},
-							Args:    []string{"git clone https://github.com/rsoaresd/cypress-browser-oauth-flow; cd cypress-browser-oauth-flow; npm install; cypress run --spec cypress/e2e/spec.cy.js; tail -f /dev/null;"},
+							Args:    []string{"git clone https://github.com/redhat-appstudio-qe/cypress-browser-oauth-flow; cd cypress-browser-oauth-flow; npm install; cypress run --spec cypress/e2e/spec.cy.js; tail -f /dev/null;"},
 							Env: []corev1.EnvVar{
 								{
 									Name:  "CYPRESS_GH_USER",


### PR DESCRIPTION
# Description
-  Fixes were addressed to [cypress-browser-oauth-flow repo](https://github.com/redhat-appstudio-qe/cypress-browser-oauth-flow) in other to fix [RHTAPBUGS-939](https://issues.redhat.com/browse/RHTAPBUGS-939). So, we are good to reenable the test.

## Issue ticket number and link
[RHTAPBUGS-939](https://issues.redhat.com/browse/RHTAPBUGS-939)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
