### PR TITLE
test: RHTAPBUGS-936 skip cleanup verification in spi environments test

### DIFF
--- a/tests/remote-secret/environments.go
+++ b/tests/remote-secret/environments.go
@@ -446,7 +446,9 @@ var _ = framework.RemoteSecretSuiteDescribe(Label("remote-secret", "rs-environme
 			Expect(remoteSecret.Status.Targets).To(HaveLen(2))
 		})
 
-		It("secrets #1, #2, #3 should be deleted when Environment is deleted", func() {
+		// Pending due to RHTAPBUGS-936
+		// https://github.com/redhat-appstudio/service-provider-integration-operator/pull/758 changes clean up logic
+		It("secrets #1, #2, #3 should be deleted when Environment is deleted", Pending, func() {
 			// Delete the existing Environments
 			Expect(fw.AsKubeAdmin.GitOpsController.DeleteAllEnvironmentsInASpecificNamespace(fw.UserNamespace, 30*time.Second)).To(Succeed())
 
@@ -459,11 +461,13 @@ var _ = framework.RemoteSecretSuiteDescribe(Label("remote-secret", "rs-environme
 				_, errRs3Ns3 := fw.AsKubeAdmin.CommonController.GetSecret(targetNamespace_3, targetSecretName_3)
 
 				return k8sErrors.IsNotFound(errRs1Ns1) && k8sErrors.IsNotFound(errRs1Ns2) && k8sErrors.IsNotFound(errRs2Ns2) && k8sErrors.IsNotFound(errRs3Ns2) && k8sErrors.IsNotFound(errRs3Ns3)
-			}, 2*time.Minute, 1*time.Second).Should(BeTrue(), fmt.Sprintf("secrets %s is not created in all environments", targetSecretName))
+			}, 2*time.Minute, 1*time.Second).Should(BeTrue(), fmt.Sprintf("secrets #1, #2, #3 are not deleted when Environment is deleted", targetSecretName))
 
 		})
 
-		It("after Environment is deleted target namespace is removed from targets in RemoteSecret status", func() {
+		// Pending due to RHTAPBUGS-936
+		// https://github.com/redhat-appstudio/service-provider-integration-operator/pull/758 changes clean up logic
+		It("after Environment is deleted target namespace is removed from targets in RemoteSecret status", Pending, func() {
 			remoteSecret, err := fw.AsKubeDeveloper.RemoteSecretController.GetRemoteSecret(remoteSecretName, namespace)
 			Expect(err).NotTo(HaveOccurred())
 			targets := remoteSecret.Status.Targets

--- a/tests/remote-secret/environments.go
+++ b/tests/remote-secret/environments.go
@@ -461,7 +461,7 @@ var _ = framework.RemoteSecretSuiteDescribe(Label("remote-secret", "rs-environme
 				_, errRs3Ns3 := fw.AsKubeAdmin.CommonController.GetSecret(targetNamespace_3, targetSecretName_3)
 
 				return k8sErrors.IsNotFound(errRs1Ns1) && k8sErrors.IsNotFound(errRs1Ns2) && k8sErrors.IsNotFound(errRs2Ns2) && k8sErrors.IsNotFound(errRs3Ns2) && k8sErrors.IsNotFound(errRs3Ns3)
-			}, 2*time.Minute, 1*time.Second).Should(BeTrue(), fmt.Sprintf("secrets #1, #2, #3 are not deleted when Environment is deleted", targetSecretName))
+			}, 2*time.Minute, 1*time.Second).Should(BeTrue(), "secrets #1, #2, #3 are not deleted when Environment is deleted")
 
 		})
 


### PR DESCRIPTION
# Description

The remote secrets cleanup by spi will now [only clean targets in the RS that explicitly have the environment name in labels on annotations](https://github.com/redhat-appstudio/service-provider-integration-operator/pull/758). That will make the test fail.

## Issue ticket number and link
[RHTAPBUGS-936](https://issues.redhat.com/browse/RHTAPBUGS-936)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
