### PR TITLE
test: temporarily disable rhtap-demo JVM rebuild

### DIFF
--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -3,9 +3,10 @@ package rhtap_demo
 import (
 	"context"
 	"fmt"
-	tektonutils "github.com/redhat-appstudio/release-service/tekton/utils"
 	"os"
 	"time"
+
+	tektonutils "github.com/redhat-appstudio/release-service/tekton/utils"
 
 	"github.com/redhat-appstudio/jvm-build-service/openshift-with-appstudio-test/e2e"
 	jvmclientSet "github.com/redhat-appstudio/jvm-build-service/pkg/client/clientset/versioned"
@@ -358,9 +359,11 @@ var _ = framework.RhtapDemoSuiteDescribe(Label("rhtap-demo"), func() {
 								pacPurgeBranchName = fmt.Sprintf("appstudio-purge-%s", component.GetName())
 
 								// JBS related config
-								_, err = fw.AsKubeAdmin.JvmbuildserviceController.CreateJBSConfig(constants.JBSConfigName, fw.UserNamespace)
-								Expect(err).ShouldNot(HaveOccurred())
-								Expect(fw.AsKubeAdmin.JvmbuildserviceController.WaitForCache(fw.AsKubeAdmin.CommonController, fw.UserNamespace)).Should(Succeed())
+								/*
+									_, err = fw.AsKubeAdmin.JvmbuildserviceController.CreateJBSConfig(constants.JBSConfigName, fw.UserNamespace)
+									Expect(err).ShouldNot(HaveOccurred())
+									Expect(fw.AsKubeAdmin.JvmbuildserviceController.WaitForCache(fw.AsKubeAdmin.CommonController, fw.UserNamespace)).Should(Succeed())
+								*/
 							})
 							AfterAll(func() {
 								if !CurrentSpecReport().Failed() {
@@ -567,7 +570,7 @@ var _ = framework.RhtapDemoSuiteDescribe(Label("rhtap-demo"), func() {
 								})
 							})
 
-							When("JVM Build Service is used for rebuilding dependencies", func() {
+							When("JVM Build Service is used for rebuilding dependencies", Pending, func() {
 								It("should eventually rebuild of all artifacts and dependencies successfully", func() {
 									jvmClient := jvmclientSet.New(fw.AsKubeAdmin.JvmbuildserviceController.JvmbuildserviceClient().JvmbuildserviceV1alpha1().RESTClient())
 									tektonClient := pipelineclientset.New(fw.AsKubeAdmin.TektonController.PipelineClient().TektonV1beta1().RESTClient())


### PR DESCRIPTION
# Description

* temporarily disable the JVM rebuild test due to [RHTAPBUGS-937](https://issues.redhat.com//browse/RHTAPBUGS-937)

## Issue ticket number and link
[RHTAPBUGS-937](https://issues.redhat.com//browse/RHTAPBUGS-937)

## Type of change

- [X] Disabling test
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
in CI

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
