### PR TITLE
feat(RHTAP-1726): Fix-GitHub-action-against-Stage - Update monitoring configuration adjusted to Prometheus SA authorization

### DIFF
--- a/tests/load-tests/ci-scripts/stage/cluster_read_config.yaml
+++ b/tests/load-tests/ci-scripts/stage/cluster_read_config.yaml
@@ -26,10 +26,6 @@
   monitoring_query: sum(rate(token_pool_gauge{rateLimited="secondary"}[5m]))
   monitoring_step: 15
 
-- name: measurements.cluster_nodes_worker_count
-  monitoring_query: count(kube_node_role{role="worker"})
-  monitoring_step: 15
-
 - name: measurements.cluster_pods_count
   monitoring_query: count(kube_pod_info)
   monitoring_step: 15
@@ -98,27 +94,6 @@
 - name: metadata.env.{{ var }}
   env_variable: {{ var }}
 {% endfor %}
-
-# Cluster nodes info
-- name: metadata.cluster.control-plane.count
-  command: oc get nodes -l node-role.kubernetes.io/master -o name | wc -l
-
-- name: metadata.cluster.control-plane.flavor
-  command: oc get nodes -l node-role.kubernetes.io/master -o json | jq --raw-output '.items | map(.metadata.labels."beta.kubernetes.io/instance-type") | unique | sort | join(",")'
-
-- name: metadata.cluster.control-plane.nodes
-  command: oc get nodes -l node-role.kubernetes.io/master -o json | jq '.items | map(.metadata.name)'
-  output: json
-
-- name: metadata.cluster.compute-nodes.count
-  command: oc get nodes -l node-role.kubernetes.io/worker -o name | wc -l
-
-- name: metadata.cluster.compute-nodes.flavor
-  command: oc get nodes -l node-role.kubernetes.io/worker -o json | jq --raw-output '.items | map(.metadata.labels."beta.kubernetes.io/instance-type") | unique | sort | join(",")'
-
-- name: metadata.cluster.compute-nodes.nodes
-  command: oc get nodes -l node-role.kubernetes.io/worker -o json | jq '.items | map(.metadata.name)'
-  output: json
 
 - name: metadata.scenario
   command: if [ -r /usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${SCENARIO} ]; then cat /usr/local/ci-secrets/redhat-appstudio-load-test/load-test-scenario.${SCENARIO} | sed 's/\\ /,/g' | sed 's/[^ ]* \([^= ]*\)=\([^= ]*\)/"\1":"\2",/g' | sed 's/\(.*\),$/{\1}/g'; else echo '{}'; fi

--- a/tests/load-tests/ci-scripts/stage/collect-results.sh
+++ b/tests/load-tests/ci-scripts/stage/collect-results.sh
@@ -40,7 +40,7 @@ mhost=$PROMETHEUS_HOST
 
 status_data.py \
     --status-data-file "$monitoring_collection_data" \
-    --additional ./stage/cluster_read_config.yaml \
+    --additional ./ci-scripts/stage/cluster_read_config.yaml \
     --monitoring-start "$mstart" \
     --monitoring-end "$mend" \
     --prometheus-host "https://$mhost" \

--- a/tests/load-tests/ci-scripts/stage/collect-results.sh
+++ b/tests/load-tests/ci-scripts/stage/collect-results.sh
@@ -40,7 +40,7 @@ mhost=$PROMETHEUS_HOST
 
 status_data.py \
     --status-data-file "$monitoring_collection_data" \
-    --additional ./cluster_read_config.yaml \
+    --additional ./stage/cluster_read_config.yaml \
     --monitoring-start "$mstart" \
     --monitoring-end "$mend" \
     --prometheus-host "https://$mhost" \


### PR DESCRIPTION
# Description
This update remained from the previous PR (https://github.com/redhat-appstudio/e2e-tests/pull/848) which was merged
Fixed the cluster_read_config.yaml metrics used to discard the nodes related metrics and adjusted the metadata.scenario calculation

## Issue ticket number and link
https://issues.redhat.com/browse/RHTAP-1726

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Ran the load-test workflow in https://github.com/naftalysh/e2e-tests/actions/workflows/loadtest.yaml
And observed the monitoring-collection.log file in the workflow artifacts

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
