### PR TITLE
chore: remove/replace SLSA1 and SLSA2 tests

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -308,7 +308,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 						Configuration: &ecp.EnterpriseContractPolicyConfiguration{
 							// The BuildahDemo pipeline used to generate the test data does not
 							// include the required test tasks, so this policy should always fail.
-							Collections: []string{"slsa2"},
+							Collections: []string{"slsa3"},
 							Exclude:     []string{"cve"},
 						},
 					}
@@ -400,8 +400,6 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 					"pipelines/enterprise-contract-everything.yaml",
 					"pipelines/enterprise-contract-redhat.yaml",
 					"pipelines/enterprise-contract-redhat-no-hermetic.yaml",
-					"pipelines/enterprise-contract-slsa1.yaml",
-					"pipelines/enterprise-contract-slsa2.yaml",
 					"pipelines/enterprise-contract-slsa3.yaml",
 				}
 

--- a/tests/release/pipelines/e2e-fbc.go
+++ b/tests/release/pipelines/e2e-fbc.go
@@ -120,7 +120,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("[RHTAPREL-373]fbc happy path e2
 			Configuration: &ecp.EnterpriseContractPolicyConfiguration{
 				Collections: []string{"minimal"},
 				Exclude:     []string{"cve", "step_image_registries"},
-				Include:     []string{"@slsa1", "@slsa2", "@slsa3"},
+				Include:     []string{"@slsa3"},
 			},
 		}
 

--- a/tests/release/pipelines/e2e-test-push-image-to-pyxis.go
+++ b/tests/release/pipelines/e2e-test-push-image-to-pyxis.go
@@ -104,7 +104,7 @@ var _ = framework.ReleaseSuiteDescribe("[HACBS-1571]test-release-e2e-push-image-
 			PublicKey:   string(publicKey),
 			Sources:     defaultEcPolicy.Spec.Sources,
 			Configuration: &ecp.EnterpriseContractPolicyConfiguration{
-				Collections: []string{"minimal", "slsa2"},
+				Collections: []string{"minimal", "slsa3"},
 				Exclude:     []string{"cve"},
 			},
 		}


### PR DESCRIPTION
# Description

We deprecated SLSA1 and SLSA2 collections/configurations/pipelines, this removes those from e2e tests.

## Issue ticket number and link

https://issues.redhat.com/browse/EC-195

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

In CI :)

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
