### PR TITLE
test: RHTAPBUGS-936 reenable cleanup environment verification in remote-secret test

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -12,7 +12,7 @@ Requirements for installing RHTAP in E2E mode:
 * An OpenShift 4.12 or higher Environment (If you are using CRC/OpenShift Local please also review [optional-codeready-containers-post-bootstrap-configuration](https://github.com/redhat-appstudio/infra-deployments/blob/main/docs/development/deployment.md#optional-openshift-local-post-bootstrap-configuration))
 * A machine from which to run the install (usually your laptop) with required tools:
   * A properly setup Go workspace using **Go 1.19 is required**
-  * The OpenShift Command Line Tool (oc) **Use the version coresponding to the Openshift version**
+  * The OpenShift Command Line Tool (oc) **Use the version corresponding to the Openshift version**
   * [yq]((https://github.com/mikefarah/yq))
   * jq
   * git


### PR DESCRIPTION
# Description

The remote secrets cleanup by spi will now [only clean targets in the RS that explicitly have the environment name in labels on annotations](https://github.com/redhat-appstudio/service-provider-integration-operator/pull/758). So, the cleanup verification should be adjusted to this new logic.

## Issue ticket number and link
[RHTAPBUGS-936](https://issues.redhat.com/browse/RHTAPBUGS-936)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
