### PR TITLE
test(STONEINTG-609): e2e automation for reporting integration test status

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -54,7 +54,7 @@ $ go mod vendor
 <p>
 
    Some tests could require you have a Github App created in order to test Component builds via Pipelines as Code.
-Such tests are [rhtap-demo](https://github.com/redhat-appstudio/e2e-tests/blob/main/tests/rhtap-demo/rhtap-demo.go) and [build](https://github.com/redhat-appstudio/e2e-tests/blob/main/tests/build/build.go).
+Such tests are [rhtap-demo](https://github.com/redhat-appstudio/e2e-tests/blob/main/tests/rhtap-demo/rhtap-demo.go), [build](https://github.com/redhat-appstudio/e2e-tests/blob/main/tests/build/build.go), and [status-reporting-to-pullrequest](https://github.com/redhat-appstudio/e2e-tests/blob/main/tests/integration-service/status-reporting-to-pullrequest.go).
 
 In this case, before you bootstrap a cluster, make sure you [created a Github App for your GitHub account](https://github.com/settings/apps). Fill in following details:
 </p>

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -99,6 +99,7 @@ In that case, before you run the test, make sure you have created
   * https://github.com/redhat-appstudio-qe/devfile-sample-hello-world (for running build-service tests)
   * https://github.com/redhat-appstudio-qe/hacbs-test-project (for rhtap-demo test)
   * https://github.com/redhat-appstudio-qe/strategy-configs (for rhtap-demo test)
+  * https://github.com/redhat-appstudio-qe/hacbs-test-project-integration (for status-reporting-to-pullrequest test)
 
 Note: All Environments used in all e2e-tests are in [default.env](../default.env) file. In case you need to run a specific tests, not all environments are necessary to be defined.
 

--- a/pkg/utils/integration/integration_test_scenarios.go
+++ b/pkg/utils/integration/integration_test_scenarios.go
@@ -92,7 +92,7 @@ func (i *IntegrationController) CreateIntegrationTestScenarioWithEnvironment(app
 func (i *IntegrationController) CreateIntegrationTestScenario_beta1(applicationName, namespace, gitURL, revision, pathInRepo string) (*integrationv1beta1.IntegrationTestScenario, error) {
 	integrationTestScenario := &integrationv1beta1.IntegrationTestScenario{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "example-resolver-pass-" + util.GenerateRandomString(4),
+			Name:      "my-integration-test-" + util.GenerateRandomString(4),
 			Namespace: namespace,
 			Labels: map[string]string{
 				"test.appstudio.openshift.io/optional": "false",

--- a/pkg/utils/integration/pipelineruns.go
+++ b/pkg/utils/integration/pipelineruns.go
@@ -210,7 +210,7 @@ func (i *IntegrationController) GetAnnotationIfExists(testNamespace, application
 // WaitForBuildPipelineRunToGetAnnotated waits for given build pipeline to get annotated with a specific annotation.
 // In case of failure, this function retries till it gets timed out.
 func (i *IntegrationController) WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, annotationKey string) error {
-	return wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		pipelineRun, err := i.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
 		if err != nil {
 			GinkgoWriter.Printf("pipelinerun for Component %s/%s can't be gotten successfully. Error: %v", testNamespace, componentName, err)

--- a/tests/integration-service/README.md
+++ b/tests/integration-service/README.md
@@ -28,6 +28,19 @@ Happy path testing describes tests that focus on the most common scenarios while
 - Asserting that the Snapshot was marked as Passed.
 - Verifying that the Ephemeral environment and related SnapshotEnvironmentBinding got deleted.
 
+### E2E tests of Status Reporting of Integration tests to CheckRuns (within `status-reporting-to-pullrequest.go`):
+
+- Creating 2 IntegrationTestScenarios: one that's supposed to pass and other one to fail.
+- Creating PaC branch and component base branches which will be used to create Pull request (PR).
+- Testing for successful creation of applications and component (with the above custom branch).
+- Checking if the Build pipelineRun is successfully triggered and completed.
+- Asserting the creation of PaC init PR within the component repo.
+- Asserting the proper status reporting of Build PipelineRun within the PR's CheckRun.
+- Asserting the signing of BuildPipelineRun.
+- Asserting the successful creation of a Snapshot after a push event.
+- Verifying that both the Integration pipelineRuns got created and finished successfully.
+- Checking that a Snapshot gets successfully marked as 'failed' after all Integration pipelinRuns finished.
+- Asserting the proper status reporting of both the Integration pipelineRuns within the PR's CheckRuns.
 
 ## Negative Test Cases
 

--- a/tests/integration-service/const.go
+++ b/tests/integration-service/const.go
@@ -1,0 +1,42 @@
+package integration
+
+import (
+	"fmt"
+
+	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
+)
+
+const (
+	componentRepoURL  = "https://github.com/redhat-appstudio-qe/" + helloWorldComponentGitSourceRepoName
+	EnvNameForNBE     = "user-picked-environment"
+	gitURLForNBE      = "https://github.com/redhat-appstudio/integration-examples.git"
+	revisionForNBE    = "main"
+	pathInRepoForNBE  = "pipelines/integration_test_app.yaml"
+
+	BundleURL              = "quay.io/redhat-appstudio/example-tekton-bundle:integration-pipeline-pass"
+	BundleURLFail          = "quay.io/redhat-appstudio/example-tekton-bundle:integration-pipeline-fail"
+	InPipelineName         = "integration-pipeline-pass"
+	InPipelineNameFail     = "integration-pipeline-fail"
+	EnvironmentName        = "development"
+	gitURL                 = "https://github.com/redhat-appstudio/integration-examples.git"
+	revision               = "843f455fe87a6d7f68c238f95a8f3eb304e65ac5"
+	pathInRepo             = "pipelines/integration_resolver_pipeline_pass.yaml"
+	autoReleasePlan        = "auto-releaseplan"
+	targetReleaseNamespace = "default"
+
+	helloWorldComponentGitSourceRepoName = "hacbs-test-project"
+	helloWorldComponentDefaultBranch     = "main"
+	helloWorldComponentRevision          = "34da5a8f51fba6a8b7ec75a727d3c72ebb5e1274"
+	gitURLForReporting                   = "https://github.com/redhat-appstudio/integration-examples.git"
+	pathInRepoForReportingPass           = "pipelines/integration_resolver_pipeline_pass.yaml"
+	pathInRepoForReportingFail           = "pipelines/integration_resolver_pipeline_fail.yaml"
+	referenceDoesntExist                 = "Reference does not exist"
+	checkrunStatusCompleted              = "completed"
+	checkrunConclusionSuccess            = "success"
+	checkrunConclusionFailure            = "failure"
+)
+
+var (
+	helloWorldComponentGitSourceURL = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), helloWorldComponentGitSourceRepoName)
+)

--- a/tests/integration-service/const.go
+++ b/tests/integration-service/const.go
@@ -8,11 +8,10 @@ import (
 )
 
 const (
-	componentRepoURL  = "https://github.com/redhat-appstudio-qe/" + helloWorldComponentGitSourceRepoName
-	EnvNameForNBE     = "user-picked-environment"
-	gitURLForNBE      = "https://github.com/redhat-appstudio/integration-examples.git"
-	revisionForNBE    = "main"
-	pathInRepoForNBE  = "pipelines/integration_test_app.yaml"
+	componentRepoURL = "https://github.com/redhat-appstudio-qe/" + helloWorldComponentGitSourceRepoName
+	EnvNameForNBE    = "user-picked-environment"
+	revisionForNBE   = "main"
+	pathInRepoForNBE = "pipelines/integration_test_app.yaml"
 
 	BundleURL              = "quay.io/redhat-appstudio/example-tekton-bundle:integration-pipeline-pass"
 	BundleURLFail          = "quay.io/redhat-appstudio/example-tekton-bundle:integration-pipeline-fail"
@@ -28,13 +27,15 @@ const (
 	helloWorldComponentGitSourceRepoName = "hacbs-test-project"
 	helloWorldComponentDefaultBranch     = "main"
 	helloWorldComponentRevision          = "34da5a8f51fba6a8b7ec75a727d3c72ebb5e1274"
-	gitURLForReporting                   = "https://github.com/redhat-appstudio/integration-examples.git"
 	pathInRepoForReportingPass           = "pipelines/integration_resolver_pipeline_pass.yaml"
 	pathInRepoForReportingFail           = "pipelines/integration_resolver_pipeline_fail.yaml"
 	referenceDoesntExist                 = "Reference does not exist"
 	checkrunStatusCompleted              = "completed"
 	checkrunConclusionSuccess            = "success"
 	checkrunConclusionFailure            = "failure"
+
+	snapshotAnnotation = "appstudio.openshift.io/snapshot"
+	scenarioAnnotation = "test.appstudio.openshift.io/scenario"
 )
 
 var (

--- a/tests/integration-service/const.go
+++ b/tests/integration-service/const.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	componentRepoURL = "https://github.com/redhat-appstudio-qe/" + helloWorldComponentGitSourceRepoName
+	componentRepoURL = "https://github.com/redhat-appstudio-qe/hacbs-test-project"
 	EnvNameForNBE    = "user-picked-environment"
 	revisionForNBE   = "main"
 	pathInRepoForNBE = "pipelines/integration_test_app.yaml"
@@ -24,9 +24,9 @@ const (
 	autoReleasePlan        = "auto-releaseplan"
 	targetReleaseNamespace = "default"
 
-	helloWorldComponentGitSourceRepoName = "hacbs-test-project"
-	helloWorldComponentDefaultBranch     = "main"
-	helloWorldComponentRevision          = "34da5a8f51fba6a8b7ec75a727d3c72ebb5e1274"
+	componentRepoNameForStatusReporting  = "hacbs-test-project-integration"
+	componentDefaultBranch               = "main"
+	componentRevision                    = "34da5a8f51fba6a8b7ec75a727d3c72ebb5e1274"
 	pathInRepoForReportingPass           = "pipelines/integration_resolver_pipeline_pass.yaml"
 	pathInRepoForReportingFail           = "pipelines/integration_resolver_pipeline_fail.yaml"
 	referenceDoesntExist                 = "Reference does not exist"
@@ -39,5 +39,5 @@ const (
 )
 
 var (
-	helloWorldComponentGitSourceURL = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), helloWorldComponentGitSourceRepoName)
+	componentGitSourceURLForStatusReporting = fmt.Sprintf("https://github.com/%s/%s", utils.GetEnv(constants.GITHUB_E2E_ORGANIZATION_ENV, "redhat-appstudio-qe"), componentRepoNameForStatusReporting)
 )

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -83,6 +83,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			})
 
 			It("checks if the passed status of integration test is reported in the Snapshot", func() {
+				timeout = time.Second * 240
+				interval = time.Second * 5
 				Eventually(func() error {
 					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -91,7 +93,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 					Expect(err).ToNot(HaveOccurred())
 
 					if statusDetail.Status != intgteststat.IntegrationTestStatusTestPassed {
-						return fmt.Errorf("test status doesn't have expected value %s", intgteststat.IntegrationTestStatusTestPassed)
+						return fmt.Errorf("test status for scenario: %s, doesn't have expected value %s, within the snapshot: %s", integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestPassed, snapshot.Name)
 					}
 					return nil
 				}, timeout, interval).Should(Succeed())

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -18,21 +18,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const (
-	gitSourceRepoName      = "devfile-sample-python-basic"
-	gitSourceURL           = "https://github.com/redhat-appstudio-qe/" + gitSourceRepoName
-	BundleURL              = "quay.io/redhat-appstudio/example-tekton-bundle:integration-pipeline-pass"
-	BundleURLFail          = "quay.io/redhat-appstudio/example-tekton-bundle:integration-pipeline-fail"
-	InPipelineName         = "integration-pipeline-pass"
-	InPipelineNameFail     = "integration-pipeline-fail"
-	EnvironmentName        = "development"
-	gitURL                 = "https://github.com/redhat-appstudio/integration-examples.git"
-	revision               = "843f455fe87a6d7f68c238f95a8f3eb304e65ac5"
-	pathInRepo             = "pipelines/integration_resolver_pipeline_pass.yaml"
-	autoReleasePlan        = "auto-releaseplan"
-	targetReleaseNamespace = "default"
-)
-
 var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests", Label("integration-service", "HACBS"), func() {
 	defer GinkgoRecover()
 

--- a/tests/integration-service/namespace-backed-environments.go
+++ b/tests/integration-service/namespace-backed-environments.go
@@ -63,7 +63,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment 
 			userPickedEnvironment, err = f.AsKubeAdmin.GitOpsController.CreatePocEnvironment(EnvNameForNBE, testNamespace)
 			Expect(err).ToNot(HaveOccurred())
 
-			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenarioWithEnvironment(applicationName, testNamespace, gitURLForNBE, revisionForNBE, pathInRepoForNBE, userPickedEnvironment)
+			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenarioWithEnvironment(applicationName, testNamespace, gitURL, revisionForNBE, pathInRepoForNBE, userPickedEnvironment)
 			Expect(err).ShouldNot(HaveOccurred())
 			phaseDTC = appstudioApi.DeploymentTargetClaimPhase_Bound
 			phaseDT = appstudioApi.DeploymentTargetPhase_Bound
@@ -118,13 +118,13 @@ var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment 
 				dtcl, err = f.AsKubeDeveloper.GitOpsController.GetDeploymentTargetClaimsList(testNamespace)
 				Expect(err).ToNot(HaveOccurred())
 				if len(dtcl.Items) == 0 {
-					return fmt.Errorf("No DeploymentTargetClaim is found.")
+					return fmt.Errorf("no DeploymentTargetClaim is found")
 				}
 				if !reflect.ValueOf(dtcl.Items[0].Status).IsZero() && dtcl.Items[0].Status.Phase != phaseDTC {
 					return fmt.Errorf("DeploymentTargetClaimPhase is not yet equal to the expected phase: " + string(phaseDTC))
 				}
 				if dtcl.Items[0].Spec.DeploymentTargetClassName == "" {
-					return fmt.Errorf("deploymentTargetClassName field within deploymentTargetClaim is empty.")
+					return fmt.Errorf("deploymentTargetClassName field within deploymentTargetClaim is empty")
 				}
 				return err
 			}, time.Minute*1, time.Second*1).Should(Succeed(), fmt.Sprintf("timed out checking DeploymentTargetClaim after Ephemeral Environment %s was created ", ephemeralEnvironment.Name))
@@ -272,7 +272,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment 
 
 			env, err = f.AsKubeAdmin.GitOpsController.CreatePocEnvironment(EnvNameForNBE, testNamespace)
 			Expect(err).ShouldNot(HaveOccurred())
-			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenarioWithEnvironment(applicationName, testNamespace, gitURLForNBE, revisionForNBE, pathInRepoForNBE, env)
+			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenarioWithEnvironment(applicationName, testNamespace, gitURL, revisionForNBE, pathInRepoForNBE, env)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 

--- a/tests/integration-service/namespace-backed-environments.go
+++ b/tests/integration-service/namespace-backed-environments.go
@@ -21,15 +21,6 @@ import (
 	managedgitopsv1alpha1 "github.com/redhat-appstudio/managed-gitops/backend-shared/apis/managed-gitops/v1alpha1"
 )
 
-const (
-	componentRepoName = "hacbs-test-project"
-	componentRepoURL  = "https://github.com/redhat-appstudio-qe/" + componentRepoName
-	EnvNameForNBE     = "user-picked-environment"
-	gitURLForNBE      = "https://github.com/redhat-appstudio/integration-examples.git"
-	revisionForNBE    = "main"
-	pathInRepoForNBE  = "pipelines/integration_test_app.yaml"
-)
-
 var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment (NBE) E2E tests", Label("integration-service", "HACBS", "namespace-backed-envs"), func() {
 	defer GinkgoRecover()
 

--- a/tests/integration-service/status-reporting-to-pullrequest.go
+++ b/tests/integration-service/status-reporting-to-pullrequest.go
@@ -1,0 +1,228 @@
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/devfile/library/v2/pkg/util"
+	"github.com/google/go-github/v44/github"
+	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
+	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appstudioApi "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	integrationv1beta1 "github.com/redhat-appstudio/integration-service/api/v1beta1"
+)
+
+var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integration tests", Label("integration-service", "HACBS", "status-reporting"), func() {
+	defer GinkgoRecover()
+
+	var f *framework.Framework
+	var err error
+
+	var prNumber int
+	var timeout, interval time.Duration
+	var osConsoleHost, prHeadSha string
+	var snapshot *appstudioApi.Snapshot
+	var component *appstudioApi.Component
+	var pipelineRun, testPipelinerun *v1beta1.PipelineRun
+	var integrationTestScenarioPass, integrationTestScenarioFail *integrationv1beta1.IntegrationTestScenario
+	var applicationName, componentName, componentBaseBranchName, pacBranchName, testNamespace string
+
+	AfterEach(framework.ReportFailure(&f))
+
+	Describe("with status reporting of Integration tests in CheckRuns", Ordered, func() {
+		BeforeAll(func() {
+			f, err = framework.NewFramework(utils.GetGeneratedNamespace("stat-rep"))
+			Expect(err).NotTo(HaveOccurred())
+			testNamespace = f.UserNamespace
+
+			consoleRoute, err := f.AsKubeAdmin.CommonController.GetOpenshiftRoute("console", "openshift-console")
+			Expect(err).ShouldNot(HaveOccurred())
+			osConsoleHost = consoleRoute.Spec.Host
+
+			if utils.IsPrivateHostname(osConsoleHost) {
+				Skip("Using private cluster (not reachable from Github), skipping...")
+			}
+
+			applicationName = createApp(*f, testNamespace)
+
+			integrationTestScenarioPass, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario_beta1(applicationName, testNamespace, gitURLForReporting, revision, pathInRepoForReportingPass)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			integrationTestScenarioFail, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario_beta1(applicationName, testNamespace, gitURLForReporting, revision, pathInRepoForReportingFail)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			componentName = fmt.Sprintf("%s-%s", "test-component-pac", util.GenerateRandomString(4))
+			pacBranchName = constants.PaCPullRequestBranchPrefix + componentName
+			componentBaseBranchName = fmt.Sprintf("base-%s", util.GenerateRandomString(4))
+
+			err = f.AsKubeAdmin.CommonController.Github.CreateRef(helloWorldComponentGitSourceRepoName, helloWorldComponentDefaultBranch, helloWorldComponentRevision, componentBaseBranchName)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			if !CurrentSpecReport().Failed() {
+				cleanup(*f, testNamespace, applicationName, componentName)
+			}
+
+			// Delete new branches created by PaC and a testing branch used as a component's base branch
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(helloWorldComponentGitSourceRepoName, pacBranchName)
+			if err != nil {
+				Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
+			}
+			err = f.AsKubeAdmin.CommonController.Github.DeleteRef(helloWorldComponentGitSourceRepoName, componentBaseBranchName)
+			if err != nil {
+				Expect(err.Error()).To(ContainSubstring("Reference does not exist"))
+			}
+		})
+
+		When("a new Component with specified custom branch is created", Label("custom-branch"), func() {
+			BeforeAll(func() {
+				componentObj := appstudioApi.ComponentSpec{
+					ComponentName: componentName,
+					Application:   applicationName,
+					Source: appstudioApi.ComponentSource{
+						ComponentSourceUnion: appstudioApi.ComponentSourceUnion{
+							GitSource: &appstudioApi.GitSource{
+								URL:      helloWorldComponentGitSourceURL,
+								Revision: componentBaseBranchName,
+							},
+						},
+					},
+				}
+				// Create a component with Git Source URL, a specified git branch
+				component, err = f.AsKubeAdmin.HasController.CreateComponent(componentObj, testNamespace, "", "", applicationName, false, utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationRequestPublicRepo))
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+			It("triggers a Build PipelineRun", func() {
+				timeout = time.Second * 600
+				interval = time.Second * 1
+				Eventually(func() error {
+					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
+					if err != nil {
+						GinkgoWriter.Printf("Build PipelineRun has not been created yet for the component %s/%s\n", testNamespace, componentName)
+						return err
+					}
+					if !pipelineRun.HasStarted() {
+						return fmt.Errorf("build pipelinerun %s/%s hasn't started yet", pipelineRun.GetNamespace(), pipelineRun.GetName())
+					}
+					return nil
+				}, timeout, constants.PipelineRunPollingInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the build PipelineRun to start for the component %s/%s", testNamespace, componentName))
+			})
+			It("should lead to a PaC init PR creation", func() {
+				timeout = time.Second * 300
+				interval = time.Second * 1
+
+				Eventually(func() bool {
+					prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(helloWorldComponentGitSourceRepoName)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					for _, pr := range prs {
+						if pr.Head.GetRef() == pacBranchName {
+							prNumber = pr.GetNumber()
+							prHeadSha = pr.Head.GetSHA()
+							return true
+						}
+					}
+					return false
+				}, timeout, interval).Should(BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchName, helloWorldComponentGitSourceRepoName))
+			})
+			It("the build PipelineRun should eventually finish successfully", func() {
+				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", 2, f.AsKubeAdmin.TektonController)).To(Succeed())
+			})
+			It("does not contain an annotation with a Snapshot Name", func() {
+				Expect(pipelineRun.Annotations["appstudio.openshift.io/snapshot"]).To(Equal(""))
+			})
+			It("eventually leads to the build PipelineRun's status reported at Checks tab", func() {
+				validateCheckRun(*f, componentName, checkrunConclusionSuccess, helloWorldComponentGitSourceRepoName, prHeadSha, prNumber)
+			})
+		})
+
+		When("the PaC build pipelineRun run succeeded", func() {
+			It("checks if the BuildPipelineRun is signed", func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToBeSigned(testNamespace, applicationName, componentName)).To(Succeed())
+			})
+
+			It("checks if the Snapshot is created", func() {
+				snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", componentName, testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, "appstudio.openshift.io/snapshot")).To(Succeed())
+			})
+		})
+
+		When("the Snapshot was created", func() {
+			It("should find both the related Integration PipelineRuns", func() {
+				testPipelinerun, err = f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToGetStarted(integrationTestScenarioPass.Name, snapshot.Name, testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(testPipelinerun.Labels["appstudio.openshift.io/snapshot"]).To(ContainSubstring(snapshot.Name))
+				Expect(testPipelinerun.Labels["test.appstudio.openshift.io/scenario"]).To(ContainSubstring(integrationTestScenarioPass.Name))
+	
+				testPipelinerun, err = f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToGetStarted(integrationTestScenarioFail.Name, snapshot.Name, testNamespace)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(testPipelinerun.Labels["appstudio.openshift.io/snapshot"]).To(ContainSubstring(snapshot.Name))
+				Expect(testPipelinerun.Labels["test.appstudio.openshift.io/scenario"]).To(ContainSubstring(integrationTestScenarioFail.Name))
+			})
+		})
+
+		When("Integration PipelineRuns are created", func() {
+			It("should eventually complete successfully", func() {
+				Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioPass, snapshot, testNamespace)).To(Succeed(), fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
+				Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioFail, snapshot, testNamespace)).To(Succeed(), fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
+			})
+		})
+
+		When("Integration PipelineRuns completes successfully", func() {
+			It("should lead to Snapshot CR being marked as failed", FlakeAttempts(3), func() {
+				// Snapshot marked as Failed because one of its Integration test failed (as expected)
+				Eventually(func() bool {
+					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot("", pipelineRun.Name, "", testNamespace)
+					return err == nil && !f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)
+				}, time.Minute*3, time.Second*5).Should(BeTrue(), fmt.Sprintf("Timed out waiting for Snapshot to be marked as failed %s/%s", snapshot.GetNamespace(), snapshot.GetName()))
+			})
+			It("eventually leads to the status reported at Checks tab for the successful Integration PipelineRun", func() {
+				validateCheckRun(*f, integrationTestScenarioPass.Name, checkrunConclusionSuccess, helloWorldComponentGitSourceRepoName, prHeadSha, prNumber)
+			})
+			It("eventually leads to the status reported at Checks tab for the failed Integration PipelineRun", func() {
+				validateCheckRun(*f, integrationTestScenarioFail.Name, checkrunConclusionFailure, helloWorldComponentGitSourceRepoName, prHeadSha, prNumber)
+			})
+		})
+	})
+})
+
+// validateCheckRun fetches a specific CheckRun within a given repo
+// by matching the CheckRun's name with the given checkRunName, and
+// then validates that it got completed and its conclusion is as expected
+func validateCheckRun(f framework.Framework, checkRunName, conclusion, repoName, prHeadSha string, prNumber int) {
+	var checkRun *github.CheckRun
+	var timeout, interval time.Duration
+
+	timeout = time.Minute * 10
+	interval = time.Second * 2
+
+	Eventually(func() *github.CheckRun {
+		checkRuns, err := f.AsKubeAdmin.CommonController.Github.ListCheckRuns(repoName, prHeadSha)
+		Expect(err).ShouldNot(HaveOccurred())
+		for _, cr := range checkRuns {
+			if strings.Contains(cr.GetName(), checkRunName) {
+				checkRun = cr
+				return cr
+			}
+		}
+		return nil
+	}, timeout, interval).ShouldNot(BeNil(), fmt.Sprintf("timed out when waiting for the PaC CheckRun, with `Name` field containing the substring %s, to appear in the PR #%d of the Component repo %s", checkRunName, prNumber, repoName))
+
+	Eventually(func() string {
+		checkRun, err := f.AsKubeAdmin.CommonController.Github.GetCheckRun(repoName, checkRun.GetID())
+		Expect(err).ShouldNot(HaveOccurred())
+		return checkRun.GetStatus()
+	}, timeout, interval).Should(Equal(checkrunStatusCompleted), fmt.Sprintf("timed out when waiting for the PaC Check suite status to be 'completed' in the Component repo %s in PR #%d", repoName, prNumber))
+	Expect(checkRun.GetConclusion()).To(Equal(conclusion), fmt.Sprintf("the PR %d in %s repo doesn't contain the expected conclusion (%s) of the CheckRun", prNumber, repoName, conclusion))
+}


### PR DESCRIPTION
# Description

This PR adds a new test file within the integration-service test suite, that automates the status reporting of integration tests within the CheckRuns.

## Issue ticket number and link
[STONEINTG-609](https://issues.redhat.com/browse/STONEINTG-609)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran the test locally in a fresh cluster by running the command: `./bin/e2e-appstudio --ginkgo.label-filter="status-reporting" ginkgo -vv`

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
