### PR TITLE
chore: cleanup private repos older than 7 days

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,6 @@ clean-quay-repos-and-robots:
 
 clean-quay-tags:
 	./mage -v local:cleanupQuayTags
+
+clean-private-repos:
+	./mage -v local:cleanupPrivateRepos

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -208,6 +208,19 @@ func (Local) CleanupQuayTags() error {
 	return cleanupQuayTags(quayClient, quayOrg, "test-images")
 }
 
+// Deletes the private repos with prefix "build-e2e" or "rhtap-demo"
+func (Local) CleanupPrivateRepos() error {
+	repoNamePrefixes := []string{"build-e2e", "rhtap-demo"}
+	quayOrgToken := os.Getenv("DEFAULT_QUAY_ORG_TOKEN")
+	if quayOrgToken == "" {
+		return fmt.Errorf("DEFAULT_QUAY_ORG_TOKEN env var was not found")
+	}
+	quayOrg := utils.GetEnv("DEFAULT_QUAY_ORG", "redhat-appstudio-qe")
+
+	quayClient := quay.NewQuayClient(&http.Client{Transport: &http.Transport{}}, quayOrgToken, "https://quay.io/api/v1")
+	return cleanupPrivateRepos(quayClient, quayOrg, repoNamePrefixes)
+}
+
 func (ci CI) TestE2E() error {
 	var testFailure bool
 

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -34,6 +34,10 @@ import (
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
+const (
+	quayApiUrl = "https://quay.io/api/v1"
+)
+
 var (
 	requiredBinaries = []string{"jq", "kubectl", "oc", "yq", "git", "helm"}
 	artifactDir      = utils.GetEnv("ARTIFACT_DIR", ".")
@@ -48,6 +52,7 @@ var (
 	// in order to run tests that require PaC application
 	requiresSprayProxyRegistering bool
 	sprayProxyConfig              *sprayproxy.SprayProxyConfig
+	quayTokenNotFoundError        = "DEFAULT_QUAY_ORG_TOKEN env var was not found"
 )
 
 func (CI) parseJobSpec() error {
@@ -188,11 +193,11 @@ func (Local) CleanupGithubOrg() error {
 func (Local) CleanupQuayReposAndRobots() error {
 	quayOrgToken := os.Getenv("DEFAULT_QUAY_ORG_TOKEN")
 	if quayOrgToken == "" {
-		return fmt.Errorf("DEFAULT_QUAY_ORG_TOKEN env var was not found")
+		return fmt.Errorf(quayTokenNotFoundError)
 	}
 	quayOrg := utils.GetEnv("DEFAULT_QUAY_ORG", "redhat-appstudio-qe")
 
-	quayClient := quay.NewQuayClient(&http.Client{Transport: &http.Transport{}}, quayOrgToken, "https://quay.io/api/v1")
+	quayClient := quay.NewQuayClient(&http.Client{Transport: &http.Transport{}}, quayOrgToken, quayApiUrl)
 	return cleanupQuayReposAndRobots(quayClient, quayOrg)
 }
 
@@ -200,11 +205,11 @@ func (Local) CleanupQuayReposAndRobots() error {
 func (Local) CleanupQuayTags() error {
 	quayOrgToken := os.Getenv("DEFAULT_QUAY_ORG_TOKEN")
 	if quayOrgToken == "" {
-		return fmt.Errorf("DEFAULT_QUAY_ORG_TOKEN env var was not found")
+		return fmt.Errorf(quayTokenNotFoundError)
 	}
 	quayOrg := utils.GetEnv("DEFAULT_QUAY_ORG", "redhat-appstudio-qe")
 
-	quayClient := quay.NewQuayClient(&http.Client{Transport: &http.Transport{}}, quayOrgToken, "https://quay.io/api/v1")
+	quayClient := quay.NewQuayClient(&http.Client{Transport: &http.Transport{}}, quayOrgToken, quayApiUrl)
 	return cleanupQuayTags(quayClient, quayOrg, "test-images")
 }
 
@@ -213,11 +218,11 @@ func (Local) CleanupPrivateRepos() error {
 	repoNamePrefixes := []string{"build-e2e", "rhtap-demo"}
 	quayOrgToken := os.Getenv("DEFAULT_QUAY_ORG_TOKEN")
 	if quayOrgToken == "" {
-		return fmt.Errorf("DEFAULT_QUAY_ORG_TOKEN env var was not found")
+		return fmt.Errorf(quayTokenNotFoundError)
 	}
 	quayOrg := utils.GetEnv("DEFAULT_QUAY_ORG", "redhat-appstudio-qe")
 
-	quayClient := quay.NewQuayClient(&http.Client{Transport: &http.Transport{}}, quayOrgToken, "https://quay.io/api/v1")
+	quayClient := quay.NewQuayClient(&http.Client{Transport: &http.Transport{}}, quayOrgToken, quayApiUrl)
 	return cleanupPrivateRepos(quayClient, quayOrg, repoNamePrefixes)
 }
 


### PR DESCRIPTION
# Description

This PR adds a make target `cleanupPrivateRepos` to cleanup private repos older than 7 days.

## Issue ticket number and link

https://issues.redhat.com/browse/STONEBLD-1764

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally using `make clean-private-repos`

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
