### PR TITLE
feat: support v1-style BuildPipelineSelector pipelineRef

### DIFF
--- a/pkg/utils/tekton/bundles.go
+++ b/pkg/utils/tekton/bundles.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	buildservice "github.com/redhat-appstudio/build-service/api/v1alpha1"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -26,9 +27,9 @@ func (t *TektonController) NewBundles() (*Bundles, error) {
 	if err != nil {
 		return nil, err
 	}
-	for _, selector := range pipelineSelector.Spec.Selectors {
-		bundleName := selector.PipelineRef.Name
-		bundleRef := selector.PipelineRef.Bundle //nolint:all
+	for i := range pipelineSelector.Spec.Selectors {
+		selector := &pipelineSelector.Spec.Selectors[i]
+		bundleName, bundleRef := utils.GetPipelineNameAndBundleRef(&selector.PipelineRef)
 		switch bundleName {
 		case "docker-build":
 			bundles.DockerBuildBundle = bundleRef

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -1174,7 +1174,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 
 			pr, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(notMatchingComponentName, applicationName, testNamespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(pr.Spec.PipelineRef.Bundle).ToNot(Equal(dummyPipelineBundleRef)) //nolint:all
+			Expect(utils.GetBundleRef(pr.Spec.PipelineRef)).ToNot(Equal(dummyPipelineBundleRef)) //nolint:all
 			Expect(pr.Spec.Params).ToNot(ContainElement(v1beta1.Param{
 				Name:  expectedAdditionalPipelineParam.Name,
 				Value: v1beta1.ParamValue{StringVal: expectedAdditionalPipelineParam.Value, Type: "string"}},


### PR DESCRIPTION
# Description

The name+bundle pipelineRef style is deprecated, Tekton API v1 will support only the resolver+params style [1]. Build-service added v1 support in https://github.com/redhat-appstudio/build-service/pull/205.

Add support for v1-style pipelineRefs by taking the bundle reference either from the 'bundle' attribute or from the 'params'.

[1]: https://tekton.dev/docs/pipelines/pipelineruns/#tekton-bundles

## Issue ticket number and link

[STONEBLD-1772](https://issues.redhat.com//browse/STONEBLD-1772)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Via branch pairing in https://github.com/redhat-appstudio/infra-deployments/pull/2709

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
