### PR TITLE
fix: register sprayproxy for integration-service

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -340,6 +340,7 @@ func (ci CI) setRequiredEnvVars() error {
 				imageTagSuffix = "release-service-image"
 				testSuiteLabel = "release"
 			case strings.Contains(jobName, "integration-service"):
+				requiresSprayProxyRegistering = true
 				envVarPrefix = "INTEGRATION_SERVICE"
 				imageTagSuffix = "integration-service-image"
 				testSuiteLabel = "integration-service"


### PR DESCRIPTION
# Description

tests running in integration-service repo are now using PaC, so the sprayproxy needs to be enabled there

## Issue ticket number and link

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
it wasn't 🤷 

# Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
