### PR TITLE
chore: prepare pipelineRef syntax for Tekton v1

### DIFF
--- a/pkg/utils/integration/pipelineruns.go
+++ b/pkg/utils/integration/pipelineruns.go
@@ -35,10 +35,10 @@ func (i *IntegrationController) CreateIntegrationPipelineRun(snapshotName, names
 			},
 		},
 		Spec: tektonv1beta1.PipelineRunSpec{
-			PipelineRef: &tektonv1beta1.PipelineRef{
-				Name:   "integration-pipeline-pass",
-				Bundle: "quay.io/redhat-appstudio/example-tekton-bundle:integration-pipeline-pass", //nolint:all
-			},
+			PipelineRef: utils.NewBundleResolverPipelineRef(
+				"integration-pipeline-pass",
+				"quay.io/redhat-appstudio/example-tekton-bundle:integration-pipeline-pass",
+			),
 			Params: []tektonv1beta1.Param{
 				{
 					Name: "output-image",

--- a/pkg/utils/tekton/pipelineruns.go
+++ b/pkg/utils/tekton/pipelineruns.go
@@ -73,10 +73,7 @@ func (b BuildahDemo) Generate() (*v1beta1.PipelineRun, error) {
 					Value: *v1beta1.NewArrayOrString("true"),
 				},
 			},
-			PipelineRef: &v1beta1.PipelineRef{
-				Name:   "docker-build",
-				Bundle: b.Bundle, //nolint:all
-			},
+			PipelineRef: utils.NewBundleResolverPipelineRef("docker-build", b.Bundle),
 			Workspaces: []v1beta1.WorkspaceBinding{
 				{
 					Name: "workspace",

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -389,6 +389,19 @@ func GetBundleRef(pipelineRef *v1beta1.PipelineRef) string {
 	return bundleRef
 }
 
+func NewBundleResolverPipelineRef(name string, bundleRef string) *v1beta1.PipelineRef {
+	return &v1beta1.PipelineRef{
+		ResolverRef: v1beta1.ResolverRef{
+			Resolver: "bundles",
+			Params: []v1beta1.Param{
+				{Name: "name", Value: v1beta1.ParamValue{StringVal: name, Type: v1beta1.ParamTypeString}},
+				{Name: "bundle", Value: v1beta1.ParamValue{StringVal: bundleRef, Type: v1beta1.ParamTypeString}},
+				{Name: "kind", Value: v1beta1.ParamValue{StringVal: "pipeline", Type: v1beta1.ParamTypeString}},
+			},
+		},
+	}
+}
+
 // ParseDevfileModel calls the devfile library's parse and returns the devfile data
 func ParseDevfileModel(devfileModel string) (data.DevfileData, error) {
 	// Retrieve the devfile from the body of the resource

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -1105,10 +1105,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 					Spec: buildservice.BuildPipelineSelectorSpec{Selectors: []buildservice.PipelineSelector{
 						{
 							Name: "user-custom-selector",
-							PipelineRef: v1beta1.PipelineRef{
-								Name:   "docker-build",
-								Bundle: dummyPipelineBundleRef, //nolint:all
-							},
+							PipelineRef: *utils.NewBundleResolverPipelineRef("docker-build", dummyPipelineBundleRef),
 							PipelineParams: []buildservice.PipelineParam{expectedAdditionalPipelineParam},
 							WhenConditions: buildservice.WhenCondition{
 								ProjectType:        "hello-world",

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -99,10 +99,7 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 				Spec: buildservice.BuildPipelineSelectorSpec{Selectors: []buildservice.PipelineSelector{
 					{
 						Name: "custom java selector",
-						PipelineRef: v1beta1.PipelineRef{
-							Name:   "java-builder",
-							Bundle: customJavaPipelineBundleRef, //nolint:all
-						},
+						PipelineRef: *utils.NewBundleResolverPipelineRef("java-builder", customJavaPipelineBundleRef),
 						WhenConditions: buildservice.WhenCondition{Language: "java"},
 					},
 				}},


### PR DESCRIPTION
# Description

Tekton v1 no longer supports the v1beta1 pipelineRef style (name+bundle), switch to the v1 style (resolver+params).

Using the v1 pipelineRef style for BuildPipelineSelectors will allow build-service to drop support for the v1beta1 style.

Use the v1 style for PipelineRuns as well for consistency.

## Issue ticket number and link

[STONEBLD-1772](https://issues.redhat.com//browse/STONEBLD-1772)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Only with CI

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
