### PR TITLE
fix: unexpected ShortenStringAddHash behavior

### DIFF
--- a/pkg/logs/log_naming.go
+++ b/pkg/logs/log_naming.go
@@ -1,7 +1,7 @@
 package logs
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"regexp"
@@ -21,7 +21,7 @@ func GetClassnameFromReport(report types.SpecReport) string {
 
 // This function is used to shorten classname and add hash to prevent issues with filesystems(255 chars for folder name) and to avoid conflicts(same shortened name of a classname)
 func ShortenStringAddHash(report types.SpecReport) string {
-	const maxNameLength = 209 // Max 255 chars minus SHA-1 (40 chars) and " sha: " is 6 chars => 255 - 40 - 6 = 209
+	const maxNameLength = 185 // Max 255 chars minus SHA-256 (64 chars) and " sha: " is 6 chars => 255 - 64 - 6 = 185
 
 	s := report.FullText()
 	if s == "" {
@@ -35,8 +35,8 @@ func ShortenStringAddHash(report types.SpecReport) string {
 	if len(removedClass) > maxNameLength {
 		removedClass = removedClass[:maxNameLength]
 	}
-	h := sha1.New()
+	h := sha256.New()
 	h.Write([]byte(removedClass))
-	sha1Hash := hex.EncodeToString(h.Sum(nil))
-	return removedClass + " sha: " + sha1Hash
+	shaHash := hex.EncodeToString(h.Sum(nil))
+	return removedClass + " sha: " + shaHash
 }

--- a/pkg/logs/log_naming.go
+++ b/pkg/logs/log_naming.go
@@ -21,7 +21,7 @@ func GetClassnameFromReport(report types.SpecReport) string {
 
 // This function is used to shorten classname and add hash to prevent issues with filesystems(255 chars for folder name) and to avoid conflicts(same shortened name of a classname)
 func ShortenStringAddHash(report types.SpecReport) string {
-	const maxNameLength = 185 // Max 255 chars minus SHA-256 (64 chars) and " sha: " is 6 chars => 255 - 64 - 6 = 185
+	const maxNameLength = 255 - sha256.BlockSize - 6 // Max 255 chars minus SHA-256 (64 chars) and " sha: " is 6 chars
 
 	s := report.FullText()
 	if s == "" {

--- a/pkg/logs/log_naming.go
+++ b/pkg/logs/log_naming.go
@@ -3,38 +3,40 @@ package logs
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"fmt"
+	"regexp"
 	"strings"
 
-	types "github.com/onsi/ginkgo/v2/types"
+	"github.com/onsi/ginkgo/v2/types"
 )
 
 func GetClassnameFromReport(report types.SpecReport) string {
-	texts := []string{}
-	texts = append(texts, report.ContainerHierarchyTexts...)
-	if report.LeafNodeText != "" {
-		texts = append(texts, report.LeafNodeText)
-	}
+	texts := report.ContainerHierarchyTexts
 	if len(texts) > 0 {
 		classStrings := strings.Fields(texts[0])
 		return classStrings[0][1:]
-	} else {
-		return strings.Join(texts, " ")
 	}
+	return report.LeafNodeText
 }
 
 // This function is used to shorten classname and add hash to prevent issues with filesystems(255 chars for folder name) and to avoid conflicts(same shortened name of a classname)
 func ShortenStringAddHash(report types.SpecReport) string {
-	className := GetClassnameFromReport(report)
+	const maxNameLength = 209 // Max 255 chars minus SHA-1 (40 chars) and " sha: " is 6 chars => 255 - 40 - 6 = 209
+
 	s := report.FullText()
-	replacedClass := strings.Replace(s, className, "", 1)
-	if len(replacedClass) > 100 {
-		stringToHash := replacedClass[100:]
-		h := sha1.New()
-		h.Write([]byte(stringToHash))
-		sha1_hash := hex.EncodeToString(h.Sum(nil))
-		stringWithHash := replacedClass[0:100] + " sha: " + sha1_hash
-		return stringWithHash
-	} else {
-		return replacedClass
+	if s == "" {
+		return ""
 	}
+
+	className := GetClassnameFromReport(report)
+	reg := regexp.MustCompile(fmt.Sprintf("\\s*%s\\s*", className))
+	removedClass := reg.ReplaceAllString(s, "")
+
+	if len(removedClass) > maxNameLength {
+		removedClass = removedClass[:maxNameLength]
+	}
+	h := sha1.New()
+	h.Write([]byte(removedClass))
+	sha1Hash := hex.EncodeToString(h.Sum(nil))
+	return removedClass + " sha: " + sha1Hash
 }

--- a/pkg/logs/log_naming_test.go
+++ b/pkg/logs/log_naming_test.go
@@ -68,7 +68,7 @@ func TestShortenStringAddHash(t *testing.T) {
 			description:    "One char report",
 			input:          types.SpecReport{ContainerHierarchyTexts: []string{"f"}},
 			result:         "f sha: ",
-			expectedLength: len("f sha: ") + 40,
+			expectedLength: len("f sha: ") + 64,
 		},
 		{
 			description: "Short report",
@@ -79,7 +79,7 @@ func TestShortenStringAddHash(t *testing.T) {
 				},
 			},
 			result:         "[Foo Suite] BEGIN Lorem ipsum END sha: ",
-			expectedLength: len("[Foo Suite] BEGIN Lorem ipsum END sha: ") + 40, // Expecting hash
+			expectedLength: len("[Foo Suite] BEGIN Lorem ipsum END sha: ") + 64, // Expecting hash
 		},
 		{
 			description: "Limit with exact limit length",

--- a/pkg/logs/log_naming_test.go
+++ b/pkg/logs/log_naming_test.go
@@ -1,6 +1,7 @@
 package logs
 
 import (
+	"crypto/sha256"
 	"github.com/onsi/ginkgo/v2/types"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -68,7 +69,7 @@ func TestShortenStringAddHash(t *testing.T) {
 			description:    "One char report",
 			input:          types.SpecReport{ContainerHierarchyTexts: []string{"f"}},
 			result:         "f sha: ",
-			expectedLength: len("f sha: ") + 64,
+			expectedLength: len("f sha: ") + sha256.BlockSize,
 		},
 		{
 			description: "Short report",
@@ -79,7 +80,7 @@ func TestShortenStringAddHash(t *testing.T) {
 				},
 			},
 			result:         "[Foo Suite] BEGIN Lorem ipsum END sha: ",
-			expectedLength: len("[Foo Suite] BEGIN Lorem ipsum END sha: ") + 64, // Expecting hash
+			expectedLength: len("[Foo Suite] BEGIN Lorem ipsum END sha: ") + sha256.BlockSize, // Expecting hash
 		},
 		{
 			description: "Limit with exact limit length",

--- a/pkg/logs/log_naming_test.go
+++ b/pkg/logs/log_naming_test.go
@@ -1,0 +1,119 @@
+package logs
+
+import (
+	"github.com/onsi/ginkgo/v2/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetClassnameFromReport(t *testing.T) {
+	type testCase struct {
+		description string
+		input       types.SpecReport
+		expected    string
+	}
+
+	for _, tc := range []testCase{
+		{
+			description: "Empty report",
+			input:       types.SpecReport{},
+			expected:    "",
+		},
+		{
+			description: "Empty LeafNodeText",
+			input: types.SpecReport{
+				ContainerHierarchyTexts: []string{"[foo-suite Foo Suite]", "first", "second", "final"},
+			},
+			expected: "foo-suite",
+		},
+		{
+			description: "Populated ContainerHierarchyTexts and LeafNodeText",
+			input: types.SpecReport{
+				ContainerHierarchyTexts: []string{"[foo-suite Foo Suite]", "first", "second", "final"},
+				LeafNodeText:            "foo",
+			},
+			expected: "foo-suite",
+		},
+		{
+			description: "Empty texts, populated LeafNodeText",
+			input: types.SpecReport{
+				ContainerHierarchyTexts: nil,
+				LeafNodeText:            "foo",
+			},
+			expected: "foo",
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			assert.Equal(t, tc.expected, GetClassnameFromReport(tc.input))
+		})
+	}
+}
+
+func TestShortenStringAddHash(t *testing.T) {
+	type testCase struct {
+		description    string
+		input          types.SpecReport
+		result         string
+		expectedLength int
+	}
+
+	for _, tc := range []testCase{
+		{
+			description:    "Empty report",
+			input:          types.SpecReport{},
+			result:         "",
+			expectedLength: 0,
+		},
+		{
+			description:    "One char report",
+			input:          types.SpecReport{ContainerHierarchyTexts: []string{"f"}},
+			result:         "f sha: ",
+			expectedLength: len("f sha: ") + 40,
+		},
+		{
+			description: "Short report",
+			input: types.SpecReport{
+				ContainerHierarchyTexts: []string{
+					"[foo-suite Foo Suite]",
+					"BEGIN Lorem ipsum END",
+				},
+			},
+			result:         "[Foo Suite] BEGIN Lorem ipsum END sha: ",
+			expectedLength: len("[Foo Suite] BEGIN Lorem ipsum END sha: ") + 40, // Expecting hash
+		},
+		{
+			description: "Limit with exact limit length",
+			input: types.SpecReport{
+				ContainerHierarchyTexts: []string{
+					"[foo-suite Foo Suite] BEGIN Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. MIDDLE Ut enim ad minim veniam, quis nostrud exercitation ullam CUT",
+				},
+			},
+			result: "[Foo Suite] " +
+				"BEGIN Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
+				"MIDDLE Ut enim ad minim veniam, quis nostrud exercitation ullam CUT sha: ",
+			expectedLength: 255,
+		},
+		{
+			description: "Long report",
+			input: types.SpecReport{
+				ContainerHierarchyTexts: []string{
+					"[foo-suite Foo Suite]",
+					"BEGIN Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+					"MIDDLE Ut enim ad minim veniam, quis nostrud exercitation ullam CUT laboris nisi ut aliquip ex ea commodo consequat.",
+					"END",
+				},
+			},
+			result: "[Foo Suite] " +
+				"BEGIN Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
+				"MIDDLE Ut enim ad minim veniam, quis nostrud exercitation ullam CUT sha: ",
+			expectedLength: 255,
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			funcResult := ShortenStringAddHash(tc.input)
+
+			assert.Contains(t, funcResult[:tc.expectedLength], funcResult) // Not checking hash
+			assert.Len(t, funcResult, tc.expectedLength)
+		})
+	}
+}


### PR DESCRIPTION
# Description

`ShortenStringAddHash` is behaving unexpectedly, please see Jira for details. 
This PR aims to add hash even when the string is shorter than the limit and actually try to fit the string into 255 chars instead of 146. 
This should help with [RHTAP-1708](https://issues.redhat.com/browse/RHTAP-1708).
Also added unit tests.

## Issue ticket number and link
https://issues.redhat.com/browse/RHTAPBUGS-962

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

It hasn't, that's why it's still a DRAFT. Will be tested by running e2e-tests and seeing the xunit output

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
