### PR TITLE
fix: Disable dotnet samples. They are not supported in rhtap

### DIFF
--- a/tests/rhtap-demo/config/scenarios.go
+++ b/tests/rhtap-demo/config/scenarios.go
@@ -74,6 +74,9 @@ var TestScenarios = []TestSpec{
 	{
 		Name:            "DEVHAS-234: creates an application with dotnet component from RHTAP samples",
 		ApplicationName: "e2e-dotnet",
+		// https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/getting-started/get-started/#choosing-a-bundled-sample
+		// Seems like RHTAP dont support yet a dotnet sample. Disabling for not this tests.
+		Skip: true,
 		Components: []ComponentSpec{
 			{
 				Name:              "dotnet-component",


### PR DESCRIPTION
# Description


](https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/getting-started/get-started/#choosing-a-bundled-sample)

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
