### PR TITLE
fix(RHTAPBUGS-989): Expected Build PLR to contain finalizer added by integration-service

### DIFF
--- a/tests/integration-service/const.go
+++ b/tests/integration-service/const.go
@@ -34,6 +34,7 @@ const (
 	checkrunConclusionSuccess           = "success"
 	checkrunConclusionFailure           = "failure"
 
+	environmentLabel                         = "appstudio.openshift.io/environment"
 	snapshotAnnotation                       = "appstudio.openshift.io/snapshot"
 	scenarioAnnotation                       = "test.appstudio.openshift.io/scenario"
 	pipelinerunFinalizerByIntegrationService = "test.appstudio.openshift.io/pipelinerun"

--- a/tests/integration-service/const.go
+++ b/tests/integration-service/const.go
@@ -34,8 +34,9 @@ const (
 	checkrunConclusionSuccess           = "success"
 	checkrunConclusionFailure           = "failure"
 
-	snapshotAnnotation = "appstudio.openshift.io/snapshot"
-	scenarioAnnotation = "test.appstudio.openshift.io/scenario"
+	snapshotAnnotation                       = "appstudio.openshift.io/snapshot"
+	scenarioAnnotation                       = "test.appstudio.openshift.io/scenario"
+	pipelinerunFinalizerByIntegrationService = "test.appstudio.openshift.io/pipelinerun"
 )
 
 var (

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -59,19 +59,27 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			}
 		})
 
-		It("triggers a build PipelineRun", Label("integration-service"), func() {
-			pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
-			Eventually(func() error {
+		When("a new Component is created", func() {
+			It("triggers a build PipelineRun", Label("integration-service"), func() {
 				pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
 				Expect(err).ShouldNot(HaveOccurred())
-				if !controllerutil.ContainsFinalizer(pipelineRun, pipelinerunFinalizerByIntegrationService) {
-					return fmt.Errorf("build pipelineRun %s/%s doesn't contain the finalizer: %s yet", pipelineRun.GetNamespace(), pipelineRun.GetName(), pipelinerunFinalizerByIntegrationService)
-				}
-				return nil
-			}, 1*time.Minute, 1*time.Second).Should(Succeed(), "timeout when waiting for finalizer to be added")
+			})
 
-			Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", 2, f.AsKubeAdmin.TektonController)).To(Succeed())
-			Expect(pipelineRun.Annotations["appstudio.openshift.io/snapshot"]).To(Equal(""))
+			It("verifies if the build PipelineRun contains the finalizer", Label("integration-service"), func() {
+				Eventually(func() error {
+					pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+					Expect(err).ShouldNot(HaveOccurred())
+					if !controllerutil.ContainsFinalizer(pipelineRun, pipelinerunFinalizerByIntegrationService) {
+						return fmt.Errorf("build pipelineRun %s/%s doesn't contain the finalizer: %s yet", pipelineRun.GetNamespace(), pipelineRun.GetName(), pipelinerunFinalizerByIntegrationService)
+					}
+					return nil
+				}, 1*time.Minute, 1*time.Second).Should(Succeed(), "timeout when waiting for finalizer to be added")
+			})
+
+			It("waits for build PipelineRun to succeed", Label("integration-service"), func() {
+				Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", 2, f.AsKubeAdmin.TektonController)).To(Succeed())
+				Expect(pipelineRun.Annotations["appstudio.openshift.io/snapshot"]).To(Equal(""))
+			})
 		})
 
 		When("the build pipelineRun run succeeded", func() {

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -101,14 +101,14 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				}, timeout, interval).Should(Succeed())
 			})
 
-			It("verifies that the finalizer has been removed", func() {
+			It("verifies that the finalizer has been removed from the build pipelinerun", func() {
 				timeout := "60s"
 				interval := "1s"
 				Eventually(func() error {
-					// This is broken because the function is just checking the object rather than going to the cluster
-					pipelineRun, _ = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
-					if controllerutil.ContainsFinalizer(pipelineRun, "test.appstudio.openshift.io/pipelinerun") {
-						return fmt.Errorf("build pipelineRun %s/%s still contains the finalizer: %s", pipelineRun.GetNamespace(), pipelineRun.GetName(), "test.appstudio.openshift.io/pipelinerun")
+					pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+					Expect(err).ShouldNot(HaveOccurred())
+					if controllerutil.ContainsFinalizer(pipelineRun, pipelinerunFinalizerByIntegrationService) {
+						return fmt.Errorf("build pipelineRun %s/%s still contains the finalizer: %s", pipelineRun.GetNamespace(), pipelineRun.GetName(), pipelinerunFinalizerByIntegrationService)
 					}
 					return nil
 				}, timeout, interval).Should(Succeed(), "timeout when waiting for finalizer to be removed")

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -78,7 +78,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 
 			It("waits for build PipelineRun to succeed", Label("integration-service"), func() {
 				Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", 2, f.AsKubeAdmin.TektonController)).To(Succeed())
-				Expect(pipelineRun.Annotations["appstudio.openshift.io/snapshot"]).To(Equal(""))
+				Expect(pipelineRun.Annotations[snapshotAnnotation]).To(Equal(""))
 			})
 		})
 
@@ -93,7 +93,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			})
 
 			It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
-				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, "appstudio.openshift.io/snapshot")).To(Succeed())
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation)).To(Succeed())
 			})
 
 			It("checks if all of the integrationPipelineRuns passed", Label("slow"), func() {
@@ -218,7 +218,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		It("triggers a build PipelineRun", Label("integration-service"), func() {
 			pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
 			Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", 2, f.AsKubeAdmin.TektonController)).To(Succeed())
-			Expect(pipelineRun.Annotations["appstudio.openshift.io/snapshot"]).To(Equal(""))
+			Expect(pipelineRun.Annotations[snapshotAnnotation]).To(Equal(""))
 		})
 
 		It("checks if the BuildPipelineRun is signed", func() {
@@ -231,7 +231,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		})
 
 		It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
-			Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, "appstudio.openshift.io/snapshot")).To(Succeed())
+			Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation)).To(Succeed())
 		})
 
 		It("checks if all of the integrationPipelineRuns finished", Label("slow"), func() {

--- a/tests/integration-service/namespace-backed-environments.go
+++ b/tests/integration-service/namespace-backed-environments.go
@@ -86,7 +86,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment 
 		It("triggers a build PipelineRun", Label("integration-service"), func() {
 			pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
 			Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", 2, f.AsKubeAdmin.TektonController)).To(Succeed())
-			Expect(pipelineRun.Annotations["appstudio.openshift.io/snapshot"]).To(Equal(""))
+			Expect(pipelineRun.Annotations[snapshotAnnotation]).To(Equal(""))
 		})
 
 		When("the build pipelineRun run succeeded", func() {
@@ -100,7 +100,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment 
 			})
 
 			It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
-				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, "appstudio.openshift.io/snapshot")).To(Succeed())
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation)).To(Succeed())
 			})
 		})
 
@@ -222,9 +222,9 @@ var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment 
 		It("should find the related Integration Test PipelineRun", func() {
 			testPipelinerun, err = f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToGetStarted(integrationTestScenario.Name, snapshot.Name, testNamespace)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(testPipelinerun.Labels["appstudio.openshift.io/snapshot"]).To(ContainSubstring(snapshot.Name))
-			Expect(testPipelinerun.Labels["test.appstudio.openshift.io/scenario"]).To(ContainSubstring(integrationTestScenario.Name))
-			Expect(testPipelinerun.Labels["appstudio.openshift.io/environment"]).To(ContainSubstring(ephemeralEnvironment.Name))
+			Expect(testPipelinerun.Labels[snapshotAnnotation]).To(ContainSubstring(snapshot.Name))
+			Expect(testPipelinerun.Labels[scenarioAnnotation]).To(ContainSubstring(integrationTestScenario.Name))
+			Expect(testPipelinerun.Labels[environmentLabel]).To(ContainSubstring(ephemeralEnvironment.Name))
 		})
 
 		When("Integration Test PipelineRun is created", func() {


### PR DESCRIPTION
# Description

* defines finalizer string within the const.go
* add finalizer-check in an Eventually block to fix this bug
* add a new "When" node to make it easy to read, write, and debug tests
* cleanup task to remove hardcoded strings from the tests

Note: for more details, please read the commit messages.

## Issue ticket number and link

[RHTAPBUGS-989](https://issues.redhat.com/browse/RHTAPBUGS-989)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I've executed the test by running it multiple times on my cluster using the command: `./bin/e2e-appstudio --ginkgo.focus="with happy path for general flow of Integration service" –ginkgo.vvv`, and it passed each time.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
