### PR TITLE
chore: PLNSRVCE-1533: create a PaC on push job to update refs to the e2e-tests image used in build-definitions

### DIFF
--- a/.tekton/update-build-definitions.yaml
+++ b/.tekton/update-build-definitions.yaml
@@ -1,0 +1,43 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: metrics-exporter-update-pipeline-service
+  annotations:
+    pipelinesascode.tekton.dev/on-event: "[push]"
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/max-keep-runs: "5"
+spec:
+  params:
+    - name: git-url
+      value: "{{ repo_url }}"
+    - name: revision
+      value: "{{ revision }}"
+    - name: build-definitions-update-script
+      value: |
+        sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' .tekton/tasks/e2e-test.yaml
+  pipelineSpec:
+    params:
+      - description: 'Source Repository URL'
+        name: git-url
+        type: string
+      - description: 'Revision of the Source Repository'
+        name: revision
+        type: string
+      - default: ""
+        name: build-definitions-update-script
+    tasks:
+      - name: update-infra-repo
+        params:
+          - name: ORIGIN_REPO
+            value: $(params.git-url)
+          - name: REVISION
+            value: $(params.revision)
+          - name: SCRIPT
+            value: $(params.build-definitions-update-script)
+          - name: TARGET_GH_REPO
+            value: redhat-appstudio/build-definitions
+          - name: GITHUB_APP_INSTALLATION_ID
+            value: "35269675"
+        taskRef:
+          bundle: quay.io/redhat-appstudio-tekton-catalog/task-update-infra-deployments:0.1
+          name: update-infra-deployments


### PR DESCRIPTION
# Description

this will update the reference to the e2e-tests image in build-definitions

We'll want to merge this after https://github.com/redhat-appstudio/build-definitions/pull/692 merges

## Issue ticket number and link

https://issues.redhat.com/browse/PLNSRVCE-1533

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [/ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

unfortunately we cannot test PaC based push jobs until after merge; we may have to iterate on this to get the generation of PRs in the build-defintions repo correct

# Checklist:

- [/ ] I have performed a self-review of my code
- [n/a ] I have commented my code, particularly in hard-to-understand areas
- [n/a ] I have made corresponding changes to the documentation
- [n/a ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ n/a] I have updated labels (if needed)
