### PR TITLE
fix(stoneintg): fix e2e-tests so buil PLR be reconciled on chains

### DIFF
--- a/pkg/clients/integration/pipelineruns.go
+++ b/pkg/clients/integration/pipelineruns.go
@@ -180,23 +180,6 @@ func (i *IntegrationController) WaitForAllIntegrationPipelinesToBeFinished(testN
 	return nil
 }
 
-// WaitForBuildPipelineRunToBeSigned waits for given build pipeline to get signed.
-// In case of failure, this function retries till it gets timed out.
-func (i *IntegrationController) WaitForBuildPipelineRunToBeSigned(testNamespace, applicationName, componentName string) error {
-	return wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
-		pipelineRun, err := i.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
-		if err != nil {
-			GinkgoWriter.Printf("pipelinerun for Component %s/%s can't be gotten successfully. Error: %v", testNamespace, componentName, err)
-			return false, nil
-		}
-		if pipelineRun.Annotations["chains.tekton.dev/signed"] != "true" {
-			GinkgoWriter.Printf("pipelinerun %s/%s hasn't been signed yet", pipelineRun.GetNamespace(), pipelineRun.GetName())
-			return false, nil
-		}
-		return true, nil
-	})
-}
-
 // GetAnnotationIfExists returns the value of a given annotation within a pipelinerun, if it exists.
 func (i *IntegrationController) GetAnnotationIfExists(testNamespace, applicationName, componentName, annotationKey string) (string, error) {
 	pipelineRun, err := i.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")

--- a/tests/integration-service/const.go
+++ b/tests/integration-service/const.go
@@ -38,6 +38,8 @@ const (
 	snapshotAnnotation                       = "appstudio.openshift.io/snapshot"
 	scenarioAnnotation                       = "test.appstudio.openshift.io/scenario"
 	pipelinerunFinalizerByIntegrationService = "test.appstudio.openshift.io/pipelinerun"
+
+	chainsSignedAnnotation = "chains.tekton.dev/signed"
 )
 
 var (

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -85,8 +85,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		})
 
 		When("the build pipelineRun run succeeded", func() {
-			It("checks if the BuildPipelineRun is signed", func() {
-				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToBeSigned(testNamespace, applicationName, componentName)).To(Succeed())
+			It("checks if the BuildPipelineRun have the annotation of chains signed", func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation)).To(Succeed())
 			})
 
 			It("checks if the Snapshot is created", func() {
@@ -225,8 +225,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			Expect(pipelineRun.Annotations[snapshotAnnotation]).To(Equal(""))
 		})
 
-		It("checks if the BuildPipelineRun is signed", func() {
-			Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToBeSigned(testNamespace, applicationName, componentName)).To(Succeed())
+		It("checks if the BuildPipelineRun have the annotation of chains signed", func() {
+			Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation)).To(Succeed())
 		})
 
 		It("checks if the Snapshot is created", func() {

--- a/tests/integration-service/namespace-backed-environments.go
+++ b/tests/integration-service/namespace-backed-environments.go
@@ -93,8 +93,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment 
 		})
 
 		When("the build pipelineRun run succeeded", func() {
-			It("checks if the BuildPipelineRun is signed", func() {
-				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToBeSigned(testNamespace, applicationName, componentName)).To(Succeed())
+			It("checks if the BuildPipelineRun have the annotation of chains signed", func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation)).To(Succeed())
 			})
 
 			It("checks if the Snapshot is created", func() {

--- a/tests/integration-service/status-reporting-to-pullrequest.go
+++ b/tests/integration-service/status-reporting-to-pullrequest.go
@@ -151,8 +151,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 		})
 
 		When("the PaC build pipelineRun run succeeded", func() {
-			It("checks if the BuildPipelineRun is signed", func() {
-				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToBeSigned(testNamespace, applicationName, componentName)).To(Succeed())
+			It("checks if the BuildPipelineRun have the annotation of chains signed", func() {
+				Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation)).To(Succeed())
 			})
 
 			It("checks if the Snapshot is created", func() {


### PR DESCRIPTION
build PLRs will only be reconciled by the buildpipeline controller after the Chains controller adds the annotation "chains.tekton.dev/signed" to it, no matter if its value is "true" or "failure".

## [STONEINTG-686](https://issues.redhat.com/browse/STONEINTG-686) 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
