### PR TITLE
fix: Change the test of tekton-results logs to meet the latest API change in tekton-results

### DIFF
--- a/pkg/utils/pipeline/results.go
+++ b/pkg/utils/pipeline/results.go
@@ -2,7 +2,6 @@ package pipeline
 
 import (
 	"crypto/tls"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -95,17 +94,7 @@ func (c *ResultClient) GetLogByName(logName string) (string, error) {
 		return "", err
 	}
 
-	var result *Result
-
-	err = json.Unmarshal(body, &result)
-	if err != nil {
-		return "", err
-	}
-	data, err := base64.StdEncoding.DecodeString(result.Result.Data)
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
+	return string(body), nil
 }
 
 type Record struct {
@@ -125,13 +114,4 @@ type Log struct {
 }
 type Logs struct {
 	Record []Record `json:"records"`
-}
-
-type Result struct {
-	Result Data `json:"result"`
-}
-
-type Data struct {
-	Name string `json:"name"`
-	Data string `json:"data"`
 }


### PR DESCRIPTION
The test for tekton-results logs needs to be changed according to the latest API change in tekton-results. Here is the change [PR](https://github.com/tektoncd/results/pull/632) of tekton-results.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
