### PR TITLE
fix: increase the timeout value from 10 mins to 20 mins

### DIFF
--- a/tests/integration-service/status-reporting-to-pullrequest.go
+++ b/tests/integration-service/status-reporting-to-pullrequest.go
@@ -101,7 +101,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 			It("triggers a Build PipelineRun", func() {
-				timeout = time.Second * 600
+				timeout = time.Minute * 20
 				interval = time.Second * 1
 				Eventually(func() error {
 					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")


### PR DESCRIPTION
# Description

Increase the timeout value from 10 mins to 20 mins of the status-report test suite, so it waits longer for the PLR to start in case the system is under heavy load.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
