### PR TITLE
fix: automatically skip the PaC-related test of integration service when there's an issue with sprayproxy server

### DIFF
--- a/tests/integration-service/status-reporting-to-pullrequest.go
+++ b/tests/integration-service/status-reporting-to-pullrequest.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -38,6 +39,10 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 
 	Describe("with status reporting of Integration tests in CheckRuns", Ordered, func() {
 		BeforeAll(func() {
+			if os.Getenv(constants.SKIP_PAC_TESTS_ENV) == "true" {
+				Skip("Skipping this test due to configuration issue with Spray proxy")
+			}
+
 			f, err = framework.NewFramework(utils.GetGeneratedNamespace("stat-rep"))
 			Expect(err).NotTo(HaveOccurred())
 			testNamespace = f.UserNamespace


### PR DESCRIPTION
# Description

* This if condition checks if the "constants.SKIP_PAC_TESTS_ENV" flag is set to "true".
* If that flag is set to true ([right here](https://github.com/redhat-appstudio/e2e-tests/blob/91966584ae5fda8a84cda8cb87a46d4e1c1a5deb/magefiles/magefile.go#L253)), that indicates there was an error registering the sprayproxy server.
* Hence, the test gets skipped automatically in that case.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've not tested this locally, but this flag is already in use by the other PaC-related test suites, see: [build.go](https://github.com/redhat-appstudio/e2e-tests/blob/91966584ae5fda8a84cda8cb87a46d4e1c1a5deb/tests/build/build.go#L578) and [rhtap-demo.go](https://github.com/redhat-appstudio/e2e-tests/blob/91966584ae5fda8a84cda8cb87a46d4e1c1a5deb/tests/rhtap-demo/rhtap-demo.go#L350)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
