### PR TITLE
fix(RHTAP-1991): Daily-CI-test-does-not-produce-JSON-file

### DIFF
--- a/tests/load-tests/ci-scripts/setup-cluster.sh
+++ b/tests/load-tests/ci-scripts/setup-cluster.sh
@@ -12,6 +12,7 @@ pushd "${2:-.}"
 # Install app-studio and tweak cluster configuration
 echo "Installing app-studio and tweaking cluster configuration"
 go mod tidy
+go mod vendor
 export MY_GITHUB_ORG QUAY_E2E_ORGANIZATION INFRA_DEPLOYMENTS_ORG INFRA_DEPLOYMENTS_BRANCH TEKTON_PERF_ENABLE_PROFILING TEKTON_PERF_PROFILE_CPU_PERIOD
 MY_GITHUB_ORG=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/github-org)
 QUAY_E2E_ORGANIZATION=$(cat /usr/local/ci-secrets/redhat-appstudio-load-test/quay-org)


### PR DESCRIPTION
# Description

fix go setup by "go mod vendor" to allow load test to work
## Issue ticket number and link
https://issues.redhat.com/browse/RHTAP-1991

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
By issuing a successful openshift-ci load test 
once we get the load-tests.json result file we know the test succeeded

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
