### PR TITLE
test: RHTAPBUGS-978 increase timeout of component deletion from 10min to 15min

### DIFF
--- a/pkg/clients/has/components.go
+++ b/pkg/clients/has/components.go
@@ -273,7 +273,7 @@ func (h *HasController) ScaleComponentReplicas(component *appservice.Component, 
 func (h *HasController) DeleteComponent(name string, namespace string, reportErrorOnNotFound bool) error {
 	// temporary logs
 	start := time.Now()
-	GinkgoWriter.Println("Start to delete component '%s' at %s", name, start.Format(time.RFC3339))
+	GinkgoWriter.Printf("Start to delete component '%s' at %s\n", name, start.Format(time.RFC3339))
 
 	component := appservice.Component{
 		ObjectMeta: metav1.ObjectMeta{
@@ -287,12 +287,12 @@ func (h *HasController) DeleteComponent(name string, namespace string, reportErr
 		}
 	}
 
-	// RHTAPBUGS-978: temporary timeout to 10min
-	err := utils.WaitUntil(h.ComponentDeleted(&component), 10*time.Minute)
+	// RHTAPBUGS-978: temporary timeout to 15min
+	err := utils.WaitUntil(h.ComponentDeleted(&component), 15*time.Minute)
 
 	// temporary logs
 	deletionTime := time.Since(start).Minutes()
-	GinkgoWriter.Printf("Finish to delete component '%s' at %s. It took '%f' minutes", name, time.Now().Format(time.RFC3339), deletionTime)
+	GinkgoWriter.Printf("Finish to delete component '%s' at %s. It took '%f' minutes\n", name, time.Now().Format(time.RFC3339), deletionTime)
 
 	return err
 }

--- a/tests/byoc/byoc.go
+++ b/tests/byoc/byoc.go
@@ -114,8 +114,8 @@ var _ = framework.ByocSuiteDescribe(Label("byoc"), Ordered, func() {
 			// Remove all resources created by the tests in case the suite was successfull
 			AfterAll(func() {
 				if !CurrentSpecReport().Failed() {
-					// RHTAPBUGS-978: temporary timeout to 10min
-					if err := fw.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(fw.UserNamespace, 10*time.Minute); err != nil {
+					// RHTAPBUGS-978: temporary timeout to 15min
+					if err := fw.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(fw.UserNamespace, 15*time.Minute); err != nil {
 						if err := fw.AsKubeAdmin.StoreAllArtifactsForNamespace(fw.UserNamespace); err != nil {
 							Fail(fmt.Sprintf("error archiving artifacts:\n%s", err))
 						}

--- a/tests/remote-secret/environments.go
+++ b/tests/remote-secret/environments.go
@@ -64,8 +64,8 @@ var _ = framework.RemoteSecretSuiteDescribe(Label("remote-secret", "rs-environme
 		// Remove all resources created by the tests in case the suite was successful
 		AfterAll(func() {
 			if !CurrentSpecReport().Failed() {
-				// RHTAPBUGS-978: temporary timeout to 10min
-				if err := fw.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(fw.UserNamespace, 10*time.Minute); err != nil {
+				// RHTAPBUGS-978: temporary timeout to 15min
+				if err := fw.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(fw.UserNamespace, 15*time.Minute); err != nil {
 					if err := fw.AsKubeAdmin.StoreAllArtifactsForNamespace(fw.UserNamespace); err != nil {
 						Fail(fmt.Sprintf("error archiving artifacts:\n%s", err))
 					}

--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -117,8 +117,8 @@ var _ = framework.RhtapDemoSuiteDescribe(Label("rhtap-demo"), func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					if !CurrentSpecReport().Failed() {
-						// RHTAPBUGS-978: temporary timeout to 10min
-						if err := fw.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(namespace, 10*time.Minute); err != nil {
+						// RHTAPBUGS-978: temporary timeout to 15min
+						if err := fw.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(namespace, 15*time.Minute); err != nil {
 							if err := fw.AsKubeAdmin.StoreAllArtifactsForNamespace(namespace); err != nil {
 								Fail(fmt.Sprintf("error archiving artifacts:\n%s", err))
 							}


### PR DESCRIPTION
# Description

- Unfortunately, 10min to wait for the component to be deleted can be not enough, which is the example of this [job](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/redhat-appstudio_e2e-tests/952/pull-ci-redhat-appstudio-e2e-tests-main-redhat-appstudio-e2e/1734489406808526848#1:build-log.txt%3A1338). The present PR increases it to 15min.


## Issue ticket number and link
[RHTAPBUGS-978](https://issues.redhat.com/browse/RHTAPBUGS-978)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
