### PR TITLE
chore: cleanup Gitops repos

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -37,7 +37,8 @@ import (
 )
 
 const (
-	quayApiUrl = "https://quay.io/api/v1"
+	quayApiUrl       = "https://quay.io/api/v1"
+	gitopsRepository = "GitOps Repository"
 )
 
 var (
@@ -167,7 +168,7 @@ func (Local) CleanupGithubOrg() error {
 		dayDuration, _ := time.ParseDuration("24h")
 		if time.Since(repo.GetCreatedAt().Time) > dayDuration {
 			// Add only repos matching the regex
-			if r.MatchString(*repo.Name) {
+			if r.MatchString(*repo.Name) || *repo.Description == gitopsRepository {
 				reposToDelete = append(reposToDelete, repo)
 			}
 		}


### PR DESCRIPTION
The QE org has 10k+ repos, most of them are left over gitops repos. I think the easiest way to fix this would be to just clean up all repos with the description 'GitOps Repository', rather than trying to expand the name regex to match every application used in the test suite.

This large number of repos means that any code that attempts to iterate over them will take minutes to complete, e.g. the current renovate code takes about 5 minutes.
