### PR TITLE
fix(STONEINTG-704): e2e tests should check if the finalizer is removed from Integration PLRs

### DIFF
--- a/pkg/clients/integration/pipelineruns.go
+++ b/pkg/clients/integration/pipelineruns.go
@@ -91,7 +91,8 @@ func (i *IntegrationController) GetBuildPipelineRun(componentName, applicationNa
 	return pipelineRun, err
 }
 
-// GetComponentPipeline returns the pipeline for a given component labels.
+// GetIntegrationPipelineRun returns the integration pipelineRun
+// for a given scenario, snapshot labels.
 func (i *IntegrationController) GetIntegrationPipelineRun(integrationTestScenarioName string, snapshotName string, namespace string) (*tektonv1beta1.PipelineRun, error) {
 	opts := []client.ListOption{
 		client.InNamespace(namespace),

--- a/tests/integration-service/README.md
+++ b/tests/integration-service/README.md
@@ -10,13 +10,15 @@ Happy path testing describes tests that focus on the most common scenarios while
 
 - Testing for successful creation of applications and components.
 - Asserting the successful creation of a snapshot after a push event.
-- Checking if the BuildPipelineRun is successfully triggered and completed.
+- Checking if the BuildPipelineRun is successfully triggered, contains the finalizer, and got completed.
 - Asserting the signing of BuildPipelineRun.
+- Validating the successful creation of a Snapshot, and removal of finalizer from BuildPipelineRun.
+- Verifying that all the Integration PipelineRuns finished successfully.
+- Checking that the status of integration tests were reported to the Snapshot.
+- Checking that a snapshot gets successfully marked as 'passed' after all Integration pipeline runs finished.
+- Validating the Global Candidate is updated
 - Validating the successful creation of a SnapshotEnvironmentBinding.
 - Validating the successful creation of a Release.
-- Validating the Global Candidate is updated
-- Verifying that all the Integration PipelineRuns finished successfully.
-- Checking that a snapshot gets successfully marked as 'passed' after all Integration pipeline runs finished.
 
 ### E2E tests of Namespace-backed Environments (within `namespace-backed-environments.go`):
 
@@ -48,6 +50,11 @@ Happy path testing describes tests that focus on the most common scenarios while
 
 - Creating an IntegrationTestScenario that is expected to fail.
 - Asserting that a snapshot is marked as failed.
+- Creating a new IntegrationTestScenario that is expected to pass.
+- Updating the Snapshot with a re-run label for the new scenario.
+- Validating that a new Integration PLR is created and finished.
+- Asserting that the Snapshot doesn't contain re-run label, and contains the name of re-triggered pipelinerun.
+- Asserting that a snapshot is still marked as failed.
 - Validating that no Release CRs and no SnapshotEnvironmentBinding are created in certain scenarios.
 - Checking that the global candidate does not get updated unexpectedly.
 


### PR DESCRIPTION
# Description

The integration service removes the finalizers from the Integration Pipelineruns after its test results are reported to the Snapshot and the overall test result is used to mark the Snapshot as Passed/Failed. So, this PR updates the current test suites to test this behaviour.

## Issue ticket number and link

[STONEINTG-704](https://issues.redhat.com//browse/STONEINTG-704)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've tested this code locally and the test suite passed 10/10 times.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
