### PR TITLE
fix(STONEINTG-702): remove check for successful Snapshot after re-run

### DIFF
--- a/tests/integration-service/namespace-backed-environments.go
+++ b/tests/integration-service/namespace-backed-environments.go
@@ -342,12 +342,6 @@ var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment 
 				}, time.Minute*2, time.Second*5).Should(Succeed())
 			})
 
-			It("checks if snapshot is still marked as successful", func() {
-				snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)).To(BeTrue(), "expected tests to succeed for snapshot %s/%s", snapshot.GetNamespace(), snapshot.GetName())
-			})
-
 			It("should lead to SnapshotEnvironmentBinding getting deleted", func() {
 				Eventually(func() error {
 					_, err = f.AsKubeAdmin.CommonController.GetSnapshotEnvironmentBinding(applicationName, testNamespace, ephemeralEnvironment)


### PR DESCRIPTION
* The re-run integration test doesn't need to succeed in order to test the re-run functionality. Running multiple namespace-backed environment integration tests can run into resource limitations, failing the test.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
