### PR TITLE
feat: improve test name creation for Report Portal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/tektoncd/cli v0.29.1
 	github.com/tektoncd/pipeline v0.49.0
+	golang.org/x/crypto v0.14.0
 	golang.org/x/oauth2 v0.13.0
 	golang.org/x/tools v0.12.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -295,7 +296,6 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
-	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.17.0 // indirect

--- a/pkg/framework/custom_junit_reporter.go
+++ b/pkg/framework/custom_junit_reporter.go
@@ -148,7 +148,7 @@ func GenerateCustomJUnitReportWithConfig(report types.Report, dst string, config
 			continue
 		}
 		test := CustomJUnitTestCase{
-			Name:      logs.ShortenStringAddHash(spec),
+			Name:      logs.ShortenTestName(spec),
 			Classname: logs.GetClassnameFromReport(spec),
 			Time:      spec.RunTime.Seconds(),
 		}
@@ -248,7 +248,7 @@ func GenerateRPPreprocReport(report types.Report, rpPreprocParentDir string) {
 	// Generate folder structure for RPPreproc with logs
 	for i := range report.SpecReports {
 		reportSpec := report.SpecReports[i]
-		name := logs.ShortenStringAddHash(reportSpec)
+		name := logs.ShortenTestName(reportSpec)
 		artifactsDirPath := artifactDir + "/" + name
 		reportPortalDirPath := rpPreprocDir + "/attachments/xunit/" + name
 		//generate folders only for failed tests

--- a/pkg/logs/log_naming.go
+++ b/pkg/logs/log_naming.go
@@ -12,7 +12,7 @@ func GetClassnameFromReport(report types.SpecReport) string {
 	if len(texts) > 0 {
 		classStrings := strings.Fields(texts[0])
 		firstClass := classStrings[0]
-		reg := regexp.MustCompile("^\\s*\\[+\\s*|\\s*]+\\s*$") // Remove whitespace and square brackets on both sides
+		reg := regexp.MustCompile(`^\s*\[+\s*|\s*]+\s*$`) // Remove whitespace and square brackets on both sides
 		return reg.ReplaceAllString(firstClass, "")
 	}
 	return report.LeafNodeText
@@ -22,7 +22,7 @@ func GetClassnameFromReport(report types.SpecReport) string {
 func ShortenTestName(report types.SpecReport) string {
 	s := report.FullText()
 
-	reg := regexp.MustCompile("\\[+.*]+\\s*")
+	reg := regexp.MustCompile(`\[+.*]+\s*`)
 	removedClass := reg.ReplaceAllString(s, "")
 
 	return removedClass

--- a/pkg/logs/log_naming.go
+++ b/pkg/logs/log_naming.go
@@ -11,7 +11,9 @@ func GetClassnameFromReport(report types.SpecReport) string {
 	texts := report.ContainerHierarchyTexts
 	if len(texts) > 0 {
 		classStrings := strings.Fields(texts[0])
-		return classStrings[0][1:len(classStrings[0])]
+		firstClass := classStrings[0]
+		reg := regexp.MustCompile("^\\s*\\[+\\s*|\\s*]+\\s*$") // Remove whitespace and square brackets on both sides
+		return reg.ReplaceAllString(firstClass, "")
 	}
 	return report.LeafNodeText
 }

--- a/pkg/logs/log_naming.go
+++ b/pkg/logs/log_naming.go
@@ -1,40 +1,27 @@
 package logs
 
 import (
-	"crypto/sha1"
-	"encoding/hex"
+	"regexp"
 	"strings"
 
-	types "github.com/onsi/ginkgo/v2/types"
+	"github.com/onsi/ginkgo/v2/types"
 )
 
 func GetClassnameFromReport(report types.SpecReport) string {
-	texts := []string{}
-	texts = append(texts, report.ContainerHierarchyTexts...)
-	if report.LeafNodeText != "" {
-		texts = append(texts, report.LeafNodeText)
-	}
+	texts := report.ContainerHierarchyTexts
 	if len(texts) > 0 {
 		classStrings := strings.Fields(texts[0])
-		return classStrings[0][1:]
-	} else {
-		return strings.Join(texts, " ")
+		return classStrings[0][1:len(classStrings[0])]
 	}
+	return report.LeafNodeText
 }
 
-// This function is used to shorten classname and add hash to prevent issues with filesystems(255 chars for folder name) and to avoid conflicts(same shortened name of a classname)
+// This function is used to shorten classname
 func ShortenStringAddHash(report types.SpecReport) string {
-	className := GetClassnameFromReport(report)
 	s := report.FullText()
-	replacedClass := strings.Replace(s, className, "", 1)
-	if len(replacedClass) > 100 {
-		stringToHash := replacedClass[100:]
-		h := sha1.New()
-		h.Write([]byte(stringToHash))
-		sha1_hash := hex.EncodeToString(h.Sum(nil))
-		stringWithHash := replacedClass[0:100] + " sha: " + sha1_hash
-		return stringWithHash
-	} else {
-		return replacedClass
-	}
+
+	reg := regexp.MustCompile("\\[+.*]+\\s*")
+	removedClass := reg.ReplaceAllString(s, "")
+
+	return removedClass
 }

--- a/pkg/logs/log_naming.go
+++ b/pkg/logs/log_naming.go
@@ -18,8 +18,8 @@ func GetClassnameFromReport(report types.SpecReport) string {
 	return report.LeafNodeText
 }
 
-// This function is used to shorten classname
-func ShortenStringAddHash(report types.SpecReport) string {
+// ShortenTestName This function is used to shorten test name by removing class name
+func ShortenTestName(report types.SpecReport) string {
 	s := report.FullText()
 
 	reg := regexp.MustCompile("\\[+.*]+\\s*")

--- a/pkg/logs/utils.go
+++ b/pkg/logs/utils.go
@@ -14,7 +14,7 @@ import (
 func createArtifactDirectory() (string, error) {
 	wd, _ := os.Getwd()
 	artifactDir := GetEnv("ARTIFACT_DIR", fmt.Sprintf("%s/tmp", wd))
-	classname := ShortenStringAddHash(CurrentSpecReport())
+	classname := ShortenTestName(CurrentSpecReport())
 	testLogsDir := fmt.Sprintf("%s/%s", artifactDir, classname)
 
 	if err := os.MkdirAll(testLogsDir, os.ModePerm); err != nil {


### PR DESCRIPTION
# Description

Report Portal migrated away from `rp_preproc` to `Data Router` as part of [RHTAP-1902](https://issues.redhat.com/browse/RHTAP-1902). 
- This changes the limit of test name lengths from 255 to 1024 chars which should be (nearly) impossible to hit.
- Furthermore, resolved issues with unwanted characters like square brackets being in the classname and testname.
- Renamed `ShortenStringAddHash` to `ShortenTestName` since hash is no longer being added

## Issue ticket number and link
[RHTAP-1708](https://issues.redhat.com/browse/RHTAP-1708)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Since the changes utilize regular expressions which do not change, it has been tested manually by seeing how it works on various test names in e2e-tests.
The idea behind removing hashes and 100 char limit has been tested in a [spike PR](https://github.com/redhat-appstudio/e2e-tests/pull/926) and seeing how it works in Report Portal.
It will also be tested by running the CI on this PR and checking the Report Portal. 

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
