### PR TITLE
chore: add env variables for fbc related test cases

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -497,6 +497,8 @@ func (ci CI) setRequiredEnvVars() error {
 				os.Setenv(fmt.Sprintf("%s_CATALOG_URL", envVarPrefix), fmt.Sprintf("https://github.com/%s/%s", pr.Organization, pr.RepoName))
 				os.Setenv(fmt.Sprintf("%s_CATALOG_REVISION", envVarPrefix), pr.CommitSHA)
 			}
+			os.Setenv("TOOLCHAIN_API_URL", constants.STAGE_TOOLCHAIN_API_URL)
+			os.Setenv("KEYLOAK_URL", constants.STAGE_KEYLOAK_URL)
 			os.Setenv("E2E_TEST_SUITE_LABEL", "release-pipelines")
 		} else { // openshift/release rehearse job for e2e-tests/infra-deployments repos
 			requiresMultiPlatformTests = true

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -168,6 +168,10 @@ const (
 
 	// #app-studio-ci-reports channel id
 	SlackCIReportsChannelID = "C02M210JZ7B"
+
+	// URLs for stage cluster
+	STAGE_TOOLCHAIN_API_URL="https://api-toolchain-host-operator.apps.stone-stg-host.qc0p.p1.openshiftapps.com"
+	STAGE_KEYLOAK_URL="https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
 )
 
 var (


### PR DESCRIPTION
Set TOOLCHAIN_API_URL and KEYLOAK_URL with stage values temporarily  for the test case can only run against stage cluster.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
