### PR TITLE
fix: increase timeout for NPE case

### DIFF
--- a/tests/integration-service/namespace-backed-environments.go
+++ b/tests/integration-service/namespace-backed-environments.go
@@ -246,7 +246,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment 
 				Eventually(func() bool {
 					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot("", pipelineRun.Name, "", testNamespace)
 					return err == nil && f.AsKubeAdmin.CommonController.HaveTestsSucceeded(snapshot)
-				}, time.Minute*3, time.Second*5).Should(BeTrue(), fmt.Sprintf("Timed out waiting for Snapshot to be marked as succeeded %s/%s", snapshot.GetNamespace(), snapshot.GetName()))
+				}, time.Minute*5, time.Second*5).Should(BeTrue(), fmt.Sprintf("Timed out waiting for Snapshot to be marked as succeeded %s/%s", snapshot.GetNamespace(), snapshot.GetName()))
 			})
 
 			It("should lead to SnapshotEnvironmentBinding getting deleted", func() {


### PR DESCRIPTION
* increase timeout when waiting for snapshot to be marked as succeeded in namespace-backed-environments.go which often fails with timeout. [See https://github.com/redhat-appstudio/integration-service/pull/481](https://github.com/redhat-appstudio/integration-service/pull/481#issuecomment-1868913625). 

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
