### PR TITLE
fix(RHTAPBUGS-1051): skip the ginkgo nodes that are re-running NBE tests

### DIFF
--- a/tests/integration-service/namespace-backed-environments.go
+++ b/tests/integration-service/namespace-backed-environments.go
@@ -263,13 +263,15 @@ var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment 
 			})
 		})
 
-		It("creates a new IntegrationTestScenario with ephemeral environment", func() {
+		// skipped due to RHTAPBUGS-1051
+		It("creates a new IntegrationTestScenario with ephemeral environment", Pending, func() {
 			var err error
 			newIntegrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenarioWithEnvironment(applicationName, testNamespace, gitURL, revisionForNBE, pathInRepoForNBE, userPickedEnvironment)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
-		It("updates the Snapshot with the re-run label for the new scenario", FlakeAttempts(3), func() {
+		// skipped due to RHTAPBUGS-1051
+		It("updates the Snapshot with the re-run label for the new scenario", Pending, FlakeAttempts(3), func() {
 			updatedSnapshot := snapshot.DeepCopy()
 			err := metadata.AddLabels(updatedSnapshot, map[string]string{snapshotRerunLabel: newIntegrationTestScenario.Name})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -277,7 +279,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Namespace-backed Environment 
 			Expect(metadata.GetLabelsWithPrefix(updatedSnapshot, snapshotRerunLabel)).NotTo(BeEmpty())
 		})
 
-		When("An snapshot is updated with a re-run label for a given scenario", func() {
+		// skipped due to RHTAPBUGS-1051
+		When("An snapshot is updated with a re-run label for a given scenario", Pending, func() {
 			It("checks if the re-run label was removed from the Snapshot", func() {
 				Eventually(func() error {
 					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)


### PR DESCRIPTION
# Description

Problem:

* Currently, our nbe.go test suite re-runs an integration test on the Snapshot within an "ephemeral namespace".
* This test coverage was added as part of Integration service's re-run feature.
* However, this new addition is causing failures specifically on the CI of the integration-service repo.
* Why? Because Integration service uses smaller cluster pool to run its CI jobs.

(Temporary) Solution:

* Just to be clear, this is just what I believe is causing the problem.
* In order to confirm it, I'm confirming the related test nodes, and monitor the CI jobs to see if it made any difference.

## Issue ticket number and link

[RHTAPBUGS-1051](https://issues.redhat.com//browse/RHTAPBUGS-1051)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

CI :crossed_fingers: 

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)