### PR TITLE
fix: Add missing logic for RHTAPBUGS-890

### DIFF
--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	buildcontrollers "github.com/redhat-appstudio/build-service/controllers"
@@ -151,7 +152,7 @@ var _ = framework.RhtapDemoSuiteDescribe(Label("rhtap-demo"), Label("verify-stag
 						err := fw.AsKubeAdmin.CommonController.GetResourceQuotaInfo("rhtap-demo", namespace, "appstudio-crds-spi")
 						Expect(err).NotTo(HaveOccurred())
 
-						if !CurrentSpecReport().Failed() {
+						if !(strings.EqualFold(utils.GetEnv("E2E_SKIP_CLEANUP", ""), "true") && !CurrentSpecReport().Failed()) {
 							// RHTAPBUGS-978: temporary timeout to 15min
 							if err := fw.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(namespace, 15*time.Minute); err != nil {
 								if err := fw.AsKubeAdmin.StoreAllArtifactsForNamespace(namespace); err != nil {


### PR DESCRIPTION
# Description

Turns out I removed one change from https://github.com/redhat-appstudio/e2e-tests/pull/916 in one of the rebases I did in that PR. 
This PR adds this logic back.

## Issue ticket number and link
RHTAPBUGX-890

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
CI

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
