### PR TITLE
chore: Added debug log in GetComponentPipelineRun

### DIFF
--- a/pkg/clients/has/components.go
+++ b/pkg/clients/has/components.go
@@ -85,6 +85,11 @@ func (h *HasController) GetComponentPipelineRunWithType(componentName string, ap
 		return nil, fmt.Errorf("error listing pipelineruns in %s namespace: %v", namespace, err)
 	}
 
+	// If we hit any other error, while fetching pipelineRun list
+	if err != nil {
+		return nil, fmt.Errorf("error while trying to get pipelinerun list in %s namespace: %v", namespace, err)
+	}
+
 	if len(list.Items) > 0 {
 		return &list.Items[0], nil
 	}


### PR DESCRIPTION
# Description

Recently we observed lot of intermittent issues in the build-definitions repo e2e-tests, it was failing with error `no pipelinerun found for component` in GetComponentPipelineRun
Added this debug log to investigate more on it.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
