### PR TITLE
fix(test): set env vars if the job is running from PR check

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -103,6 +103,10 @@ func (ci CI) PrepareE2EBranch() error {
 		return err
 	}
 
+	if err := ci.setRequiredEnvVars(); err != nil {
+		return fmt.Errorf("error when setting up required env vars: %v", err)
+	}
+
 	if openshiftJobSpec.Refs.Repo == "e2e-tests" {
 		if err := gitCheckoutRemoteBranch(pr.RemoteName, pr.CommitSHA); err != nil {
 			return err


### PR DESCRIPTION
# Description
The job `ci/prow/appstudio-hac-e2e-tests` is PR check, but is running with the main branch, not with the branch from a PR. This PR should fix it.

## Issue ticket number and link
https://issues.redhat.com/browse/HAC-5623
