### PR TITLE
feat: add new bootstrap target for hac e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ test/unit:
 ci/test/e2e:
 	./mage -v ci:teste2e
 
+ci/bootstrap:
+	./mage -v ci:bootstrap
+
 ci/test/upgrade:
 	./mage -v ci:testUpgrade 
 

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -231,6 +231,17 @@ func (Local) CleanupPrivateRepos() error {
 	return cleanupPrivateRepos(quayClient, quayOrg, repoNamePrefixes)
 }
 
+func (ci CI) Bootstrap() error {
+	if err := ci.init(); err != nil {
+		return fmt.Errorf("error when running ci init: %v", err)
+	}
+
+	if err := BootstrapCluster(); err != nil {
+		return fmt.Errorf("error when bootstrapping cluster: %v", err)
+	}
+	return nil
+}
+
 func (ci CI) TestE2E() error {
 	var testFailure bool
 
@@ -240,10 +251,6 @@ func (ci CI) TestE2E() error {
 
 	if err := PreflightChecks(); err != nil {
 		return fmt.Errorf("error when running preflight checks: %v", err)
-	}
-
-	if err := setRequiredEnvVars(); err != nil {
-		return fmt.Errorf("error when setting up required env vars: %v", err)
 	}
 
 	if err := retry(BootstrapCluster, 2, 10*time.Second); err != nil {


### PR DESCRIPTION
# Description

related PR: https://github.com/openshift/release/pull/47866

[the PR we merged yesterday](https://github.com/redhat-appstudio/e2e-tests/pull/1005) was not working, because the bootstrap target used for HAC E2E didn't include the ci:init target, which is crucial for determining Github PR's remote name and branch.

This PR fixes the issue

## Issue ticket number and link
N/A

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
