### PR TITLE
fix: Move assertions in a setup node

### DIFF
--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -99,17 +99,12 @@ var _ = framework.RhtapDemoSuiteDescribe(Label("rhtap-demo"), Label("verify-stag
 		ssourl = utils.GetEnv("STAGE_SSOURL", "")
 		apiurl = utils.GetEnv("STAGE_APIURL", "")
 		username = utils.GetEnv("STAGE_USERNAME", "")
-		if token == "" && ssourl == "" && apiurl == "" && username == "" {
-			Fail("Failed: Please set the required Stage Variables for user")
-		}
-		TestScenarios = append(TestScenarios, e2eConfig.GetScenarios(true)...)
 
+		TestScenarios = append(TestScenarios, e2eConfig.GetScenarios(true)...)
 	}
 
 	if Label("rhtap-demo").MatchesLabelFilter(GinkgoLabelFilter()) {
-
 		TestScenarios = append(TestScenarios, e2eConfig.GetScenarios(false)...)
-
 	}
 
 	for _, appTest := range TestScenarios {
@@ -118,6 +113,12 @@ var _ = framework.RhtapDemoSuiteDescribe(Label("rhtap-demo"), Label("verify-stag
 
 			Describe(appTest.Name, Ordered, func() {
 				BeforeAll(func() {
+					if Label("verify-stage").MatchesLabelFilter(GinkgoLabelFilter()) {
+						if token == "" && ssourl == "" && apiurl == "" && username == "" {
+							Fail("Failed: Please set the required Stage Variables for user")
+						}
+					}
+
 					// Initialize the tests controllers
 					if !appTest.Stage {
 


### PR DESCRIPTION
# Description

* Currently when we run e2e tests of any suite, it fails with the message `Failed: Please set the required Stage Variables for user` because related code was placed within the Container node rather than a subject/setup node.
* This PR moves that code within a Setup node instead by moving the current code within rhtap-demo test suite within a new `Describe` node.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I tested locally by running the integration-service's E2E tests before and after these changes and can now confirm that I can run the tests.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
