### PR TITLE
fix: adjust SPI oauth flow timeouts

### DIFF
--- a/tests/spi/access-control.go
+++ b/tests/spi/access-control.go
@@ -133,7 +133,7 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "access-control"), func() 
 				SPITokenBinding, err = user.Framework.AsKubeDeveloper.SPIController.GetSPIAccessTokenBinding(SPITokenBinding.Name, namespace)
 				Expect(err).NotTo(HaveOccurred())
 				return SPITokenBinding.Status.Phase
-			}, 1*time.Minute, 5*time.Second).Should(Equal(v1beta1.SPIAccessTokenBindingPhaseInjected), fmt.Sprintf("SPIAccessTokenBinding %s/%s is not in %s phase", SPITokenBinding.GetNamespace(), SPITokenBinding.GetName(), v1beta1.SPIAccessTokenBindingPhaseInjected))
+			}, 5*time.Minute, 5*time.Second).Should(Equal(v1beta1.SPIAccessTokenBindingPhaseInjected), fmt.Sprintf("SPIAccessTokenBinding %s/%s is not in %s phase", SPITokenBinding.GetNamespace(), SPITokenBinding.GetName(), v1beta1.SPIAccessTokenBindingPhaseInjected))
 
 			// SPIAccessToken exists and is in Read phase
 			Eventually(func() (v1beta1.SPIAccessTokenPhase, error) {

--- a/tests/spi/oauth.go
+++ b/tests/spi/oauth.go
@@ -198,7 +198,7 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "gh-oauth-flow"), func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				return (pod.Status.Phase == corev1.PodRunning)
-			}, 5*time.Minute, 5*time.Second).Should(BeTrue(), "Cypress pod did not start")
+			}, 15*time.Minute, 5*time.Second).Should(BeTrue(), "Cypress pod did not start")
 
 		})
 
@@ -208,7 +208,7 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "gh-oauth-flow"), func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				return SPITokenBinding.Status.Phase == v1beta1.SPIAccessTokenBindingPhaseInjected
-			}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "SPIAccessTokenBinding is not in Injected phase")
+			}, 15*time.Minute, 10*time.Second).Should(BeTrue(), "SPIAccessTokenBinding is not in Injected phase")
 		})
 
 	})

--- a/tests/spi/oauth.go
+++ b/tests/spi/oauth.go
@@ -208,7 +208,7 @@ var _ = framework.SPISuiteDescribe(Label("spi-suite", "gh-oauth-flow"), func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				return SPITokenBinding.Status.Phase == v1beta1.SPIAccessTokenBindingPhaseInjected
-			}, 15*time.Minute, 10*time.Second).Should(BeTrue(), "SPIAccessTokenBinding is not in Injected phase")
+			}, 15*time.Minute, 10*time.Second).Should(BeTrue(), "SPIAccessTokenBinding is not in Injected phase after Oauth flow")
 		})
 
 	})


### PR DESCRIPTION
# Description

Sometimes cluster is busy and, even if the flow completes correctly, the spi oauth flow times out. Increasing the timeout to avoid such cases. 

## Issue ticket number and link
[RHTAPBUGS-1110](https://issues.redhat.com/browse/RHTAPBUGS-1110)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
