### PR TITLE
fix: quick fix to run rhtap-demo test by default

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -298,7 +298,7 @@ func (ci CI) TestE2E() error {
 }
 
 func RunE2ETests() error {
-	labelFilter := utils.GetEnv("E2E_TEST_SUITE_LABEL", "!upgrade-create && !upgrade-verify && !upgrade-cleanup && !release-pipelines && !verify-stage")
+	labelFilter := utils.GetEnv("E2E_TEST_SUITE_LABEL", "!upgrade-create && !upgrade-verify && !upgrade-cleanup && !release-pipelines && !verify-stage && rhtap-demo")
 	return runTests(labelFilter, "e2e-report.xml")
 }
 


### PR DESCRIPTION
# Description

a quick fix to enable rhtap-demo tests to be run in e2e-tests PRs and periodic jobs

**Note** there was a discussion around improving the stage/dev environment test logic in rhtap-demo test - it will be more investigated and possibly implemented in the scope of [RHTAPBUGS-1118](https://issues.redhat.com//browse/RHTAPBUGS-1118)

## Issue ticket number and link
https://issues.redhat.com/browse/RHTAPBUGS-1118

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
