### PR TITLE
fix: release-service: wait for IsMatched() == true

### DIFF
--- a/tests/release/service/release_plan_and_admission_matched.go
+++ b/tests/release/service/release_plan_and_admission_matched.go
@@ -77,11 +77,13 @@ var _ = framework.ReleaseServiceSuiteDescribe("ReleasePlan and ReleasePlanAdmiss
 					Expect(err).NotTo(HaveOccurred())
 					condition := meta.FindStatusCondition(releasePlanCR.Status.Conditions, releaseApi.MatchedConditionType.String())
 					if condition == nil {
-						return fmt.Errorf("the MatchedConditon of %s is still not set", releasePlanCR.Name)
+						return fmt.Errorf("the MatchedCondition of %s is still not set", releasePlanCR.Name)
+					}
+					if !releasePlanCR.IsMatched() {
+						return fmt.Errorf("the MatchedCondition of %s is still false", releasePlanCR.Name)
 					}
 					return nil
 				}, releasecommon.ReleasePlanStatusUpdateTimeout, releasecommon.DefaultInterval).Should(Succeed())
-				Expect(releasePlanCR.IsMatched()).To(BeTrue())
 				Expect(releasePlanCR.Status.ReleasePlanAdmission.Name).To(Equal(managedNamespace + "/" + releasecommon.TargetReleasePlanAdmissionName))
 				Expect(releasePlanCR.Status.ReleasePlanAdmission.Active).To(BeTrue())
 			})


### PR DESCRIPTION
# Description

this test has been flakey lately and I suspect it's because at the time when the `ReleasePlan` is fetched, the "Matched" condition is not yet updated after creation of `ReleasePlanAdmission`

## Issue ticket number and link
https://issues.redhat.com/browse/KFLUXBUGS-17

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
```
make build && ./bin/e2e-appstudio --ginkgo.v --ginkgo.label-filter="release_plan_and_admission"
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
