### PR TITLE
fix(KONFLUX-1090): KONFLUX-1090-Update-offline-token-secrets-in-GitHub

### DIFF
--- a/tests/load-tests/ci-scripts/offline-token-regeneration/json_split_and_encode_v2.sh
+++ b/tests/load-tests/ci-scripts/offline-token-regeneration/json_split_and_encode_v2.sh
@@ -14,19 +14,28 @@ split_encode_and_save_json() {
     local input_file="$1"
     local parts_count="$2"
 
-    # Calculate the number of lines per part
+    # Calculate the total number of records in the JSON array
     local total_lines=$(jq '.creds | length' < "$input_file")
+
+    # Calculate the number of records per part, ensuring it rounds up
+    # This ensures that each part will have an equal number of records
+    # with the last part possibly having fewer.
     local lines_per_part=$(( (total_lines + parts_count - 1) / parts_count ))
 
     # Split the JSON array, encode each part, and save to files
     for ((i = 0; i < parts_count; i++)); do
+        # Calculate the start and end indices for each part
         local start=$(( i * lines_per_part ))
-        local end=$(( start + lines_per_part - 1 ))
+        local end=$(( start + lines_per_part ))
 
-        # Extract part of the JSON array, encode it, and save to a file
-        # jq ".creds | .[$start:$end]" < "$input_file" | base64 -w 0 > "part_$(($i + 1)).encoded"
-input_file="$1"
-        # jq "{ \"creds\": .creds | .[$start:$end] }" < "$input_file" > "part_$(($i + 1)).json"
+        # Adjust end index if it exceeds the total number of records
+        # This is necessary for the last part if total_records is not
+        # perfectly divisible by parts_count.
+        if [ $end -gt $total_lines ]; then
+            end=$total_lines
+        fi
+
+        # Extract part of the JSON array and save base64 encoded to a file
         jq "{ \"creds\": .creds | .[$start:$end] }" < "$input_file" | base64 -w 0 > "part_$(($i + 1)).encoded"
     done
 }


### PR DESCRIPTION
Fix json_split_and_encode_v2.sh

# Description
Fixed json_split_and_encode_v2.sh to correctly split the user list json file to 4 parts
The previous script missed the last record from each part, this script fixes that to enable full list of users to
exist within the 4 parts

## Issue ticket number and link
https://issues.redhat.com/browse/KONFLUX-1090
https://issues.redhat.com/browse/KONFLUX-1007
https://issues.redhat.com/browse/KONFLUX-1031

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I used it to update the users secrets in https://github.com/redhat-appstudio/e2e-tests/settings/secrets/actions 
And in https://github.com/naftalysh/e2e-tests/settings/secrets/actions
As part of my tests for https://issues.redhat.com/browse/KONFLUX-1031


# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
