### PR TITLE
fix(KONFLUX-870): KONFLUX-870-Expose-accurate-resources-metrics

### DIFF
--- a/cmd/loadTests.go
+++ b/cmd/loadTests.go
@@ -1062,12 +1062,7 @@ func (h *ConcreteHandlerResources) handleApplicationCreation(ctx *JourneyContext
 		return false
 	}
 
-	ApplicationCreationTimeSumPerThread[ctx.ThreadIndex] += applicationCreationTime
 	MetricsWrapper(MetricsController, metricsConstants.CollectorApplications, metricsConstants.MetricTypeGuage, metricsConstants.MetricApplicationCreationTimeGauge, applicationCreationTime.Seconds())
-	if applicationCreationTime > ApplicationCreationTimeMaxPerThread[ctx.ThreadIndex] {
-		ApplicationCreationTimeMaxPerThread[ctx.ThreadIndex] = applicationCreationTime
-	}
-
 	return h.validateApplicationCreation(ctx, framework, ApplicationName, username, usernamespace, applicationCreationTime)
 }
 
@@ -1182,6 +1177,13 @@ func handleApplicationSuccess(ctx *JourneyContext, ApplicationName string, appli
 	SuccessfulApplicationCreationsPerThread[ctx.ThreadIndex] += 1
 	MetricsWrapper(MetricsController, metricsConstants.CollectorApplications, metricsConstants.MetricTypeCounter, metricsConstants.MetricSuccessfulApplicationCreationCounter)
 	increaseBar(ctx.ApplicationsBar, applicationsBarMutex)
+
+	// Transform applicationActualCreationTimeInSeconds from float64 to time.Duration
+	applicationActualCreationTimeInSecondsToDuration := time.Duration(applicationActualCreationTimeInSeconds * float64(time.Second))
+	ApplicationCreationTimeSumPerThread[ctx.ThreadIndex] += applicationActualCreationTimeInSecondsToDuration
+	if applicationActualCreationTimeInSecondsToDuration > ApplicationCreationTimeMaxPerThread[ctx.ThreadIndex] {
+		ApplicationCreationTimeMaxPerThread[ctx.ThreadIndex] = applicationActualCreationTimeInSecondsToDuration
+	}
 }
 
 func handleApplicationFailure(ctx *JourneyContext, ApplicationName string, username string, err error, conditionError error) {
@@ -1217,12 +1219,7 @@ func (h *ConcreteHandlerResources) handleIntegrationTestScenarioCreation(ctx *Jo
 	}
 
 	itsName := integrationTestScenario.Name
-	ItsCreationTimeSumPerThread[ctx.ThreadIndex] += itsCreationTime
 	MetricsWrapper(MetricsController, metricsConstants.CollectorIntegrationTestsSC, metricsConstants.MetricTypeGuage, metricsConstants.MetricIntegrationTestSenarioCreationTimeGauge, itsCreationTime.Seconds())
-	if itsCreationTime > ItsCreationTimeMaxPerThread[ctx.ThreadIndex] {
-		ItsCreationTimeMaxPerThread[ctx.ThreadIndex] = itsCreationTime
-	}
-
 	return h.validateIntegrationTestScenario(ctx, framework, itsName, ApplicationName, username, usernamespace, itsCreationTime)
 }
 
@@ -1292,6 +1289,13 @@ func handleItsSuccess(ctx *JourneyContext, itsName, username string, itsActualCr
 	MetricsWrapper(MetricsController, metricsConstants.CollectorIntegrationTestsSC, metricsConstants.MetricTypeCounter, metricsConstants.MetricSuccessfulIntegrationTestSenarioCreationCounter)
 	increaseBar(ctx.ItsBar, itsBarMutex)
 	userTestScenarioMap.Store(username, itsName)
+
+	// Transform itsActualCreationTimeInSeconds from float64 to time.Duration
+	itsActualCreationTimeInSecondsToDuration := time.Duration(itsActualCreationTimeInSeconds * float64(time.Second))
+	ItsCreationTimeSumPerThread[ctx.ThreadIndex] += itsActualCreationTimeInSecondsToDuration
+	if itsActualCreationTimeInSecondsToDuration > ItsCreationTimeMaxPerThread[ctx.ThreadIndex] {
+		ItsCreationTimeMaxPerThread[ctx.ThreadIndex] = itsActualCreationTimeInSecondsToDuration
+	}
 }
 
 func handleItsFailure(ctx *JourneyContext, applicationName string, err, conditionError error) {
@@ -1335,12 +1339,7 @@ func (h *ConcreteHandlerResources) handleCDQCreation(ctx *JourneyContext, framew
 		return false, nil
 	}
 
-	CDQCreationTimeSumPerThread[ctx.ThreadIndex] += cdqCreationTime
 	MetricsWrapper(MetricsController, metricsConstants.CollectorCDQ, metricsConstants.MetricTypeGuage, metricsConstants.MetricCDQCreationTimeGauge, cdqCreationTime.Seconds())
-	if cdqCreationTime > CDQCreationTimeMaxPerThread[ctx.ThreadIndex] {
-		CDQCreationTimeMaxPerThread[ctx.ThreadIndex] = cdqCreationTime
-	}
-
 	return h.validateCDQ(ctx, framework, ComponentDetectionQueryName, ApplicationName, username, usernamespace, cdqCreationTime)
 }
 
@@ -1397,6 +1396,13 @@ func handleCdqSuccess(ctx *JourneyContext, CDQName string, cdqActualCreationTime
 	SuccessfulCDQCreationsPerThread[ctx.ThreadIndex] += 1
 	MetricsWrapper(MetricsController, metricsConstants.CollectorCDQ, metricsConstants.MetricTypeCounter, metricsConstants.MetricSuccessfulCDQCreationCounter)
 	increaseBar(ctx.CDQsBar, cdqsBarMutex)
+
+	// Transform cdqActualCreationTimeInSeconds from float64 to time.Duration
+	cdqActualCreationTimeInSecondsToDuration := time.Duration(cdqActualCreationTimeInSeconds * float64(time.Second))
+	CDQCreationTimeSumPerThread[ctx.ThreadIndex] += cdqActualCreationTimeInSecondsToDuration
+	if cdqActualCreationTimeInSecondsToDuration > CDQCreationTimeMaxPerThread[ctx.ThreadIndex] {
+		CDQCreationTimeMaxPerThread[ctx.ThreadIndex] = cdqActualCreationTimeInSecondsToDuration
+	}
 }
 
 func handleCdqFailure(ctx *JourneyContext, applicationName string, err, conditionError error) {
@@ -1442,12 +1448,7 @@ func (h *ConcreteHandlerResources) handleComponentCreation(ctx *JourneyContext, 
 			break // Exit the inner loop
 		}
 		componentName = component.Name
-
-		ComponentCreationTimeSumPerThread[ctx.ThreadIndex] += componentCreationTime
 		MetricsWrapper(MetricsController, metricsConstants.CollectorComponents, metricsConstants.MetricTypeGuage, metricsConstants.MetricComponentCreationTimeGauge, componentCreationTime.Seconds())
-		if componentCreationTime > ComponentCreationTimeMaxPerThread[ctx.ThreadIndex] {
-			ComponentCreationTimeMaxPerThread[ctx.ThreadIndex] = componentCreationTime
-		}
 	}
 
 	// handleComponentCreation failed
@@ -1512,6 +1513,13 @@ func handleComponentSuccess(ctx *JourneyContext, username, componentName string,
 	userComponentMap.Store(username, componentName)
 	increaseBar(ctx.ComponentsBar, componentsBarMutex)
 	ctx.ChPipelines <- username
+
+	// Transform componentActualCreationTimeInSeconds from float64 to time.Duration
+	componentActualCreationTimeInSecondsToDuration := time.Duration(componentActualCreationTimeInSeconds * float64(time.Second))
+	ComponentCreationTimeSumPerThread[ctx.ThreadIndex] += componentActualCreationTimeInSecondsToDuration
+	if componentActualCreationTimeInSecondsToDuration > ComponentCreationTimeMaxPerThread[ctx.ThreadIndex] {
+		ComponentCreationTimeMaxPerThread[ctx.ThreadIndex] = componentActualCreationTimeInSecondsToDuration
+	}
 }
 
 func handleComponentFailure(ctx *JourneyContext, applicationName string, err, conditionError error) {


### PR DESCRIPTION
# Description

Expose accurate resources metrics into load-tests.json (metrics that overcome the time-skew issue)
Updated array values for application, its, cdq and component 
to relate to actual values, affecting the update of load-tests.json values accordingly

## Issue ticket number and link
https://issues.redhat.com/browse/KONFLUX-870

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
To be tested in openshift-ci load jobs

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
