### PR TITLE
refactor(RHTAPREL-852): don't run fbc tests in catalog PRs

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -495,6 +495,7 @@ func setRequiredEnvVars() error {
 			os.Setenv("E2E_TEST_SUITE_LABEL", "e2e-demo,rhtap-demo,spi-suite,remote-secret,integration-service,ec,byoc,build-templates,multi-platform")
 		} else if strings.Contains(jobName, "release-service-catalog") { // release-service-catalog jobs (pull, rehearsal)
 			envVarPrefix := "RELEASE_SERVICE"
+			os.Setenv("E2E_TEST_SUITE_LABEL", "release-pipelines")
 			// "rehearse" jobs metadata are not relevant for testing
 			if !strings.Contains(jobName, "rehearse") {
 				os.Setenv(fmt.Sprintf("%s_CATALOG_URL", envVarPrefix), fmt.Sprintf("https://github.com/%s/%s", pr.RemoteName, pr.RepoName))
@@ -508,6 +509,7 @@ func setRequiredEnvVars() error {
 					}
 					os.Setenv(fmt.Sprintf("%s_PR_OWNER", envVarPrefix), pr.RemoteName)
 					os.Setenv(fmt.Sprintf("%s_PR_SHA", envVarPrefix), pairedSha)
+					os.Setenv("E2E_TEST_SUITE_LABEL", "release-pipelines && !fbc-tests")
 				}
 			}
 			if os.Getenv("REL_IMAGE_CONTROLLER_QUAY_ORG") != "" {
@@ -516,7 +518,6 @@ func setRequiredEnvVars() error {
 			if os.Getenv("REL_IMAGE_CONTROLLER_QUAY_TOKEN") != "" {
 				os.Setenv("IMAGE_CONTROLLER_QUAY_TOKEN", os.Getenv("REL_IMAGE_CONTROLLER_QUAY_TOKEN"))
 			}
-			os.Setenv("E2E_TEST_SUITE_LABEL", "release-pipelines")
 		} else { // openshift/release rehearse job for e2e-tests/infra-deployments repos
 			requiresMultiPlatformTests = true
 			requiresSprayProxyRegistering = true


### PR DESCRIPTION
The fbc tests go against the stage cluster so they shouldn't be run on paired catalog PRs.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
