### PR TITLE
fix: ocp upgrade: support any channel type

### DIFF
--- a/magefiles/upgrade/upgrade.go
+++ b/magefiles/upgrade/upgrade.go
@@ -26,7 +26,7 @@ import (
 )
 
 const majorMinorVersionFormat = "4.%d"
-const fastChannelFormat = "fast-" + majorMinorVersionFormat
+const channelFormat = "%s-" + majorMinorVersionFormat
 
 const spiVaultNamespaceName = "spi-vault"
 const spiVaultPodName = "vault-0"
@@ -76,13 +76,15 @@ func newStatusHelper(kcs *kubeclient.Clientset, ccs *configv1client.Clientset) (
 	currentChannel := clusterVersion.Spec.Channel
 	klog.Infof("current channel is %q, current ocp version is %q", currentChannel, initialVersion)
 
+	sp := strings.Split(currentChannel, "-")
+	channelType, currentChannelVersion := sp[0], sp[1]
 	var minorVersion int
-	if _, err = fmt.Sscanf(currentChannel, fastChannelFormat, &minorVersion); err != nil {
+	if _, err = fmt.Sscanf(currentChannelVersion, majorMinorVersionFormat, &minorVersion); err != nil {
 		return nil, fmt.Errorf("can't detect the next version channel: %+v", err)
 	}
 	currentMajorMinorVersion := fmt.Sprintf(majorMinorVersionFormat, minorVersion+1)
 	nextMajorMinorVersion := fmt.Sprintf(majorMinorVersionFormat, minorVersion+1)
-	nextVersionChannel := fmt.Sprintf(fastChannelFormat, minorVersion+1)
+	nextVersionChannel := fmt.Sprintf(channelFormat, channelType, minorVersion+1)
 
 	var foundNextVersionChannel bool
 	for _, ch := range clusterVersion.Status.Desired.Channels {


### PR DESCRIPTION
# Description

we might want to test ocp upgrades with different types of upgrade channels (stable, fast, candidate, etc..)

previously the **fast** channel was hardcoded. with the current change, any type of channel is supported

## Issue ticket number and link
[KONFLUX-2063](https://issues.redhat.com//browse/KONFLUX-2063)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
❯ make ci/test/openshift-upgrade
./mage -v ci:performOpenShiftUpgrade
Running target: CI:PerformOpenShiftUpgrade
I0227 11:31:59.300799   97823 upgrade.go:77] current channel is "candidate-4.13", current ocp version is "4.13.32"
I0227 11:31:59.445403   97823 upgrade.go:112] desired major.minor version is "4.14", desired channel is "candidate-4.14"
I0227 11:31:59.900868   97823 upgrade.go:190] admin ack {"data":{"ack-4.13-kube-1.27-api-removals-in-4.14":"true"}} successfully applied
I0227 11:32:00.049246   97823 upgrade.go:206] desired minor version "4.14" not yet present in available updates
I0227 11:32:00.198017   97823 upgrade.go:201] found the desired version "4.14.14" in available updates
Requesting update to 4.14.14
I0227 11:32:00.662956   97823 upgrade.go:230] upgrading from 4.13.32 - current progress: Cluster version is 4.13.32
I0227 11:32:00.811451   97823 upgrade.go:230] upgrading from 4.13.32 - current progress: Cluster version is 4.13.32
I0227 11:32:20.981539   97823 upgrade.go:230] upgrading from 4.13.32 - current progress: Cluster version is 4.13.32
I0227 11:32:40.971998   97823 upgrade.go:230] upgrading from 4.13.32 - current progress: Working towards 4.14.14: 9 of 860 done (1% complete)
...
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
