### PR TITLE
chore: re-enable test for checking pipeline logs

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -307,8 +307,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 					Expect(records.Record).NotTo(BeEmpty(), fmt.Sprintf("No records found for PipelineRun %s", pr.Name))
 				})
 
-				// Skipping till fix of the issue RHTAPBUGS-948 is available in RHTAP
-				It("should have Pipeline Logs", Pending, func() {
+				It("should have Pipeline Logs", func() {
 					// Verify if result is stored in Database
 					// temporary logs due to RHTAPBUGS-213
 					logs, err := resultClient.GetLogs(testNamespace, string(pr.GetUID()))


### PR DESCRIPTION
# Description

re-enable the test after https://issues.redhat.com/browse/KFLUXBUGS-99 was fixed

## Issue ticket number and link
https://issues.redhat.com/browse/KFLUXBUGS-99

## Type of change

- [X] re-enable test

# How Has This Been Tested?

```
 ginkgo --focus-file tests/build/build_templates.go --v ./cmd/
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
