### PR TITLE
fix: increase timeout for invalid annotation test

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -1048,6 +1048,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 			It("handles invalid request annotation", func() {
 
 				invalidAnnotation := "foo"
+				expectedInvalidAnnotationMessage := fmt.Sprintf("unexpected build request: %s", invalidAnnotation)
 
 				Expect(f.AsKubeAdmin.HasController.SetComponentAnnotation(componentName, controllers.BuildRequestAnnotationName, invalidAnnotation, testNamespace)).To(Succeed())
 
@@ -1078,11 +1079,11 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build", "
 					if err != nil {
 						return err
 					}
-					if !strings.Contains(buildStatus.Message, fmt.Sprintf("unexpected build request: %s", invalidAnnotation)) {
-						return fmt.Errorf("build status message is not as expected, got %s", buildStatus.Message)
+					if !strings.Contains(buildStatus.Message, expectedInvalidAnnotationMessage) {
+						return fmt.Errorf("build status message is not as expected, got: %q, expected: %q", buildStatus.Message, expectedInvalidAnnotationMessage)
 					}
 					return nil
-				}, time.Minute*1, 2*time.Second).Should(Succeed(), "failed while checking build status message is correct after setting invalid annotations")
+				}, time.Minute*2, 2*time.Second).Should(Succeed(), "failed while checking build status message for component %q is correct after setting invalid annotations", componentName)
 			})
 		})
 	})


### PR DESCRIPTION
# Description

this test fails from time to time due to [insufficient timeout](https://issues.redhat.com/browse/KFLUXBUGS-101?focusedId=24247693&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24247693)

this PR increases doubles the timeout and improves logging

## Issue ticket number and link
[KFLUXBUGS-101](https://issues.redhat.com//browse/KFLUXBUGS-101)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
ginkgo -v --label-filter='annotations' ./cmd/
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
