### PR TITLE
fix: Retry removing finalizer from pipelineruns

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -129,7 +129,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 					if utils.Contains(pipelineRunsWithE2eFinalizer, pipelineRuns.Items[i].GetName()) {
 						err = kubeadminClient.TektonController.RemoveFinalizerFromPipelineRun(&pipelineRuns.Items[i], finalizerName)
 						if err != nil {
-							fmt.Printf("error removing e2e test finalizer from %s : %v\n", pipelineRuns.Items[i].GetName(), err)
+							GinkgoWriter.Printf("error removing e2e test finalizer from %s : %v\n", pipelineRuns.Items[i].GetName(), err)
 							return err
 						}
 					}

--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -119,14 +119,23 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 
 		AfterAll(func() {
 			//Remove finalizers from pipelineruns
-			pipelineRuns, err := kubeadminClient.HasController.GetAllPipelineRunsForApplication(applicationName, testNamespace)
-			Expect(err).ShouldNot(HaveOccurred())
-			for i := 0; i < len(pipelineRuns.Items); i++ {
-				if utils.Contains(pipelineRunsWithE2eFinalizer, pipelineRuns.Items[i].GetName()) {
-					err = kubeadminClient.TektonController.RemoveFinalizerFromPipelineRun(&pipelineRuns.Items[i], finalizerName)
-					Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("error removing e2e test finalizer from %s : %v", pipelineRuns.Items[i].GetName(), err))
+			Eventually(func() error {
+				pipelineRuns, err := kubeadminClient.HasController.GetAllPipelineRunsForApplication(applicationName, testNamespace)
+				if err != nil {
+					fmt.Printf("error while getting pipelineruns: %v\n", err)
+					return err
 				}
-			}
+				for i := 0; i < len(pipelineRuns.Items); i++ {
+					if utils.Contains(pipelineRunsWithE2eFinalizer, pipelineRuns.Items[i].GetName()) {
+						err = kubeadminClient.TektonController.RemoveFinalizerFromPipelineRun(&pipelineRuns.Items[i], finalizerName)
+						if err != nil {
+							fmt.Printf("error removing e2e test finalizer from %s : %v\n", pipelineRuns.Items[i].GetName(), err)
+							return err
+						}
+					}
+				}
+				return nil
+			}, time.Minute*1, time.Second*10).Should(Succeed(), "timed out when trying to remove the e2e-test finalizer from pipelineruns")
 			// Do cleanup only in case the test succeeded
 			if !CurrentSpecReport().Failed() {
 				// Clean up only Application CR (Component and Pipelines are included) in case we are targeting specific namespace

--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -122,7 +122,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 			Eventually(func() error {
 				pipelineRuns, err := kubeadminClient.HasController.GetAllPipelineRunsForApplication(applicationName, testNamespace)
 				if err != nil {
-					fmt.Printf("error while getting pipelineruns: %v\n", err)
+					GinkgoWriter.Printf("error while getting pipelineruns: %v\n", err)
 					return err
 				}
 				for i := 0; i < len(pipelineRuns.Items); i++ {


### PR DESCRIPTION
# Description

When `pipelineRuns, err := kubeadminClient.HasController.GetAllPipelineRunsForApplication(applicationName, testNamespace)` returns an error, we might leak the finalizers and removing finalizer will be skipped.
Added retry mechanism to try it multiple times.

## Issue ticket number and link
https://issues.redhat.com/browse/KFLUXBUGS-1133

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
