### PR TITLE
fix: increase the timeout values for FBC tests

### DIFF
--- a/tests/release/pipelines/fbc_release.go
+++ b/tests/release/pipelines/fbc_release.go
@@ -243,17 +243,17 @@ func assertReleasePipelineRunSucceeded(devFw, managedFw framework.Framework, dev
 	Eventually(func() error {
 		snapshot, err := devFw.AsKubeDeveloper.IntegrationController.GetSnapshot("", buildPr.Name, "", devNamespace)
 		if err != nil {
-			return fmt.Errorf("snapshot in namespace %s has not been found yet", devNamespace)
+			return err
 		}
 		releaseCR, err := devFw.AsKubeDeveloper.ReleaseController.GetRelease("", snapshot.Name, devNamespace)
 		if err != nil {
-			return fmt.Errorf("release in namespace %s has not been found yet", managedNamespace)
+			return err
 		}
 		Expect(err).ShouldNot(HaveOccurred())
 
 		releasePr, err := managedFw.AsKubeAdmin.ReleaseController.GetPipelineRunInNamespace(managedFw.UserNamespace, releaseCR.GetName(), releaseCR.GetNamespace())
 		if err != nil {
-			return fmt.Errorf("releasePipelineRun in namespace %s has not been found yet", managedNamespace)
+			return err
 		}
 		Expect(err).ShouldNot(HaveOccurred())
 
@@ -318,8 +318,8 @@ func createFBCReleasePlanAdmission(fbcRPAName string, managedFw framework.Framew
 			"publishingCredentials":           "fbc-preview-publishing-credentials",
 			"iibServiceConfigSecret":          "iib-preview-services-config",
 			"iibOverwriteFromIndexCredential": "iib-overwrite-fromimage-credentials",
-			"requestUpdateTimeout":            "420",
-			"buildTimeoutSeconds":             "480",
+			"requestUpdateTimeout":            "1500",
+			"buildTimeoutSeconds":             "1500",
 			"hotfix":                          hotfix,
 			"issueId":                         issueId,
 			"preGA":                           preGA,


### PR DESCRIPTION
Signed-off-by: Jing Qi <jinqi@redhat.com>

The buildTimeoutSeconds in RPA is not enough to complete the build some time. 
Change the error being return to original error from system.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
