### PR TITLE
fix: The clair-scan task is not required for FBC pipelines

### DIFF
--- a/pkg/utils/build/task_results.go
+++ b/pkg/utils/build/task_results.go
@@ -44,6 +44,9 @@ func ValidateBuildPipelineTestResults(pipelineRun *pipeline.PipelineRun, c crcli
 		if taskName == "inspect-image" && !strings.HasPrefix(strings.ToLower(componentName), "fbc-") {
 			continue
 		}
+		if taskName == "clair-scan" && !strings.HasPrefix(strings.ToLower(componentName), "fbc-") {
+			continue
+		}
 		results, err := fetchTaskRunResults(c, pipelineRun, taskName)
 		if err != nil {
 			return err


### PR DESCRIPTION
In https://github.com/release-engineering/rhtap-ec-policy/pull/19, I removed the requirement of multiple checks for FBC pipelines due to their special nature where the images produced are not themsleves pushed, instead metadata is extracted from it and published to the index for OLM.

Therefore, we no longer need to require clair-scan images to be present for these pipelines either.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
