### PR TITLE
fix: extend the Chains attestation timeout

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -155,6 +155,8 @@ const (
 
 	PipelineRunPollingInterval = 10 * time.Second
 
+	ChainsAttestationTimeout = 10 * time.Minute
+
 	JsonStageUsersPath = "users.json"
 
 	SamplePrivateRepoName = "test-private-repo"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -155,7 +155,8 @@ const (
 
 	PipelineRunPollingInterval = 10 * time.Second
 
-	ChainsAttestationTimeout = 10 * time.Minute
+	// Increased to 30 min from 10 min due to https://issues.redhat.com/browse/KFLUXBUGS-24
+	ChainsAttestationTimeout = 30 * time.Minute
 
 	JsonStageUsersPath = "users.json"
 

--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -32,8 +32,7 @@ import (
 )
 
 var (
-	ecPipelineRunTimeout     = time.Duration(10 * time.Minute)
-	chainsAttestationTimeout = time.Duration(10 * time.Minute)
+	ecPipelineRunTimeout = time.Duration(10 * time.Minute)
 )
 
 const pipelineCompletionRetries = 2
@@ -386,7 +385,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 				It("verify-enterprise-contract check should pass", Label(buildTemplatesTestLabel), func() {
 					// If the Tekton Chains controller is busy, it may take longer than usual for it
 					// to sign and attest the image built in BeforeAll.
-					err = kubeadminClient.TektonController.AwaitAttestationAndSignature(imageWithDigest, chainsAttestationTimeout)
+					err = kubeadminClient.TektonController.AwaitAttestationAndSignature(imageWithDigest, constants.ChainsAttestationTimeout)
 					Expect(err).ToNot(HaveOccurred())
 
 					cm, err := kubeadminClient.CommonController.GetConfigMap("ec-defaults", "enterprise-contract-service")
@@ -542,7 +541,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 					imageWithDigest, err = getImageWithDigest(kubeadminClient, componentNames[i], applicationName, testNamespace)
 					Expect(err).NotTo(HaveOccurred())
 
-					err = kubeadminClient.TektonController.AwaitAttestationAndSignature(imageWithDigest, chainsAttestationTimeout)
+					err = kubeadminClient.TektonController.AwaitAttestationAndSignature(imageWithDigest, constants.ChainsAttestationTimeout)
 					Expect(err).NotTo(HaveOccurred())
 				})
 

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -399,7 +399,7 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 
 				imageWithDigest := i.Spec.Image + "@" + i.Spec.Digest
 
-				Expect(f.AsKubeAdmin.TektonController.AwaitAttestationAndSignature(imageWithDigest, 5*time.Minute)).To(
+				Expect(f.AsKubeAdmin.TektonController.AwaitAttestationAndSignature(imageWithDigest, constants.ChainsAttestationTimeout)).To(
 					Succeed(),
 					"Could not find .att or .sig ImageStreamTags within the 1 minute timeout. "+
 						"Most likely the chains-controller did not create those in time. "+

--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -82,7 +82,6 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 		// pushed to.
 		var buildPipelineRunName, image, imageWithDigest string
 		var pipelineRunTimeout int
-		var attestationTimeout time.Duration
 		var defaultECP *ecp.EnterpriseContractPolicy
 
 		BeforeAll(func() {
@@ -108,7 +107,6 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 			Expect(err).ToNot(HaveOccurred())
 
 			pipelineRunTimeout = int(time.Duration(20) * time.Minute)
-			attestationTimeout = time.Duration(5) * time.Minute
 
 			defaultECP, err = fwk.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")
 			Expect(err).NotTo(HaveOccurred())
@@ -144,13 +142,13 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 		})
 
 		It("creates signature and attestation", func() {
-			err := fwk.AsKubeAdmin.TektonController.AwaitAttestationAndSignature(imageWithDigest, attestationTimeout)
+			err := fwk.AsKubeAdmin.TektonController.AwaitAttestationAndSignature(imageWithDigest, constants.ChainsAttestationTimeout)
 			Expect(err).NotTo(
 				HaveOccurred(),
 				"Could not find .att or .sig ImageStreamTags within the %s timeout. "+
 					"Most likely the chains-controller did not create those in time. "+
 					"Look at the chains-controller logs.",
-				attestationTimeout.String(),
+				constants.ChainsAttestationTimeout.String(),
 			)
 			GinkgoWriter.Printf("Cosign verify pass with .att and .sig ImageStreamTags found for %s\n", imageWithDigest)
 		})


### PR DESCRIPTION
It can take The Tekton Chains operator a long time to attest images. Recently, in the build-definitions test suite, we observed Chains taking nearly 30 minutes - even an hour in extreme cases - to do its job.

We don't have much data at the moment, only these 6 cases (time taken between the push of the binary image and the push of the attestation, based on timestamps in quay.io):

    56m
    49m
    14m
    13m
    24m
    27m

A timeout of 30 minutes seems to be necessary to handle the common case (while still not enough for the worst case).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
