### PR TITLE
ci: refine OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,4 @@
 reviewers:
-- build-team
-- ec-team
-- integration-team
-- release-team
 - rhtap-qe
 
 approvers:

--- a/pkg/clients/imagecontroller/OWNERS
+++ b/pkg/clients/imagecontroller/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- build-team

--- a/pkg/clients/integration/OWNERS
+++ b/pkg/clients/integration/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- integration-team

--- a/pkg/clients/jvmbuildservice/OWNERS
+++ b/pkg/clients/jvmbuildservice/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- build-team

--- a/pkg/clients/release/OWNERS
+++ b/pkg/clients/release/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- release-team


### PR DESCRIPTION
# Description
* Remove other teams than rhtap-qe from reviewers in the root OWNERS file
* Add teams as reviewers to their pkg/clients folder

Discussion is welcome.

## Issue ticket number and link
[KONFLUX-2406](https://issues.redhat.com/browse/KONFLUX-2406)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

It hasn't. I don't think it's even possible. 

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
