### PR TITLE
perf: drop the push-sbom-to-pyxis task

### DIFF
--- a/tests/release/pipelines/rh_push_to_external_registry.go
+++ b/tests/release/pipelines/rh_push_to_external_registry.go
@@ -360,10 +360,6 @@ var _ = framework.ReleasePipelinesSuiteDescribe("[HACBS-1571]test-release-e2e-pu
 					sbomImage := release.Image{}
 					Expect(json.Unmarshal(body, &sbomImage)).To(Succeed(), "failed to unmarshal body content: %s", string(body))
 
-					if sbomImage.ContentManifest.ID == "" {
-						return fmt.Errorf("ContentManifest field is empty for sbom image: %+v", sbomImage)
-					}
-
 					return nil
 				}, releasecommon.ReleaseCreationTimeout, releasecommon.DefaultInterval).Should(Succeed())
 			}


### PR DESCRIPTION
# Description

Drop the pyxis sbom push task

See corresponding change at https://github.com/redhat-appstudio/release-service-catalog/pull/382

## Issue ticket number and link

This is triggered by https://issues.redhat.com/browse/PSSECMGT-3181

## Type of change

Removing an old task.

# How Has This Been Tested?

Not tested outside of CI yet.
