### PR TITLE
fix: do not delete hosts with invalid certs

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -1113,6 +1114,7 @@ func CleanupRegisteredPacServers() error {
 }
 
 func isValidPacHost(server string) bool {
-	_, err := http.Get(strings.TrimSpace(server))
+	httpClient := http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	_, err := httpClient.Get(strings.TrimSpace(server))
 	return err == nil
 }


### PR DESCRIPTION
# Description

Related to [KFLUXBUGS-348](https://issues.redhat.com//browse/KFLUXBUGS-348) where a big portion of failures were caused by [periodic cleanup job](https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-redhat-appstudio-rhtap-installer-main-rhtap-dump-external-resources) that takes care of cleaning up quay.io robot accounts/images/tags and **invalid PaC endpoints registered to sprayproxy**

And the last mentioned functionality has a bug that caused deletion of valid PaC endpoint from sprayproxy while the related e2e job (that relied on the PaC endpoint being registered there) was still running. The reason why it was deleted was that our CI clusters don't use valid certificates for application endpoints, thus when an http request was sent to such endpoint (without skipping TLS verification), error was returned, so the script interpreted it like the cluster wouldn't exist.

This PR adds the `InsecureSkipVerify` config, which fixes the issue.

More info [here](https://issues.redhat.com/browse/KFLUXBUGS-348?focusedId=24366975&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24366975)

## Issue ticket number and link
[KFLUXBUGS-348](https://issues.redhat.com//browse/KFLUXBUGS-348)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
I modified the make target for cleaning up invalid PaC endpoints to just print "INVALID" in case the PaC endpoint should be deleted and "VALID" in case it should be kept. Then I registered a cluster with no TLS certs to sprayproxy and ran the make target:

Before the code change:
```
❯ make clean-registered-servers
./mage -v CleanupRegisteredPacServers
Running target: CleanupRegisteredPacServers
...
I0319 10:45:32.350458   69965 magefile.go:1108] INVALID:  https://pipelines-as-code-controller-openshift-pipelines.apps.708ece4f4b5f559834dd.hypershift.aws-2.ci.openshift.org
...
```

After code change:
```
❯ make clean-registered-servers
./mage -v CleanupRegisteredPacServers
Running target: CleanupRegisteredPacServers
...
I0319 10:45:32.350458   69965 magefile.go:1108] VALID:  https://pipelines-as-code-controller-openshift-pipelines.apps.708ece4f4b5f559834dd.hypershift.aws-2.ci.openshift.org
...
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
