### PR TITLE
fix(STONEBLD-2265): increase chains timeout since chains controller is overwhelmed

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -155,8 +155,9 @@ const (
 
 	PipelineRunPollingInterval = 10 * time.Second
 
-	// Increased to 30 min from 10 min due to https://issues.redhat.com/browse/KFLUXBUGS-24
-	ChainsAttestationTimeout = 30 * time.Minute
+	// Increased to 1.5 hrs from 10 min due to KFLUXBUGS-24 or SRVKP-4240,
+	// and since now we're frequently hitting the worst case
+	ChainsAttestationTimeout = 90 * time.Minute
 
 	JsonStageUsersPath = "users.json"
 


### PR DESCRIPTION
# Description

* Because the build-definitions PR checks are running on the production cluster, due to the heavy load chains controller is overwhelemed more often.
* This is causing test timeout while waiting for chains controller to attest artifacts.
* These days, we're hitting the worst case more often making it difficult for us to merge PRs on build-def repo.
* This PR increases the timeout from 30 mins to 90mins
* We should reduce this timeout as soon as the situation is improved by shifting the checks to execute on the staging cluster instead, which has comparatively less load.

## Issue ticket number and link
[STONEBLD-2265](https://issues.redhat.com/browse/STONEBLD-2265)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
