### PR TITLE
fix: Fix Untar to create parent dirs when necessary

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -364,6 +364,10 @@ func Untar(dst string, tarPath string) error {
 			}
 		// if it's a file create it
 		case tar.TypeReg:
+			dirPath := filepath.Dir(target)
+			if err := CreateDir(dirPath); err != nil {
+				return fmt.Errorf("error when create parent directories %s: %v", dirPath, err)
+			}
 			err = CreateFile(target, header, tr)
 			if err != nil {
 				return err


### PR DESCRIPTION
Since build-tasks-dockerfiles 5805b6, only files are recorded in the headers of generated tar archive. Then, during Untar, the parent directories have to be created firstly.


## Issue ticket number and link

https://github.com/redhat-appstudio/build-definitions/pull/855

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This change does not break anything. After merge, e2e tests should work for https://github.com/redhat-appstudio/build-definitions/pull/855 by untaring the source archive.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
