### PR TITLE
fix: test EC only for a single component

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -397,7 +397,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 						verifyECTaskBundle := cm.Data["verify_ec_task_bundle"]
 						Expect(verifyECTaskBundle).ToNot(BeEmpty())
 
-						publicSecretName := "cosign-public-key"
+						publicSecretName := "cosign-public-key" // #nosec G101 -- the name of a secret is not a secret
 						publicKey, err := kubeadminClient.TektonController.GetTektonChainsPublicKey()
 						Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Due to https://issues.redhat.com/browse/KFLUXBUGS-24, testing the EC pipelines takes extremely long (the tests have to wait for the attestation to exist before they can start the EC pipelines).

Run the test only for one component to try and improve the situation.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
