### PR TITLE
fix: gitops repos cleanup script

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -170,7 +170,7 @@ func (Local) CleanupGithubOrg() error {
 		dayDuration, _ := time.ParseDuration("24h")
 		if time.Since(repo.GetCreatedAt().Time) > dayDuration {
 			// Add only repos matching the regex
-			if r.MatchString(*repo.Name) || *repo.Description == gitopsRepository {
+			if r.MatchString(repo.GetName()) || repo.GetDescription() == gitopsRepository {
 				reposToDelete = append(reposToDelete, repo)
 			}
 		}


### PR DESCRIPTION
# Description
* fix [runtime error in cleanup script](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-redhat-appstudio-e2e-tests-main-appstudio-dump-external-resources/1772050911749738496#1:build-log.txt%3A36)

## Issue ticket number and link
https://issues.redhat.com/browse/KFLUXBUGS-1170

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
```
DRY_RUN=false ./mage -v local:cleanupGithubOrg
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
