### PR TITLE
feat(RHTAPREL-869): add e2e tests for create-advisory pipeline

### DIFF
--- a/pkg/clients/release/plans.go
+++ b/pkg/clients/release/plans.go
@@ -15,7 +15,7 @@ import (
 )
 
 // CreateReleasePlan creates a new ReleasePlan using the given parameters.
-func (r *ReleaseController) CreateReleasePlan(name, namespace, application, targetNamespace, autoReleaseLabel string) (*releaseApi.ReleasePlan, error) {
+func (r *ReleaseController) CreateReleasePlan(name, namespace, application, targetNamespace, autoReleaseLabel string, data *runtime.RawExtension) (*releaseApi.ReleasePlan, error) {
 	var releasePlan *releaseApi.ReleasePlan = &releaseApi.ReleasePlan{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: name,
@@ -28,6 +28,7 @@ func (r *ReleaseController) CreateReleasePlan(name, namespace, application, targ
 		},
 		Spec: releaseApi.ReleasePlanSpec{
 			Application: application,
+			Data:        data,
 			Target:      targetNamespace,
 		},
 	}

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -137,7 +137,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		})
 
 		It("creates a ReleasePlan", func() {
-			_, err = f.AsKubeAdmin.ReleaseController.CreateReleasePlan(autoReleasePlan, testNamespace, applicationName, targetReleaseNamespace, "")
+			_, err = f.AsKubeAdmin.ReleaseController.CreateReleasePlan(autoReleasePlan, testNamespace, applicationName, targetReleaseNamespace, "", nil)
 			Expect(err).ShouldNot(HaveOccurred())
 			testScenarios, err := f.AsKubeAdmin.IntegrationController.GetIntegrationTestScenarios(applicationName, testNamespace)
 			Expect(err).ShouldNot(HaveOccurred())

--- a/tests/release/const.go
+++ b/tests/release/const.go
@@ -13,6 +13,7 @@ const (
 	ReleaseStrategyPolicy        string = "policy"
 
 	RedhatAppstudioUserSecret            string = "hacbs-release-tests-token"
+	RedhatAppstudioQESecret              string = "redhat-appstudio-qe-bot-token"
 	HacbsReleaseTestsTokenSecret         string = "redhat-appstudio-registry-pull-secret"
 	PublicSecretNameAuth                 string = "cosign-public-key"
 	ReleasePipelineServiceAccountDefault string = "release-service-account"

--- a/tests/release/pipelines/fbc_release.go
+++ b/tests/release/pipelines/fbc_release.go
@@ -84,7 +84,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("FBC e2e-tests", Label("release-
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println("Created application :", fbcApplicationName)
 
-			_, err = devFw.AsKubeDeveloper.ReleaseController.CreateReleasePlan(fbcReleasePlanName, devNamespace, fbcApplicationName, managedNamespace, "true")
+			_, err = devFw.AsKubeDeveloper.ReleaseController.CreateReleasePlan(fbcReleasePlanName, devNamespace, fbcApplicationName, managedNamespace, "true", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			createFBCReleasePlanAdmission(fbcReleasePlanAdmissionName, *managedFw, devNamespace, managedNamespace, fbcApplicationName, fbcEnterpriseContractPolicyName, relSvcCatalogPathInRepo, "false", "", "", "", "")
@@ -127,7 +127,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("FBC e2e-tests", Label("release-
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println("Created application :", fbcHotfixAppName)
 
-			_, err = devFw.AsKubeDeveloper.ReleaseController.CreateReleasePlan(fbcHotfixRPName, devNamespace, fbcHotfixAppName, managedNamespace, "true")
+			_, err = devFw.AsKubeDeveloper.ReleaseController.CreateReleasePlan(fbcHotfixRPName, devNamespace, fbcHotfixAppName, managedNamespace, "true", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			createFBCReleasePlanAdmission(fbcHotfixRPAName, *managedFw, devNamespace, managedNamespace, fbcHotfixAppName, fbcHotfixECPolicyName, relSvcCatalogPathInRepo, "true", issueId, "false", "", "")
@@ -169,7 +169,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("FBC e2e-tests", Label("release-
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoWriter.Println("Created application :", fbcPreGAAppName)
 
-			_, err = devFw.AsKubeDeveloper.ReleaseController.CreateReleasePlan(fbcPreGARPName, devNamespace, fbcPreGAAppName, managedNamespace, "true")
+			_, err = devFw.AsKubeDeveloper.ReleaseController.CreateReleasePlan(fbcPreGARPName, devNamespace, fbcPreGAAppName, managedNamespace, "true", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			createFBCReleasePlanAdmission(fbcPreGARPAName, *managedFw, devNamespace, managedNamespace, fbcPreGAAppName, fbcPreGAECPolicyName, relSvcCatalogPathInRepo, "false", issueId, "true", productName, productVersion)

--- a/tests/release/pipelines/push_to_external_registry.go
+++ b/tests/release/pipelines/push_to_external_registry.go
@@ -75,7 +75,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("Push to external registry", Lab
 
 		component = releasecommon.CreateComponentByCDQ(*fw, devNamespace, managedNamespace, releasecommon.ApplicationNameDefault, releasecommon.ComponentName, releasecommon.GitSourceComponentUrl)
 
-		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(releasecommon.SourceReleasePlanName, devNamespace, releasecommon.ApplicationNameDefault, managedNamespace, "")
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(releasecommon.SourceReleasePlanName, devNamespace, releasecommon.ApplicationNameDefault, managedNamespace, "", nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		data, err := json.Marshal(map[string]interface{}{

--- a/tests/release/pipelines/release_to_github.go
+++ b/tests/release/pipelines/release_to_github.go
@@ -73,7 +73,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for release-to-github
 			err = devFw.AsKubeAdmin.CommonController.LinkSecretToServiceAccount(devNamespace, releasecommon.HacbsReleaseTestsTokenSecret, constants.DefaultPipelineServiceAccount, true)
 			Expect(err).ToNot(HaveOccurred())
 
-			githubUser := utils.GetEnv("GITHUB_USER","")
+			githubUser := utils.GetEnv("GITHUB_USER","redhat-appstudio-qe-bot")
 			githubToken := utils.GetEnv(constants.GITHUB_TOKEN_ENV, "")
 			gh, err = github.NewGithubClient(githubToken, githubUser)
 			Expect(githubToken).ToNot(BeEmpty())
@@ -83,11 +83,11 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for release-to-github
 				gh.DeleteRelease(sampRepoOwner, sampRepo, sampReleaseURL)
 			}
 
-			_, err = managedFw.AsKubeAdmin.CommonController.GetSecret(managedNamespace, releasecommon.RedhatAppstudioUserSecret)
+			_, err = managedFw.AsKubeAdmin.CommonController.GetSecret(managedNamespace, releasecommon.RedhatAppstudioQESecret)
 			if errors.IsNotFound(err) {
 				githubSecret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      releasecommon.RedhatAppstudioUserSecret,
+						Name:      releasecommon.RedhatAppstudioQESecret,
 						Namespace: managedNamespace,
 					},
 					Type: corev1.SecretTypeOpaque,
@@ -100,13 +100,13 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for release-to-github
 			}
 			Expect(err).ToNot(HaveOccurred())
 
-			err = managedFw.AsKubeAdmin.CommonController.LinkSecretToServiceAccount(managedNamespace, releasecommon.RedhatAppstudioUserSecret, constants.DefaultPipelineServiceAccount, true)
+			err = managedFw.AsKubeAdmin.CommonController.LinkSecretToServiceAccount(managedNamespace, releasecommon.RedhatAppstudioQESecret, constants.DefaultPipelineServiceAccount, true)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, err = devFw.AsKubeDeveloper.HasController.CreateApplication(sampApplicationName, devNamespace)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = devFw.AsKubeDeveloper.ReleaseController.CreateReleasePlan(sampReleasePlanName, devNamespace, sampApplicationName, managedNamespace, "true")
+			_, err = devFw.AsKubeDeveloper.ReleaseController.CreateReleasePlan(sampReleasePlanName, devNamespace, sampApplicationName, managedNamespace, "true", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			createGHReleasePlanAdmission(sampReleasePlanAdmissionName, *managedFw, devNamespace, managedNamespace, sampApplicationName, sampEnterpriseContractPolicyName, sampCatalogPathInRepo, "false", "", "", "", "")
@@ -214,7 +214,7 @@ func createGHReleasePlanAdmission(sampRPAName string, managedFw framework.Framew
 
 	data, err := json.Marshal(map[string]interface{}{
 		"github": map[string]interface{}{
-			"githubSecret": releasecommon.RedhatAppstudioUserSecret,
+			"githubSecret": releasecommon.RedhatAppstudioQESecret,
 		},
 		"sign": map[string]interface{}{
 			"configMapName": "hacbs-signing-pipeline-config-redhatbeta2",

--- a/tests/release/pipelines/rh_advisories.go
+++ b/tests/release/pipelines/rh_advisories.go
@@ -1,0 +1,277 @@
+package pipelines
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+	"regexp"
+
+	"github.com/devfile/library/v2/pkg/util"
+	ecp "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appservice "github.com/redhat-appstudio/application-api/api/v1alpha1"
+	"github.com/redhat-appstudio/e2e-tests/pkg/clients/has"
+	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
+	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
+	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	releaseapi "github.com/redhat-appstudio/release-service/api/v1alpha1"
+	releasecommon "github.com/redhat-appstudio/e2e-tests/tests/release"
+	tektonutils "github.com/redhat-appstudio/release-service/tekton/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	advsServiceAccountName   = "release-service-account"
+	advsCatalogPathInRepo    = "pipelines/rh-advisories/rh-advisories.yaml"
+)
+
+var component *appservice.Component
+
+var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-advisories pipeline", Label("release-pipelines", "rh-advisories"), func() {
+	defer GinkgoRecover()
+	var pyxisKeyDecoded, pyxisCertDecoded []byte
+
+	var devWorkspace = utils.GetEnv(constants.RELEASE_DEV_WORKSPACE_ENV, constants.DevReleaseTeam)
+	var managedWorkspace = utils.GetEnv(constants.RELEASE_MANAGED_WORKSPACE_ENV, constants.ManagedReleaseTeam)
+
+	var devNamespace = devWorkspace + "-tenant"
+	var managedNamespace = managedWorkspace + "-tenant"
+
+	var err error
+	var devFw *framework.Framework
+	var managedFw *framework.Framework
+	var advsApplicationName = "advs-app-" + util.GenerateRandomString(4)
+	var advsComponentName = "advs-comp-" + util.GenerateRandomString(4)
+	var advsReleasePlanName = "advs-rp-" + util.GenerateRandomString(4)
+	var advsReleasePlanAdmissionName = "advs-rpa-" + util.GenerateRandomString(4)
+	var advsEnterpriseContractPolicyName = "advs-policy-" + util.GenerateRandomString(4)
+
+	var snapshot *appservice.Snapshot
+	var releaseCR *releaseapi.Release
+	var releasePR, buildPR *tektonv1.PipelineRun
+
+	AfterEach(framework.ReportFailure(&devFw))
+
+	Describe("Rh-advisories happy path", Label("rhAdvisories"), func() {
+		BeforeAll(func() {
+			devFw = releasecommon.NewFramework(devWorkspace)
+			managedFw = releasecommon.NewFramework(managedWorkspace)
+			managedNamespace = managedFw.UserNamespace
+
+			keyPyxisStage := os.Getenv(constants.PYXIS_STAGE_KEY_ENV)
+			Expect(keyPyxisStage).ToNot(BeEmpty())
+
+			certPyxisStage := os.Getenv(constants.PYXIS_STAGE_CERT_ENV)
+			Expect(certPyxisStage).ToNot(BeEmpty())
+
+			// Creating k8s secret to access Pyxis stage based on base64 decoded of key and cert
+			pyxisKeyDecoded, err = base64.StdEncoding.DecodeString(string(keyPyxisStage))
+			Expect(err).ToNot(HaveOccurred())
+
+			pyxisCertDecoded, err = base64.StdEncoding.DecodeString(string(certPyxisStage))
+			Expect(err).ToNot(HaveOccurred())
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pyxis",
+					Namespace: managedNamespace,
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"cert": pyxisCertDecoded,
+					"key":  pyxisKeyDecoded,
+				},
+			}
+
+			// Delete the secret if it exists in case it is not correct
+			_ = managedFw.AsKubeAdmin.CommonController.DeleteSecret(managedNamespace, "pyxis")
+			_, err = managedFw.AsKubeAdmin.CommonController.CreateSecret(managedNamespace, secret)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = managedFw.AsKubeAdmin.CommonController.LinkSecretToServiceAccount(managedNamespace, releasecommon.RedhatAppstudioUserSecret, constants.DefaultPipelineServiceAccount, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = devFw.AsKubeDeveloper.HasController.CreateApplication(advsApplicationName, devNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			createADVSReleasePlan(advsReleasePlanName, *devFw, devNamespace, advsApplicationName, managedNamespace, "true")
+			component = releasecommon.CreateComponentByCDQ(*devFw, devNamespace, managedNamespace, advsApplicationName, advsComponentName, releasecommon.AdditionalGitSourceComponentUrl)
+			createADVSReleasePlanAdmission(advsReleasePlanAdmissionName, *managedFw, devNamespace, managedNamespace, advsApplicationName, advsEnterpriseContractPolicyName, advsCatalogPathInRepo)
+
+			createADVSEnterpriseContractPolicy(advsEnterpriseContractPolicyName, *managedFw, devNamespace, managedNamespace)
+		})
+
+		AfterAll(func() {
+			devFw = releasecommon.NewFramework(devWorkspace)
+			managedFw = releasecommon.NewFramework(managedWorkspace)
+			Expect(devFw.AsKubeDeveloper.HasController.DeleteApplication(advsApplicationName, devNamespace, false)).NotTo(HaveOccurred())
+			Expect(managedFw.AsKubeDeveloper.TektonController.DeleteEnterpriseContractPolicy(advsEnterpriseContractPolicyName, managedNamespace, false)).NotTo(HaveOccurred())
+			Expect(managedFw.AsKubeDeveloper.ReleaseController.DeleteReleasePlanAdmission(advsReleasePlanAdmissionName, managedNamespace, false)).NotTo(HaveOccurred())
+		})
+
+		var _ = Describe("Post-release verification", func() {
+			It("verifies that a build PipelineRun is created in dev namespace and succeeds", func() {
+				devFw = releasecommon.NewFramework(devWorkspace)
+				Eventually(func() error {
+					buildPR, err = devFw.AsKubeDeveloper.HasController.GetComponentPipelineRun(component.Name, advsApplicationName, devNamespace, "")
+					if err != nil {
+						return err
+					}
+					if !buildPR.IsDone() {
+						return fmt.Errorf("build pipelinerun %s in namespace %s did not finish yet", buildPR.Name, buildPR.Namespace)
+					}
+					Expect(tekton.HasPipelineRunSucceeded(buildPR)).To(BeTrue(), fmt.Sprintf("build pipelinerun %s/%s did not succeed", buildPR.GetNamespace(), buildPR.GetName()))
+					snapshot, err = devFw.AsKubeDeveloper.IntegrationController.GetSnapshot("", buildPR.Name, "", devNamespace)
+					if err != nil {
+						return err
+					}
+					return nil
+				}, releasecommon.BuildPipelineRunCompletionTimeout, releasecommon.DefaultInterval).Should(Succeed(), "timed out when waiting for build pipelinerun to be created")
+				Expect(devFw.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(component, "", devFw.AsKubeDeveloper.TektonController, &has.RetryOptions{Retries: 3, Always: true})).To(Succeed())
+			})
+			It("verifies the advs release pipelinerun is running and succeeds", func() {
+				devFw = releasecommon.NewFramework(devWorkspace)
+				managedFw = releasecommon.NewFramework(managedWorkspace)
+
+				releaseCR, err = devFw.AsKubeDeveloper.ReleaseController.GetRelease("", snapshot.Name, devNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+				Eventually(func() error {
+					releasePR, err = managedFw.AsKubeAdmin.ReleaseController.GetPipelineRunInNamespace(managedFw.UserNamespace, releaseCR.GetName(), releaseCR.GetNamespace())
+					if err != nil {
+						return err
+					}
+					GinkgoWriter.Println("Release PR: ", releasePR.Name)
+					if  !releasePR.IsDone(){
+						return fmt.Errorf("release pipelinerun %s in namespace %s did not finished yet", releasePR.Name, releasePR.Namespace)
+					}
+					return nil
+				}, releasecommon.ReleasePipelineRunCompletionTimeout, releasecommon.DefaultInterval).Should(Succeed(), "timed out when waiting for release pipelinerun to succeed")
+				Expect(tekton.HasPipelineRunSucceeded(releasePR)).To(BeTrue(), fmt.Sprintf("release pipelinerun %s/%s did not succeed", releasePR.GetNamespace(), releasePR.GetName()))
+			})
+
+			It("verifies release CR completed and set succeeded.", func() {
+				devFw = releasecommon.NewFramework(devWorkspace)
+				Eventually(func() error {
+					releaseCr, err := devFw.AsKubeDeveloper.ReleaseController.GetRelease("", snapshot.Name, devNamespace)
+					if err != nil {
+						return err
+					}
+					GinkgoWriter.Println("Release CR: ", releaseCr.Name)
+					if !releaseCr.IsReleased() {
+						return fmt.Errorf("release %s/%s is not marked as finished yet", releaseCR.GetNamespace(), releaseCR.GetName())
+					}
+					return nil
+				}, 10 * time.Minute, releasecommon.DefaultInterval).Should(Succeed())
+			})
+
+			It("verifies if the repository URL is valid", func() {
+				managedFw = releasecommon.NewFramework(managedWorkspace)
+				releasePR, err = managedFw.AsKubeAdmin.ReleaseController.GetPipelineRunInNamespace(managedFw.UserNamespace, releaseCR.GetName(), releaseCR.GetNamespace())
+				Expect(err).NotTo(HaveOccurred())
+				advisoryURL := releasePR.Status.PipelineRunStatusFields.Results[0].Value.StringVal
+				pattern := `https?://[^/\s]+/[^/\s]+/[^/\s]+/+\-\/blob\/main\/data\/advisories\/[^\/]+\/[^\/]+\/[^\/]+\/advisory\.yaml`
+				re, err := regexp.Compile(pattern)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(re.MatchString(advisoryURL)).To(BeTrue(), fmt.Sprintf("Advisory_url %s is not valid", advisoryURL))
+			})
+		})
+	})
+})
+
+func createADVSEnterpriseContractPolicy(advsECPName string, managedFw framework.Framework, devNamespace, managedNamespace string) {
+	defaultEcPolicySpec := ecp.EnterpriseContractPolicySpec{
+		Description: "Red Hat's enterprise requirements",
+		PublicKey:   "k8s://openshift-pipelines/public-key",
+		Sources: []ecp.Source{{
+			Name:   "Default",
+			Policy: []string{releasecommon.EcPolicyLibPath, releasecommon.EcPolicyReleasePath},
+			Data:   []string{releasecommon.EcPolicyDataBundle, releasecommon.EcPolicyDataPath},
+		}},
+		Configuration: &ecp.EnterpriseContractPolicyConfiguration{
+			Exclude: []string{"cve", "step_image_registries", "tasks.required_tasks_found:prefetch-dependencies"},
+			Include: []string{"minimal"},
+		},
+	}
+
+	_, err := managedFw.AsKubeDeveloper.TektonController.CreateEnterpriseContractPolicy(advsECPName, managedNamespace, defaultEcPolicySpec)
+	Expect(err).NotTo(HaveOccurred())
+
+}
+
+func createADVSReleasePlan(advsReleasePlanName string, devFw framework.Framework, devNamespace, advsAppName, managedNamespace string, autoRelease string) {
+	var err error
+
+	data, err := json.Marshal(map[string]interface{}{
+		"releaseNotes": map[string]interface{}{
+			"description": "releaseNotes description",
+			"references": []string{"https://server.com/ref1", "http://server2.com/ref2"},
+			"solution": "some solution",
+			"synopsis": "test synopsis",
+			"topic": "test topic",
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = devFw.AsKubeDeveloper.ReleaseController.CreateReleasePlan(advsReleasePlanName, devNamespace, advsAppName,
+			managedNamespace, autoRelease, &runtime.RawExtension{
+			Raw: data,
+		})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func createADVSReleasePlanAdmission(advsRPAName string, managedFw framework.Framework, devNamespace, managedNamespace, advsAppName, advsECPName, pathInRepoValue string) {
+	var err error
+
+	data, err := json.Marshal(map[string]interface{}{
+		"mapping": map[string]interface{}{
+			"components": []map[string]interface{}{
+				{
+					"name":       component.GetName(),
+					"repository": "quay.io/redhat-pending/rhtap----konflux-release-e2e",
+				},
+			},
+		},
+		"pyxis": map[string]interface{}{
+			"server": "stage",
+			"secret": "pyxis",
+		},
+		"releaseNotes": map[string]interface{}{
+			"cpe": "cpe:/a:example.com",
+			"product_id": "555",
+			"product_name": "test product",
+			"product_stream" : "rhtas-tp1",
+			"product_version" : "v1.0",
+			"type": "RHSA",
+		},
+		"images": map[string]interface{}{
+			"defaultTag": "latest",
+			"addGitShaTag": false,
+			"addTimestampTag": false,
+			"addSourceShaTag": false,
+			"floatingTags":[]string{"testtag", "testtag2"},
+                },
+		"sign": map[string]interface{}{
+			"configMapName": "hacbs-signing-pipeline-config-redhatbeta2",
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = managedFw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(advsRPAName, managedNamespace, "", devNamespace, advsECPName, advsServiceAccountName, []string{advsAppName}, true, &tektonutils.PipelineRef{
+		Resolver: "git",
+		Params: []tektonutils.Param{
+			{Name: "url", Value: releasecommon.RelSvcCatalogURL},
+			{Name: "revision", Value: releasecommon.RelSvcCatalogRevision},
+			{Name: "pathInRepo", Value: pathInRepoValue},
+		},
+	}, &runtime.RawExtension{
+		Raw: data,
+	})
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/tests/release/pipelines/rh_push_to_external_registry.go
+++ b/tests/release/pipelines/rh_push_to_external_registry.go
@@ -138,7 +138,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("[HACBS-1571]test-release-e2e-pu
 			additionalComponentDetected = compDetected
 		}
 
-		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(releasecommon.SourceReleasePlanName, devNamespace, releasecommon.ApplicationNameDefault, managedNamespace, "true")
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(releasecommon.SourceReleasePlanName, devNamespace, releasecommon.ApplicationNameDefault, managedNamespace, "true", nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		data, err := json.Marshal(map[string]interface{}{

--- a/tests/release/service/happy_path.go
+++ b/tests/release/service/happy_path.go
@@ -89,7 +89,7 @@ var _ = framework.ReleaseServiceSuiteDescribe("Release service happy path", Labe
 		component, err = fw.AsKubeAdmin.HasController.CreateComponent(componentDetected.ComponentStub, devNamespace, "", "", releasecommon.ApplicationNameDefault, false, map[string]string{})
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(releasecommon.SourceReleasePlanName, devNamespace, releasecommon.ApplicationNameDefault, managedNamespace, "")
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(releasecommon.SourceReleasePlanName, devNamespace, releasecommon.ApplicationNameDefault, managedNamespace, "", nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		data, err := json.Marshal(map[string]interface{}{

--- a/tests/release/service/release_plan_and_admission_matched.go
+++ b/tests/release/service/release_plan_and_admission_matched.go
@@ -40,7 +40,7 @@ var _ = framework.ReleaseServiceSuiteDescribe("ReleasePlan and ReleasePlanAdmiss
 		Expect(err).NotTo(HaveOccurred())
 
 		//Create ReleasePlan
-		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(releasecommon.SourceReleasePlanName, devNamespace, releasecommon.ApplicationNameDefault, managedNamespace, "true")
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(releasecommon.SourceReleasePlanName, devNamespace, releasecommon.ApplicationNameDefault, managedNamespace, "true", nil)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -119,7 +119,7 @@ var _ = framework.ReleaseServiceSuiteDescribe("ReleasePlan and ReleasePlanAdmiss
 		})
 
 		It("Creates a manual release ReleasePlan CR in devNamespace", func() {
-			_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(releasecommon.SecondReleasePlanName, devNamespace, releasecommon.ApplicationNameDefault, managedNamespace, "false")
+			_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(releasecommon.SecondReleasePlanName, devNamespace, releasecommon.ApplicationNameDefault, managedNamespace, "false", nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/tests/release/service/release_plan_owner_ref.go
+++ b/tests/release/service/release_plan_owner_ref.go
@@ -31,7 +31,7 @@ var _ = framework.ReleaseServiceSuiteDescribe("[HACBS-2469]test-releaseplan-owne
 		_, err = fw.AsKubeAdmin.HasController.CreateApplication(releasecommon.ApplicationNameDefault, devNamespace)
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(releasecommon.SourceReleasePlanName, devNamespace, releasecommon.ApplicationNameDefault, "managed", "true")
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan(releasecommon.SourceReleasePlanName, devNamespace, releasecommon.ApplicationNameDefault, "managed", "true", nil)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -729,7 +729,7 @@ func createReleaseConfig(fw framework.Framework, managedNamespace, componentName
 
 	Expect(fw.AsKubeAdmin.TektonController.CreateOrUpdateSigningSecret(publicKey, "cosign-public-key", managedNamespace)).To(Succeed())
 
-	_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan("source-releaseplan", fw.UserNamespace, appName, managedNamespace, "")
+	_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlan("source-releaseplan", fw.UserNamespace, appName, managedNamespace, "", nil)
 	Expect(err).NotTo(HaveOccurred())
 
 	defaultEcPolicy, err := fw.AsKubeAdmin.TektonController.GetEnterpriseContractPolicy("default", "enterprise-contract-service")


### PR DESCRIPTION
Added e2e tests for create-advisory pipeline
Added data paramater to the CreateReleasePlan function and update it in the repo
Changed release_to_github.go for the conflicting secret usage

# Description
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
