### PR TITLE
fix(KFLUXBUGS-1147): update checkRun name for build pipelineRun

### DIFF
--- a/tests/integration-service/status-reporting-to-pullrequest.go
+++ b/tests/integration-service/status-reporting-to-pullrequest.go
@@ -151,7 +151,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 			})
 
 			It("eventually leads to the build PipelineRun's status reported at Checks tab", func() {
-				validateCheckRun(*f, componentName, checkrunConclusionSuccess, componentRepoNameForStatusReporting, prHeadSha, prNumber)
+				expectedCheckRunName := fmt.Sprintf("%s-%s", componentName, "on-pull-request")
+				validateCheckRun(*f, expectedCheckRunName, checkrunConclusionSuccess, componentRepoNameForStatusReporting, prHeadSha, prNumber)
 			})
 		})
 


### PR DESCRIPTION
* Add the on-pull-request suffix to differentiate the build pipelineRun checkRun from the integration tests since they now both contain the component name

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
