### PR TITLE
fix: fixed tag of buildah-remote task for MP test

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -593,7 +593,7 @@ func SetupMultiPlatformTests() error {
 				currentBuildahTaskRef = lastBundle.Value.StringVal
 				klog.Infof("Found current task ref %s", currentBuildahTaskRef)
 				//TODO: current use pinned sha?
-				lastBundle.Value = *tektonapi.NewStructuredValues("quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.1")
+				lastBundle.Value = *tektonapi.NewStructuredValues("quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.1-ac185e95bbd7a25c1c4acf86995cbaf30eebedc4")
 				lastName.Value = *tektonapi.NewStructuredValues("buildah-remote")
 				t.Params = append(t.Params, tektonapi.Param{Name: "PLATFORM", Value: *tektonapi.NewStructuredValues("$(params.PLATFORM)")})
 				dockerPipelineObject.Spec.Params = append(dockerPipelineObject.PipelineSpec().Params, tektonapi.ParamSpec{Name: "PLATFORM", Default: tektonapi.NewStructuredValues(platformType)})


### PR DESCRIPTION
# Description

MP test was failing due to a bug introduced in https://github.com/redhat-appstudio/build-definitions/pull/862/files, which was merged and related task pushed to `quay.io/redhat-appstudio-tekton-catalog/task-buildah-remote:0.1`, that is used by the MP test

more details in [related jira](https://issues.redhat.com/browse/KFLUXBUGS-1189) and linked slack thread

specifying a fixed tag (instead of a floating one) prevents this issue from happening

## Issue ticket number and link
https://issues.redhat.com/browse/KFLUXBUGS-1189

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI ([link to successful CI run](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/redhat-appstudio_e2e-tests/1109/pull-ci-redhat-appstudio-e2e-tests-main-redhat-appstudio-e2e/1775911774357295104))

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
