### PR TITLE
fix: re-trigger non-pac build

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -178,6 +178,9 @@ const (
 
 	DevReleaseTeam     = "dev-release-team"
 	ManagedReleaseTeam = "managed-release-team"
+
+	// Name of the finalizer used for blocking pruning of E2E test PipelineRuns
+	E2ETestFinalizerName = "e2e-test"
 )
 
 var (

--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -47,7 +47,6 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 
 		var applicationName, componentName, symlinkComponentName, testNamespace string
 		var kubeadminClient *framework.ControllerHub
-		var finalizerName string = "e2e-test"
 		var pipelineRunsWithE2eFinalizer []string
 
 		BeforeAll(func() {
@@ -126,7 +125,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 				}
 				for i := 0; i < len(pipelineRuns.Items); i++ {
 					if utils.Contains(pipelineRunsWithE2eFinalizer, pipelineRuns.Items[i].GetName()) {
-						err = kubeadminClient.TektonController.RemoveFinalizerFromPipelineRun(&pipelineRuns.Items[i], finalizerName)
+						err = kubeadminClient.TektonController.RemoveFinalizerFromPipelineRun(&pipelineRuns.Items[i], constants.E2ETestFinalizerName)
 						if err != nil {
 							GinkgoWriter.Printf("error removing e2e test finalizer from %s : %v\n", pipelineRuns.Items[i].GetName(), err)
 							return err
@@ -159,9 +158,9 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 				if !pipelineRun.HasStarted() {
 					return fmt.Errorf("pipelinerun %s/%s has not started yet", pipelineRun.GetNamespace(), pipelineRun.GetName())
 				}
-				err = kubeadminClient.TektonController.AddFinalizerToPipelineRun(pipelineRun, finalizerName)
+				err = kubeadminClient.TektonController.AddFinalizerToPipelineRun(pipelineRun, constants.E2ETestFinalizerName)
 				if err != nil {
-					return fmt.Errorf("error while adding finalizer %q to the pipelineRun %q: %v", finalizerName, pipelineRun.GetName(), err)
+					return fmt.Errorf("error while adding finalizer %q to the pipelineRun %q: %v", constants.E2ETestFinalizerName, pipelineRun.GetName(), err)
 				}
 				pipelineRunsWithE2eFinalizer = append(pipelineRunsWithE2eFinalizer, pipelineRun.GetName())
 				return nil
@@ -183,9 +182,9 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 					if !pipelineRun.HasStarted() {
 						return fmt.Errorf("pipelinerun %s/%s has not started yet", pipelineRun.GetNamespace(), pipelineRun.GetName())
 					}
-					err = kubeadminClient.TektonController.AddFinalizerToPipelineRun(pipelineRun, finalizerName)
+					err = kubeadminClient.TektonController.AddFinalizerToPipelineRun(pipelineRun, constants.E2ETestFinalizerName)
 					if err != nil {
-						return fmt.Errorf("error while adding finalizer %q to the pipelineRun %q: %v", finalizerName, pipelineRun.GetName(), err)
+						return fmt.Errorf("error while adding finalizer %q to the pipelineRun %q: %v", constants.E2ETestFinalizerName, pipelineRun.GetName(), err)
 					}
 					pipelineRunsWithE2eFinalizer = append(pipelineRunsWithE2eFinalizer, pipelineRun.GetName())
 					return nil


### PR DESCRIPTION
# Description

re-triggering of non-pac builds did not work, this PR fixes it

## Issue ticket number and link
[KFLUXBUGS-1190](https://issues.redhat.com//browse/KFLUXBUGS-1190)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
ginkgo -v --label-filter='build-templates-e2e' ./cmd/
# wait for build pipelinerun, cancel it and wait for pipelinerun to get triggered
# then the test should still pass
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
