### PR TITLE
test: Stop testing deprecated ec pipelines

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -501,10 +501,6 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 			Context("build-definitions ec pipelines", Label(buildTemplatesTestLabel), func() {
 				ecPipelines := []string{
 					"pipelines/enterprise-contract.yaml",
-					"pipelines/enterprise-contract-everything.yaml",
-					"pipelines/enterprise-contract-redhat.yaml",
-					"pipelines/enterprise-contract-redhat-no-hermetic.yaml",
-					"pipelines/enterprise-contract-slsa3.yaml",
 				}
 
 				var gitRevision, gitURL, imageWithDigest string


### PR DESCRIPTION
# Description

All, but the original enterprise-contract Pipeline, are now considered deprecated. Users have been notified. The alternative Pipelines will be removed on May 13th. Testing these Pipelines provides very little value right now. Let's stop doing so in order to speed up the tests.

## Issue ticket number and link

https://issues.redhat.com/browse/EC-330

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
