### PR TITLE
fix: ginkgo spec generation if path contains dash

### DIFF
--- a/pkg/testspecs/ginkgosspec.go
+++ b/pkg/testspecs/ginkgosspec.go
@@ -131,6 +131,7 @@ func generateGinkgoSpec(cwd, teamTmplPath, destination string, dataFile string) 
 	// Since that is not a semantic we follow I perform this action.
 	dirs := strings.Split(filepath.Dir(destination), "/")
 	dir := dirs[len(dirs)-1]
+	dir = strings.ReplaceAll(dir, "-", "_")
 	ginkgoFileName := fmt.Sprintf("%s_test.go", dir)
 	postFileName := filepath.Base(destination)
 	err = os.Chdir(filepath.Dir(destination))

--- a/pkg/testspecs/templates.go
+++ b/pkg/testspecs/templates.go
@@ -38,8 +38,9 @@ func NewTemplateData(specOutline TestOutline, destination string) *TemplateData 
 
 	dir := filepath.Dir(destination)
 	dirName := strings.Split(dir, "/")[len(strings.Split(dir, "/"))-1]
+	packageName := regexp.MustCompile(`^([a-z]+)`).FindString(dirName)
 
-	return &TemplateData{Outline: specOutline, PackageName: dirName, FrameworkDescribeString: newSpecName}
+	return &TemplateData{Outline: specOutline, PackageName: packageName, FrameworkDescribeString: newSpecName}
 }
 
 func RenderFrameworkDescribeGoFile(t TemplateData) error {


### PR DESCRIPTION
# Description
- Package name in .go file is generated by taking the part of filename before dash, e.g. integration-service -> integration
- Handle [Ginkgo automatically changing](https://github.com/onsi/ginkgo/blob/master/ginkgo/generators/generators_common.go#L25) `-` to `_`

## Issue ticket number and link
https://issues.redhat.com/browse/KFLUXBUGS-1212

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Manually by running `./mage GenerateTeamSpecificGinkgoSpecFromTextOutline` with a path containing a dash `-`.

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
