### PR TITLE
feat(KONFLUX-2456): remove SEB and Env checks from rhtap-demo and remote

### DIFF
--- a/tests/remote-secret/component-annotation-image-pull-remote-secret.go
+++ b/tests/remote-secret/component-annotation-image-pull-remote-secret.go
@@ -38,11 +38,9 @@ var _ = framework.RemoteSecretSuiteDescribe(Label("remote-secret", "component-an
 	component := &appservice.Component{}
 	targets := []rs.TargetStatus{}
 	snapshot := &appservice.Snapshot{}
-	env := &appservice.Environment{}
 
 	applicationName := "component-annotation-dotnet-component"
 	gitSourceUrl := "https://github.com/devfile-samples/devfile-sample-dotnet60-basic"
-	environmentName := "image-pull-remote-secret"
 	secret := ""
 
 	AfterEach(framework.ReportFailure(&fw))
@@ -83,11 +81,6 @@ var _ = framework.RemoteSecretSuiteDescribe(Label("remote-secret", "component-an
 
 				return fw.AsKubeDeveloper.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
 			}, 1*time.Minute, 1*time.Second).Should(BeTrue(), fmt.Sprintf("timed out waiting for HAS controller to create gitops repository for the %s application in %s namespace", applicationName, fw.UserNamespace))
-		})
-
-		It("creates an environment", func() {
-			env, err = fw.AsKubeDeveloper.GitOpsController.CreatePocEnvironment(environmentName, namespace)
-			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("creates component detection query", func() {
@@ -136,17 +129,6 @@ var _ = framework.RemoteSecretSuiteDescribe(Label("remote-secret", "component-an
 					return nil
 				}, timeout, interval).Should(Succeed(), fmt.Sprintf("timed out waiting for the snapshot for the component %s/%s to be marked as successful", component.GetNamespace(), component.GetName()))
 			}
-		})
-
-		It("checks if a SnapshotEnvironmentBinding is created successfully", func() {
-			Eventually(func() error {
-				_, err := fw.AsKubeAdmin.CommonController.GetSnapshotEnvironmentBinding(application.Name, namespace, env)
-				if err != nil {
-					GinkgoWriter.Println("SnapshotEnvironmentBinding has not been found yet")
-					return err
-				}
-				return nil
-			}, timeout, interval).Should(Succeed(), fmt.Sprintf("timed out waiting for the SnapshotEnvironmentBinding to be created (snapshot: %s, env: %s, namespace: %s)", snapshot.GetName(), env.GetName(), snapshot.GetNamespace()))
 		})
 
 		It("checks if image pull remote secret was deployed", func() {

--- a/tests/remote-secret/image-repository-cr-image-pull-remote-secret.go
+++ b/tests/remote-secret/image-repository-cr-image-pull-remote-secret.go
@@ -43,11 +43,9 @@ var _ = framework.RemoteSecretSuiteDescribe(Label("remote-secret", "image-reposi
 	pushTargets := []rs.TargetStatus{}
 	imageRepository := &image.ImageRepository{}
 	snapshot := &appservice.Snapshot{}
-	env := &appservice.Environment{}
 
 	applicationName := "image-repository-cr-dotnet-component"
 	gitSourceUrl := "https://github.com/devfile-samples/devfile-sample-dotnet60-basic"
-	environmentName := "image-pull-remote-secret"
 	secret := ""
 
 	AfterEach(framework.ReportFailure(&fw))
@@ -88,11 +86,6 @@ var _ = framework.RemoteSecretSuiteDescribe(Label("remote-secret", "image-reposi
 
 				return fw.AsKubeDeveloper.CommonController.Github.CheckIfRepositoryExist(gitOpsRepository)
 			}, 1*time.Minute, 1*time.Second).Should(BeTrue(), fmt.Sprintf("timed out waiting for HAS controller to create gitops repository for the %s application in %s namespace", applicationName, fw.UserNamespace))
-		})
-
-		It("creates an environment", func() {
-			env, err = fw.AsKubeDeveloper.GitOpsController.CreatePocEnvironment(environmentName, namespace)
-			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("creates component detection query", func() {
@@ -169,17 +162,6 @@ var _ = framework.RemoteSecretSuiteDescribe(Label("remote-secret", "image-reposi
 				return nil
 			}, timeout, interval).Should(Succeed(), fmt.Sprintf("timed out waiting for the snapshot for the component %s/%s to be marked as successful", component.GetNamespace(), component.GetName()))
 
-		})
-
-		It("checks if a SnapshotEnvironmentBinding is created successfully", func() {
-			Eventually(func() error {
-				_, err := fw.AsKubeAdmin.CommonController.GetSnapshotEnvironmentBinding(application.Name, namespace, env)
-				if err != nil {
-					GinkgoWriter.Println("SnapshotEnvironmentBinding has not been found yet")
-					return err
-				}
-				return nil
-			}, timeout, interval).Should(Succeed(), fmt.Sprintf("timed out waiting for the SnapshotEnvironmentBinding to be created (snapshot: %s, env: %s, namespace: %s)", snapshot.GetName(), env.GetName(), snapshot.GetNamespace()))
 		})
 
 		It("checks if image pull remote secret was created", func() {


### PR DESCRIPTION
# Description

As part of the feature of decoupling the ephemeral environments in konflux,
this PR is about removing the checks related to SEB(snapshot environment binding )
and Gitops from the e2e-test rhtap-demo .

## for more details check [KONFLUX-2456](https://issues.redhat.com/browse/KONFLUX-2456)
this PR replaces the closed [PR#1118](https://github.com/redhat-appstudio/e2e-tests/pull/1125)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
