### PR TITLE
feat(RELEASE-500): update release service catalog reference to konflux ci

### DIFF
--- a/tests/release/const.go
+++ b/tests/release/const.go
@@ -1,9 +1,10 @@
 package common
 
 import (
+	"time"
+
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
-	"time"
 )
 
 const (
@@ -40,10 +41,10 @@ const (
 	PyxisStageImagesApiEndpoint     string = "https://pyxis.preprod.api.redhat.com/v1/images/id/"
 
 	// EC constants
-	EcPolicyLibPath         = "github.com/enterprise-contract/ec-policies//policy/lib"
-	EcPolicyReleasePath     = "github.com/enterprise-contract/ec-policies//policy/release"
-	EcPolicyDataBundle      = "oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest"
-	EcPolicyDataPath        = "github.com/release-engineering/rhtap-ec-policy//data"
+	EcPolicyLibPath     = "github.com/enterprise-contract/ec-policies//policy/lib"
+	EcPolicyReleasePath = "github.com/enterprise-contract/ec-policies//policy/release"
+	EcPolicyDataBundle  = "oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest"
+	EcPolicyDataPath    = "github.com/release-engineering/rhtap-ec-policy//data"
 
 	// Service constants
 	ApplicationName string = "application"
@@ -55,6 +56,6 @@ var ManagednamespaceSecret = []corev1.ObjectReference{
 
 // Pipelines variables
 var (
-	RelSvcCatalogURL      string = utils.GetEnv("RELEASE_SERVICE_CATALOG_URL", "https://github.com/redhat-appstudio/release-service-catalog")
+	RelSvcCatalogURL      string = utils.GetEnv("RELEASE_SERVICE_CATALOG_URL", "https://github.com/konflux-ci/release-service-catalog")
 	RelSvcCatalogRevision string = utils.GetEnv("RELEASE_SERVICE_CATALOG_REVISION", "staging")
 )

--- a/tests/release/pipelines/README.md
+++ b/tests/release/pipelines/README.md
@@ -1,10 +1,10 @@
 # Release pipelines e2e tests suite
 
-This suite contains e2e-tests for testing release pipelines from repository [release-service-catalog](https://github.com/redhat-appstudio/release-service-catalog/tree/development).
+This suite contains e2e-tests for testing release pipelines from repository [release-service-catalog](https://github.com/konflux-ci/release-service-catalog/tree/development).
 All tests must have the label `release-pipelines`.
 
 ## Branch alignment
- * Below are the branches in [release-service-catalog](https://github.com/redhat-appstudio/release-service-catalog/tree/development). All these branches will be tested per requirement.  
+ * Below are the branches in [release-service-catalog](https://github.com/konflux-ci/release-service-catalog/tree/development). All these branches will be tested per requirement.  
    - production	: this branch will be used for RHTAP production environment
    - stage	: this branch will be used for RHTAP stage environment
    - development: this branch is the default branch for development


### PR DESCRIPTION
 This commit updates the `release-service-catalog` refrence
 as result of migration to `konflux-ci` from `redhat-appstudio`
 more details parent EPIC:
 https://issues.redhat.com/browse/RHTAPREL-800

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
