### PR TITLE
fix: update EC policy inclusion

### DIFF
--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -383,7 +383,11 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 					generator.PublicKey = fmt.Sprintf("k8s://%s/%s", namespace, secretName)
 					policy := contract.PolicySpecWithSourceConfig(
 						defaultECP.Spec,
-						ecp.SourceConfig{Include: []string{"attestation_task_bundle.task_ref_bundles_acceptable"}},
+						ecp.SourceConfig{Include: []string{
+							// Account for "acceptable" to "trusted" renaming. Eventually remove "acceptable" from this list
+							"attestation_task_bundle.task_ref_bundles_acceptable",
+							"attestation_task_bundle.task_ref_bundles_trusted",
+						}},
 					)
 					Expect(fwk.AsKubeAdmin.TektonController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
 


### PR DESCRIPTION
# Description

The policy rule `attestation_task_bundle.task_ref_bundles_acceptable` was recently renamed to
`attestation_task_bundle.task_ref_bundles_trusted`. This commit updates the test to include either to facilitate the transition. Once all users are up to date, we can drop inclusion of the old name.

This change is required because the test relies on this particular policy rule to fail.

## Issue ticket number and link

https://issues.redhat.com/browse/KFLUXBUGS-1225

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
