### PR TITLE
feat: match new extra-src filename form

### DIFF
--- a/pkg/utils/build/source_image.go
+++ b/pkg/utils/build/source_image.go
@@ -24,7 +24,7 @@ import (
 const (
 	extraSourceSubDir     = "extra_src_dir"
 	rpmSubDir             = "rpm_dir"
-	srcTarFileRegex       = "extra-src-[0-9]+.tar"
+	srcTarFileRegex       = "extra-src-[0-9a-f]+.tar"
 	shaValueRegex         = "[a-f0-9]{40}"
 	tarGzFileRegex        = ".tar.gz$"
 	gomodDependencySubDir = "deps/gomod/pkg/mod/cache/download/"
@@ -89,12 +89,12 @@ func IsSourceFilesExistsInSourceImage(srcImage string, gitUrl string, isHermetic
 		return false, fmt.Errorf("no tar file found in extra_src_dir, found files %v", fileNames)
 	}
 
-	// Get all the extra-src-[0-9]+.tar files
+	// Get all the extra-src-*.tar files
 	extraSrcTarFiles := utils.FilterSliceUsingPattern(srcTarFileRegex, fileNames)
-	fmt.Printf("Files found with pattern extra-src-[0-9]+.tar: %v\n", extraSrcTarFiles)
 	if len(extraSrcTarFiles) == 0 {
-		return false, fmt.Errorf("no tar file found with pattern extra-src-[0-9]+.tar")
+		return false, fmt.Errorf("no tar file found with pattern %s", srcTarFileRegex)
 	}
+	fmt.Printf("Files found with pattern %s: %v\n", srcTarFileRegex, extraSrcTarFiles)
 
 	//Untar all the extra-src-[0-9]+.tar files
 	for _, tarFile := range extraSrcTarFiles {


### PR DESCRIPTION
Related to [STONEBLD-1831](https://issues.redhat.com//browse/STONEBLD-1831)

Counter within file name extra-src-*.tar will be replaced with extra-src archive checksum. Regex is updated and it is compatible with the existing numeric counter.

## Issue ticket number and link

[STONEBLD-1831](https://issues.redhat.com//browse/STONEBLD-1831)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
