### PR TITLE
fix: PaC: get correct commit SHA after PLR rerun

### DIFF
--- a/pkg/clients/has/components.go
+++ b/pkg/clients/has/components.go
@@ -127,10 +127,10 @@ type RetryOptions struct {
 }
 
 // Waits for a given component to be finished and in case of hitting issue: https://issues.redhat.com/browse/SRVKP-2749 do a given retries.
-func (h *HasController) WaitForComponentPipelineToBeFinished(component *appservice.Component, sha string, t *tekton.TektonController, r *RetryOptions) error {
+func (h *HasController) WaitForComponentPipelineToBeFinished(component *appservice.Component, sha string, t *tekton.TektonController, r *RetryOptions, prToUpdate *pipeline.PipelineRun) error {
 	attempts := 1
 	app := component.Spec.Application
-	var pr *pipeline.PipelineRun
+	pr := &pipeline.PipelineRun{}
 
 	for {
 		err := wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 30*time.Minute, true, func(ctx context.Context) (done bool, err error) {
@@ -182,6 +182,11 @@ func (h *HasController) WaitForComponentPipelineToBeFinished(component *appservi
 		} else {
 			break
 		}
+	}
+
+	// If prToUpdate variable was passed to this function, update it with the latest version of the PipelineRun object
+	if prToUpdate != nil {
+		pr.DeepCopyInto(prToUpdate)
 	}
 
 	return nil

--- a/pkg/clients/has/components.go
+++ b/pkg/clients/has/components.go
@@ -126,7 +126,13 @@ type RetryOptions struct {
 	Always bool
 }
 
-// Waits for a given component to be finished and in case of hitting issue: https://issues.redhat.com/browse/SRVKP-2749 do a given retries.
+// WaitForComponentPipelineToBeFinished waits for a given component PipelineRun to be finished
+// In case of hitting issues like `TaskRunImagePullFailed` or `CouldntGetTask` it will re-trigger the PLR.
+// Due to re-trigger mechanism this function can invalidate the related PLR object which might be used later in the test
+// (by deleting the original PLR and creating a new one in case the PLR fails on one of the attempts).
+// For that case this function gives an option to pass in a pointer to a related PLR object (`prToUpdate`) which will be updated (with a valid PLR object) before the end of this function
+// and the PLR object can be then used for making assertions later in the test.
+// If there's no intention for using the original PLR object later in the test, use `nil` instead of the pointer.
 func (h *HasController) WaitForComponentPipelineToBeFinished(component *appservice.Component, sha string, t *tekton.TektonController, r *RetryOptions, prToUpdate *pipeline.PipelineRun) error {
 	attempts := 1
 	app := component.Spec.Application

--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -200,7 +200,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 				component, err := kubeadminClient.HasController.GetComponent(componentNames[i], testNamespace)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(kubeadminClient.HasController.WaitForComponentPipelineToBeFinished(component, "",
-					kubeadminClient.TektonController, &has.RetryOptions{Retries: pipelineCompletionRetries, Always: true})).To(Succeed())
+					kubeadminClient.TektonController, &has.RetryOptions{Retries: pipelineCompletionRetries, Always: true}, nil)).To(Succeed())
 			})
 
 			It(fmt.Sprintf("should ensure SBOM is shown for component with Git source URL %s", gitUrl), Label(buildTemplatesTestLabel), func() {
@@ -515,7 +515,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 					component, err := kubeadminClient.HasController.GetComponent(componentNames[i], testNamespace)
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(kubeadminClient.HasController.WaitForComponentPipelineToBeFinished(
-						component, "", kubeadminClient.TektonController, &has.RetryOptions{Retries: pipelineCompletionRetries, Always: true})).To(Succeed())
+						component, "", kubeadminClient.TektonController, &has.RetryOptions{Retries: pipelineCompletionRetries, Always: true}, nil)).To(Succeed())
 
 					imageWithDigest, err = getImageWithDigest(kubeadminClient, componentNames[i], applicationName, testNamespace)
 					Expect(err).NotTo(HaveOccurred())
@@ -585,7 +585,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", Label("build", 
 			component, err := kubeadminClient.HasController.GetComponent(symlinkComponentName, testNamespace)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(kubeadminClient.HasController.WaitForComponentPipelineToBeFinished(component, "",
-				kubeadminClient.TektonController, &has.RetryOptions{Retries: pipelineCompletionRetries})).Should(MatchError(ContainSubstring("cloned repository contains symlink pointing outside of the cloned repository")))
+				kubeadminClient.TektonController, &has.RetryOptions{Retries: pipelineCompletionRetries}, nil)).Should(MatchError(ContainSubstring("cloned repository contains symlink pointing outside of the cloned repository")))
 		})
 	})
 })

--- a/tests/build/jvm-build.go
+++ b/tests/build/jvm-build.go
@@ -193,7 +193,7 @@ var _ = framework.JVMBuildSuiteDescribe("JVM Build Service E2E tests", Label("jv
 
 		It("that PipelineRun completes successfully", func() {
 			Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "",
-				f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true})).To(Succeed())
+				f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(Succeed())
 
 			pr, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
 			Expect(err).ShouldNot(HaveOccurred())

--- a/tests/build/multi-platform.go
+++ b/tests/build/multi-platform.go
@@ -140,7 +140,7 @@ var _ = framework.MultiPlatformBuildSuiteDescribe("Multi Platform Controller E2E
 			})
 
 			It("that PipelineRun completes successfully", func() {
-				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true})).To(Succeed())
+				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(Succeed())
 			})
 
 			It("test that cleanup happened successfully", func() {
@@ -247,7 +247,7 @@ var _ = framework.MultiPlatformBuildSuiteDescribe("Multi Platform Controller E2E
 			})
 
 			It("that PipelineRun completes successfully", func() {
-				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true})).To(Succeed())
+				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(Succeed())
 			})
 
 			It("check cleanup happened successfully", func() {
@@ -329,7 +329,7 @@ var _ = framework.MultiPlatformBuildSuiteDescribe("Multi Platform Controller E2E
 			})
 
 			It("that PipelineRun completes successfully", func() {
-				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true})).To(Succeed())
+				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(Succeed())
 			})
 
 			It("check cleanup happened successfully", func() {
@@ -412,7 +412,7 @@ var _ = framework.MultiPlatformBuildSuiteDescribe("Multi Platform Controller E2E
 			})
 
 			It("that PipelineRun completes successfully", func() {
-				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true})).To(Succeed())
+				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(Succeed())
 			})
 
 			It("check cleanup happened successfully", func() {

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -77,9 +77,9 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			})
 
 			It("waits for build PipelineRun to succeed", Label("integration-service"), func() {
-				Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "",
-					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true})).To(Succeed())
 				Expect(pipelineRun.Annotations[snapshotAnnotation]).To(Equal(""))
+				Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "",
+					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(Succeed())
 			})
 		})
 
@@ -208,10 +208,10 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 
 		It("triggers a build PipelineRun", Label("integration-service"), func() {
 			pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
-			Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", f.AsKubeAdmin.TektonController,
-				&has.RetryOptions{Retries: 2, Always: true})).To(Succeed())
-
 			Expect(pipelineRun.Annotations[snapshotAnnotation]).To(Equal(""))
+			Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", f.AsKubeAdmin.TektonController,
+				&has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(Succeed())
+
 		})
 
 		It("checks if the BuildPipelineRun have the annotation of chains signed", func() {

--- a/tests/integration-service/status-reporting-to-pullrequest.go
+++ b/tests/integration-service/status-reporting-to-pullrequest.go
@@ -125,7 +125,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 			})
 			It("should lead to build PipelineRun finishing successfully", func() {
 				Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component,
-					"", f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true})).To(Succeed())
+					"", f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(Succeed())
 			})
 			It("should have a related PaC init PR created", func() {
 				timeout = time.Second * 300

--- a/tests/release/pipelines/fbc_release.go
+++ b/tests/release/pipelines/fbc_release.go
@@ -15,8 +15,8 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
-        releaseapi "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	releasecommon "github.com/redhat-appstudio/e2e-tests/tests/release"
+	releaseapi "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonutils "github.com/redhat-appstudio/release-service/tekton/utils"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,7 +42,6 @@ var managedFw *framework.Framework
 var _ = framework.ReleasePipelinesSuiteDescribe("FBC e2e-tests", Label("release-pipelines", "fbc-tests"), func() {
 	defer GinkgoRecover()
 
-
 	var devNamespace = devWorkspace + "-tenant"
 	var managedNamespace = managedWorkspace + "-tenant"
 
@@ -66,7 +65,6 @@ var _ = framework.ReleasePipelinesSuiteDescribe("FBC e2e-tests", Label("release-
 	var fbcPreGAECPolicyName = "fbc-prega-policy-" + util.GenerateRandomString(4)
 
 	AfterEach(framework.ReportFailure(&devFw))
-
 
 	Describe("with FBC happy path", Label("fbcHappyPath"), func() {
 		var component *appservice.Component
@@ -204,7 +202,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("FBC e2e-tests", Label("release-
 })
 
 func assertBuildPipelineRunCreated(devFw framework.Framework, devNamespace, managedNamespace, fbcAppName string, component *appservice.Component) {
-	Expect(devFw.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(component, "", devFw.AsKubeDeveloper.TektonController, &has.RetryOptions{Retries: 3, Always: true})).To(Succeed())
+	Expect(devFw.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(component, "", devFw.AsKubeDeveloper.TektonController, &has.RetryOptions{Retries: 3, Always: true}, nil)).To(Succeed())
 	buildPr, err = devFw.AsKubeDeveloper.HasController.GetComponentPipelineRun(component.Name, fbcAppName, devNamespace, "")
 	Expect(err).ShouldNot(HaveOccurred())
 }
@@ -222,7 +220,7 @@ func assertReleasePipelineRunSucceeded(devFw, managedFw framework.Framework, dev
 		}
 		GinkgoWriter.Println("Release CR: ", releaseCR.Name)
 		return nil
-	}, 5 * time.Minute, releasecommon.DefaultInterval).Should(Succeed(), "timed out when waiting for Snapshot and Release being created")
+	}, 5*time.Minute, releasecommon.DefaultInterval).Should(Succeed(), "timed out when waiting for Snapshot and Release being created")
 
 	mFw = releasecommon.NewFramework(managedWorkspace)
 	// Create a ticker that ticks every 3 minutes
@@ -265,12 +263,12 @@ func assertReleaseCRSucceeded(devFw framework.Framework, devNamespace, managedNa
 		}
 		conditions := releaseCR.Status.Conditions
 		if len(conditions) > 0 {
-                        for _, c := range conditions {
-                                if c.Type == "Released" && c.Status == "True" {
+			for _, c := range conditions {
+				if c.Type == "Released" && c.Status == "True" {
 					GinkgoWriter.Println("Release CR is released")
-                                }
-                       }
-                }
+				}
+			}
+		}
 
 		if !releaseCR.IsReleased() {
 			return fmt.Errorf("release %s/%s is not marked as finished yet", releaseCR.GetNamespace(), releaseCR.GetName())

--- a/tests/release/pipelines/push_to_external_registry.go
+++ b/tests/release/pipelines/push_to_external_registry.go
@@ -129,7 +129,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("Push to external registry", Lab
 	var _ = Describe("Post-release verification", func() {
 		It("verifies that a build PipelineRun is created in dev namespace and succeeds", func() {
 			Expect(fw.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "",
-				fw.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true})).To(Succeed())
+				fw.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(Succeed())
 		})
 
 		It("verifies that a Release CR should have been created in the dev namespace", func() {

--- a/tests/release/pipelines/release_to_github.go
+++ b/tests/release/pipelines/release_to_github.go
@@ -3,8 +3,8 @@ package pipelines
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/devfile/library/v2/pkg/util"
 	ecp "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
@@ -17,23 +17,23 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
-	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	releaseapi "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	releasecommon "github.com/redhat-appstudio/e2e-tests/tests/release"
+	releaseapi "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonutils "github.com/redhat-appstudio/release-service/tekton/utils"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
-	sampServiceAccountName   = "release-service-account"
-	sampSourceGitURL         = "https://github.com/redhat-appstudio-qe/devfile-sample-go-basic"
-	sampReleaseURL           = "https://github.com/redhat-appstudio-qe/devfile-sample-go-basic/releases/tag/v2.1"
-	sampRepoOwner            = "redhat-appstudio-qe"
-	sampRepo                 = "devfile-sample-go-basic"
-	sampCatalogPathInRepo    = "pipelines/release-to-github/release-to-github.yaml"
+	sampServiceAccountName = "release-service-account"
+	sampSourceGitURL       = "https://github.com/redhat-appstudio-qe/devfile-sample-go-basic"
+	sampReleaseURL         = "https://github.com/redhat-appstudio-qe/devfile-sample-go-basic/releases/tag/v2.1"
+	sampRepoOwner          = "redhat-appstudio-qe"
+	sampRepo               = "devfile-sample-go-basic"
+	sampCatalogPathInRepo  = "pipelines/release-to-github/release-to-github.yaml"
 )
 
 var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for release-to-github pipeline", Label("release-pipelines", "release-to-github"), func() {
@@ -73,7 +73,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for release-to-github
 			err = devFw.AsKubeAdmin.CommonController.LinkSecretToServiceAccount(devNamespace, releasecommon.HacbsReleaseTestsTokenSecret, constants.DefaultPipelineServiceAccount, true)
 			Expect(err).ToNot(HaveOccurred())
 
-			githubUser := utils.GetEnv("GITHUB_USER","redhat-appstudio-qe-bot")
+			githubUser := utils.GetEnv("GITHUB_USER", "redhat-appstudio-qe-bot")
 			githubToken := utils.GetEnv(constants.GITHUB_TOKEN_ENV, "")
 			gh, err = github.NewGithubClient(githubToken, githubUser)
 			Expect(githubToken).ToNot(BeEmpty())
@@ -140,7 +140,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for release-to-github
 					}
 					return nil
 				}, releasecommon.BuildPipelineRunCompletionTimeout, releasecommon.DefaultInterval).Should(Succeed(), "timed out when waiting for build pipelinerun to be created")
-				Expect(devFw.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(component, "", devFw.AsKubeDeveloper.TektonController, &has.RetryOptions{Retries: 3, Always: true})).To(Succeed())
+				Expect(devFw.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(component, "", devFw.AsKubeDeveloper.TektonController, &has.RetryOptions{Retries: 3, Always: true}, nil)).To(Succeed())
 			})
 			It("verifies the samp release pipelinerun is running and succeeds", func() {
 				devFw = releasecommon.NewFramework(devWorkspace)
@@ -154,7 +154,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for release-to-github
 						return err
 					}
 					GinkgoWriter.Println("Release PR: ", releasePR.Name)
-					if  !releasePR.IsDone(){
+					if !releasePR.IsDone() {
 						return fmt.Errorf("release pipelinerun %s in namespace %s did not finished yet", releasePR.Name, releasePR.Namespace)
 					}
 					return nil
@@ -174,7 +174,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for release-to-github
 						return fmt.Errorf("release %s/%s is not marked as finished yet", releaseCR.GetNamespace(), releaseCR.GetName())
 					}
 					return nil
-				}, 10 * time.Minute, releasecommon.DefaultInterval).Should(Succeed())
+				}, 10*time.Minute, releasecommon.DefaultInterval).Should(Succeed())
 			})
 
 			It("verifies if the Release exists in github repo", func() {

--- a/tests/release/pipelines/rh_advisories.go
+++ b/tests/release/pipelines/rh_advisories.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"time"
 	"regexp"
+	"time"
 
 	"github.com/devfile/library/v2/pkg/util"
 	ecp "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
@@ -18,18 +18,18 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
-	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	releaseapi "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	releasecommon "github.com/redhat-appstudio/e2e-tests/tests/release"
+	releaseapi "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonutils "github.com/redhat-appstudio/release-service/tekton/utils"
-	"k8s.io/apimachinery/pkg/runtime"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
-	advsServiceAccountName   = "release-service-account"
-	advsCatalogPathInRepo    = "pipelines/rh-advisories/rh-advisories.yaml"
+	advsServiceAccountName = "release-service-account"
+	advsCatalogPathInRepo  = "pipelines/rh-advisories/rh-advisories.yaml"
 )
 
 var component *appservice.Component
@@ -134,7 +134,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-advisories pip
 					}
 					return nil
 				}, releasecommon.BuildPipelineRunCompletionTimeout, releasecommon.DefaultInterval).Should(Succeed(), "timed out when waiting for build pipelinerun to be created")
-				Expect(devFw.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(component, "", devFw.AsKubeDeveloper.TektonController, &has.RetryOptions{Retries: 3, Always: true})).To(Succeed())
+				Expect(devFw.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(component, "", devFw.AsKubeDeveloper.TektonController, &has.RetryOptions{Retries: 3, Always: true}, nil)).To(Succeed())
 			})
 			It("verifies the advs release pipelinerun is running and succeeds", func() {
 				devFw = releasecommon.NewFramework(devWorkspace)
@@ -148,7 +148,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-advisories pip
 						return err
 					}
 					GinkgoWriter.Println("Release PR: ", releasePR.Name)
-					if  !releasePR.IsDone(){
+					if !releasePR.IsDone() {
 						return fmt.Errorf("release pipelinerun %s in namespace %s did not finished yet", releasePR.Name, releasePR.Namespace)
 					}
 					return nil
@@ -168,7 +168,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-advisories pip
 						return fmt.Errorf("release %s/%s is not marked as finished yet", releaseCR.GetNamespace(), releaseCR.GetName())
 					}
 					return nil
-				}, 10 * time.Minute, releasecommon.DefaultInterval).Should(Succeed())
+				}, 10*time.Minute, releasecommon.DefaultInterval).Should(Succeed())
 			})
 
 			It("verifies if the repository URL is valid", func() {
@@ -211,16 +211,16 @@ func createADVSReleasePlan(advsReleasePlanName string, devFw framework.Framework
 	data, err := json.Marshal(map[string]interface{}{
 		"releaseNotes": map[string]interface{}{
 			"description": "releaseNotes description",
-			"references": []string{"https://server.com/ref1", "http://server2.com/ref2"},
-			"solution": "some solution",
-			"synopsis": "test synopsis",
-			"topic": "test topic",
+			"references":  []string{"https://server.com/ref1", "http://server2.com/ref2"},
+			"solution":    "some solution",
+			"synopsis":    "test synopsis",
+			"topic":       "test topic",
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())
 
 	_, err = devFw.AsKubeDeveloper.ReleaseController.CreateReleasePlan(advsReleasePlanName, devNamespace, advsAppName,
-			managedNamespace, autoRelease, &runtime.RawExtension{
+		managedNamespace, autoRelease, &runtime.RawExtension{
 			Raw: data,
 		})
 	Expect(err).NotTo(HaveOccurred())
@@ -243,20 +243,20 @@ func createADVSReleasePlanAdmission(advsRPAName string, managedFw framework.Fram
 			"secret": "pyxis",
 		},
 		"releaseNotes": map[string]interface{}{
-			"cpe": "cpe:/a:example.com",
-			"product_id": "555",
-			"product_name": "test product",
-			"product_stream" : "rhtas-tp1",
-			"product_version" : "v1.0",
-			"type": "RHSA",
+			"cpe":             "cpe:/a:example.com",
+			"product_id":      "555",
+			"product_name":    "test product",
+			"product_stream":  "rhtas-tp1",
+			"product_version": "v1.0",
+			"type":            "RHSA",
 		},
 		"images": map[string]interface{}{
-			"defaultTag": "latest",
-			"addGitShaTag": false,
+			"defaultTag":      "latest",
+			"addGitShaTag":    false,
 			"addTimestampTag": false,
 			"addSourceShaTag": false,
-			"floatingTags":[]string{"testtag", "testtag2"},
-                },
+			"floatingTags":    []string{"testtag", "testtag2"},
+		},
 		"sign": map[string]interface{}{
 			"configMapName": "hacbs-signing-pipeline-config-redhatbeta2",
 		},

--- a/tests/release/pipelines/rh_push_to_external_registry.go
+++ b/tests/release/pipelines/rh_push_to_external_registry.go
@@ -210,14 +210,14 @@ var _ = framework.ReleasePipelinesSuiteDescribe("[HACBS-1571]test-release-e2e-pu
 			component1, err = fw.AsKubeAdmin.HasController.CreateComponent(componentDetected.ComponentStub, devNamespace, "", "", releasecommon.ApplicationNameDefault, true, map[string]string{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fw.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component1, "",
-				fw.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true})).To(Succeed())
+				fw.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(Succeed())
 		})
 
 		It("verifies that Component 2 can be created and build PipelineRun is created for it in dev namespace and succeeds", func() {
 			component2, err = fw.AsKubeAdmin.HasController.CreateComponent(additionalComponentDetected.ComponentStub, devNamespace, "", "", releasecommon.ApplicationNameDefault, true, map[string]string{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fw.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component2, "",
-				fw.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true})).To(Succeed())
+				fw.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(Succeed())
 		})
 
 		It("tests that Snapshot is created for each Component", func() {

--- a/tests/release/service/happy_path.go
+++ b/tests/release/service/happy_path.go
@@ -143,7 +143,7 @@ var _ = framework.ReleaseServiceSuiteDescribe("Release service happy path", Labe
 	var _ = Describe("Post-release verification", func() {
 		It("verifies that a build PipelineRun is created in dev namespace and succeeds", func() {
 			Expect(fw.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "",
-				fw.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true})).To(Succeed())
+				fw.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(Succeed())
 		})
 
 		It("verifies that a Release CR should have been created in the dev namespace", func() {

--- a/tests/remote-secret/component-annotation-image-pull-remote-secret.go
+++ b/tests/remote-secret/component-annotation-image-pull-remote-secret.go
@@ -109,7 +109,7 @@ var _ = framework.RemoteSecretSuiteDescribe(Label("remote-secret", "component-an
 				Expect(err).ShouldNot(HaveOccurred(), "failed to get component: %v", err)
 
 				Expect(fw.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "",
-					fw.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true})).To(Succeed())
+					fw.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(Succeed())
 			}
 		})
 

--- a/tests/remote-secret/image-repository-cr-image-pull-remote-secret.go
+++ b/tests/remote-secret/image-repository-cr-image-pull-remote-secret.go
@@ -143,7 +143,7 @@ var _ = framework.RemoteSecretSuiteDescribe(Label("remote-secret", "image-reposi
 			Expect(err).ShouldNot(HaveOccurred(), "failed to get component: %v", err)
 
 			Expect(fw.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "",
-				fw.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true})).To(Succeed())
+				fw.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(Succeed())
 		})
 
 		It("finds the snapshot and checks if it is marked as successful", func() {


### PR DESCRIPTION
# Description

when PaC PLR gets re-triggered, the commit SHA changes and if the original one (or related PipelineRun object) is later used in the test, the test would fail

## Issue ticket number and link
[KFLUXBUGS-348](https://issues.redhat.com//browse/KFLUXBUGS-348)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
```
# run PaC test case, e.g:
ginkgo -v --focus="Maven project - Simple and Advanced build" ./cmd/
# Wait until PaC PLR is running and cancel it
# Wait until the test completes with no errors
```
# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
