### PR TITLE
fix(STONEINTG-697): e2e-tests will stop watching for successful deployments

### DIFF
--- a/tests/rhtap-demo/README.md
+++ b/tests/rhtap-demo/README.md
@@ -31,7 +31,6 @@ ginkgo --label-filter='verify-stage' ./cmd/
    3. The Component Detection Query was created successfully
    4. The Component (simple) Build finished successfully
    5. Snapshot was created and integration test finished successfully
-   6. Component was successfully deployed to a dev environment and the health endpoint is reachable
 
 ### Advanced build (enabled only if AdvancedBuildSpec is set)
 1. Setup

--- a/tests/rhtap-demo/config/scenarios.go
+++ b/tests/rhtap-demo/config/scenarios.go
@@ -29,7 +29,7 @@ var TestScenarios = []TestSpec{
 				GitSourceContext:           "",
 				GitSourceDefaultBranchName: "main",
 				HealthEndpoint:             "/",
-				SkipDeploymentCheck:        false,
+				SkipDeploymentCheck:        true,
 				AdvancedBuildSpec: &AdvancedBuildSpec{
 					TestScenario: TestScenarioSpec{
 						GitURL:      "https://github.com/konflux-ci/integration-examples.git",
@@ -317,7 +317,7 @@ var TestScenarios = []TestSpec{
 				GitSourceRevision:   "",
 				GitSourceContext:    "",
 				HealthEndpoint:      "/",
-				SkipDeploymentCheck: false,
+				SkipDeploymentCheck: true,
 			},
 		},
 	},


### PR DESCRIPTION
# Description

* Now that integration-service will no longer deploy successful snapshots to all the available root envs, we won't have any component deployments.
* So, we should update the tests to stop checking for component deployments.

## Issue ticket number and link

[STONEINTG-697](https://issues.redhat.com/browse/STONEINTG-697)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

I've tested this change locally on a couple of fresh clusters by deploying the changes from https://github.com/redhat-appstudio/integration-service/pull/677 and running the changes of this PR. The rhtap-demo test passed.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)