### PR TITLE
refactor: Remove CreateIntegrationTestScenarioV2() and extend signature of original function

### DIFF
--- a/cmd/loadTests.go
+++ b/cmd/loadTests.go
@@ -1368,7 +1368,7 @@ func (h *ConcreteHandlerResources) handleIntegrationTestScenarioCreation(ctx *Jo
 	defer klog.V(5).Infof("handleIntegrationTestScenarioCreation end username: %s, usernamespace: %s, applicationName: %s, itsName: %s", username, usernamespace, applicationName, itsName)
 
 	startTimeForIts := time.Now()
-	_, err := framework.AsKubeDeveloper.IntegrationController.CreateIntegrationTestScenarioV2(itsName, applicationName, usernamespace, testScenarioGitURL, testScenarioRevision, testScenarioPathInRepo)
+	_, err := framework.AsKubeDeveloper.IntegrationController.CreateIntegrationTestScenario(itsName, applicationName, usernamespace, testScenarioGitURL, testScenarioRevision, testScenarioPathInRepo)
 	itsCreationTime := time.Since(startTimeForIts)
 	if err != nil {
 		logError(6, fmt.Sprintf("Unable to create integrationTestScenario for Application %s: %v \n", applicationName, err))

--- a/pkg/clients/integration/integration_test_scenarios.go
+++ b/pkg/clients/integration/integration_test_scenarios.go
@@ -63,10 +63,11 @@ func (i *IntegrationController) CreateIntegrationTestScenarioWithEnvironment(app
 }
 
 // CreateIntegrationTestScenario creates beta1 version integrationTestScenario.
-// Universal method to create a IntegrationTestScenario (its) in the kubernetes clusters and adds a suffix to the its name to allow multiple its's with unique names.
-// Generate a random its name with #combinations > 11M, Create unique resource names that adhere to RFC 1123 Label Names
-// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
-func (i *IntegrationController) CreateIntegrationTestScenarioV2(itsName, applicationName, namespace, gitURL, revision, pathInRepo string) (*integrationv1beta1.IntegrationTestScenario, error) {
+func (i *IntegrationController) CreateIntegrationTestScenario(itsName, applicationName, namespace, gitURL, revision, pathInRepo string) (*integrationv1beta1.IntegrationTestScenario, error) {
+	if itsName == "" {
+		itsName = "my-integration-test-" + util.GenerateRandomString(4)
+	}
+
 	integrationTestScenario := &integrationv1beta1.IntegrationTestScenario{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      itsName,
@@ -100,13 +101,6 @@ func (i *IntegrationController) CreateIntegrationTestScenarioV2(itsName, applica
 		return nil, err
 	}
 	return integrationTestScenario, nil
-}
-
-// CreateIntegrationTestScenario creates beta1 version integrationTestScenario.
-func (i *IntegrationController) CreateIntegrationTestScenario(applicationName, namespace, gitURL, revision, pathInRepo string) (*integrationv1beta1.IntegrationTestScenario, error) {
-	// use default itsName from the original function to keep backwards compatability
-	itsName := "my-integration-test-" + util.GenerateRandomString(4)
-	return i.CreateIntegrationTestScenarioV2(itsName, applicationName, namespace, gitURL, revision, pathInRepo)
 }
 
 // Get return the status from the Application Custom Resource object.

--- a/tests/integration-service/integration.go
+++ b/tests/integration-service/integration.go
@@ -47,7 +47,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 
 			applicationName = createApp(*f, testNamespace)
 			componentName, originalComponent = createComponent(*f, testNamespace, applicationName)
-			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario(applicationName, testNamespace, gitURL, revision, pathInRepoPass)
+			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -195,7 +195,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			applicationName = createApp(*f, testNamespace)
 			componentName, originalComponent = createComponent(*f, testNamespace, applicationName)
 
-			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario(applicationName, testNamespace, gitURL, revision, pathInRepoFail)
+			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoFail)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -257,7 +257,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		})
 
 		It("creates a new IntegrationTestScenario", func() {
-			newIntegrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario(applicationName, testNamespace, gitURL, revision, pathInRepoPass)
+			newIntegrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 

--- a/tests/integration-service/status-reporting-to-pullrequest.go
+++ b/tests/integration-service/status-reporting-to-pullrequest.go
@@ -57,10 +57,10 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 
 			applicationName = createApp(*f, testNamespace)
 
-			integrationTestScenarioPass, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario(applicationName, testNamespace, gitURL, revision, pathInRepoPass)
+			integrationTestScenarioPass, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			integrationTestScenarioFail, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario(applicationName, testNamespace, gitURL, revision, pathInRepoFail)
+			integrationTestScenarioFail, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoFail)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			componentName = fmt.Sprintf("%s-%s", "test-component-pac", util.GenerateRandomString(6))

--- a/tests/rhtap-demo/rhtap-demo.go
+++ b/tests/rhtap-demo/rhtap-demo.go
@@ -312,7 +312,7 @@ var _ = framework.RhtapDemoSuiteDescribe(func() {
 								createReleaseConfig(*fw, managedNamespace, component.GetName(), appTest.ApplicationName, sharedSecret.Data[".dockerconfigjson"])
 
 								its := componentSpec.AdvancedBuildSpec.TestScenario
-								integrationTestScenario, err = fw.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario(appTest.ApplicationName, fw.UserNamespace, its.GitURL, its.GitRevision, its.TestPath)
+								integrationTestScenario, err = fw.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", appTest.ApplicationName, fw.UserNamespace, its.GitURL, its.GitRevision, its.TestPath)
 								Expect(err).ShouldNot(HaveOccurred())
 
 								pacBranchName = fmt.Sprintf("appstudio-%s", component.GetName())


### PR DESCRIPTION
# Description
Remove CreateIntegrationTestScenarioV2() and extend signature of original function.

This is a followup on https://github.com/redhat-appstudio/e2e-tests/pull/1092, so that is why it contains all the commits from that as well. Will rebase once 1092 is merged.

## Issue ticket number and link
N/A

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Manual load test run against Stage. I would rely on CI here.