### PR TITLE
fix(EC-619): Set default for tekton bundle repo

### DIFF
--- a/tests/build/tkn-bundle.go
+++ b/tests/build/tkn-bundle.go
@@ -34,6 +34,7 @@ var _ = framework.TknBundleSuiteDescribe("tkn bundle task", Label("tasks", "HACB
 	var pvcName string = "source-pvc"
 	var pvcAccessMode corev1.PersistentVolumeAccessMode = "ReadWriteOnce"
 	var baseTaskRun *pipeline.TaskRun
+	var qeBundleRepo string = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), taskName)
 
 	var gitRevision, gitURL, bundleImg string
 
@@ -50,7 +51,7 @@ var _ = framework.TknBundleSuiteDescribe("tkn bundle task", Label("tasks", "HACB
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// set a custom bundle repo for the task
-			bundleRepo := os.Getenv("TKN_BUNDLE_REPO")
+			bundleRepo := utils.GetEnv("TKN_BUNDLE_REPO", qeBundleRepo)
 			Expect(bundleRepo).NotTo(BeEmpty())
 			bundleImg = fmt.Sprintf("%s:%s", bundleRepo, taskName)
 		} else {
@@ -63,7 +64,7 @@ var _ = framework.TknBundleSuiteDescribe("tkn bundle task", Label("tasks", "HACB
 
 			err = kubeClient.CommonController.CreateQuayRegistrySecret(namespace)
 			Expect(err).NotTo(HaveOccurred())
-			bundleImg = fmt.Sprintf("quay.io/%s/test-images:%s", utils.GetQuayIOOrganization(), taskName)
+			bundleImg = qeBundleRepo
 		}
 
 		// resolve the gitURL and gitRevision


### PR DESCRIPTION
# Description

The bundle image repo is empty when running in the build-definitions CI and breaking. This sets a default to the QE org/pr repo.

## Issue ticket number and link
https://issues.redhat.com/browse/EC-619

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
I ran it locally.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
