### PR TITLE
fix: Use golden-container latest images in enterprise contract tests

### DIFF
--- a/pkg/utils/tekton/pipelineruns.go
+++ b/pkg/utils/tekton/pipelineruns.go
@@ -57,7 +57,7 @@ func (b BuildahDemo) Generate() (*pipeline.PipelineRun, error) {
 			Params: []pipeline.Param{
 				{
 					Name:  "dockerfile",
-					Value: *pipeline.NewStructuredValues("docker/Dockerfile"),
+					Value: *pipeline.NewStructuredValues("Containerfile"),
 				},
 				{
 					Name:  "output-image",
@@ -65,7 +65,7 @@ func (b BuildahDemo) Generate() (*pipeline.PipelineRun, error) {
 				},
 				{
 					Name:  "git-url",
-					Value: *pipeline.NewStructuredValues("https://github.com/redhat-appstudio-qe/devfile-sample-hello-world.git"),
+					Value: *pipeline.NewStructuredValues("https://github.com/enterprise-contract/golden-container.git"),
 				},
 				{
 					Name:  "skip-checks",

--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -310,7 +310,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 
 			Context("ec-cli command", func() {
 				It("verifies ec cli has error handling", func() {
-					generator.WithComponentImage("quay.io/redhat-appstudio/ec-golden-image@sha256:4b318620a32349fd37827163c67b5ff6e503f05b3ca4dde066ee03bb34be9ae1")
+					generator.WithComponentImage("quay.io/redhat-appstudio/ec-golden-image:latest")
 					pr, err := fwk.AsKubeAdmin.TektonController.RunPipeline(generator, namespace, pipelineRunTimeout)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(fwk.AsKubeAdmin.TektonController.WatchPipelineRun(pr.Name, namespace, pipelineRunTimeout)).To(Succeed())
@@ -347,7 +347,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests
 						defaultECP.Spec, ecp.SourceConfig{Include: []string{"minimal"}})
 					Expect(fwk.AsKubeAdmin.TektonController.CreateOrUpdatePolicyConfiguration(namespace, policy)).To(Succeed())
 
-					generator.WithComponentImage("quay.io/redhat-appstudio/ec-golden-image:e2e-test-out-of-date-task")
+					generator.WithComponentImage("quay.io/redhat-appstudio/ec-golden-image:latest")
 					generator.AppendComponentImage("quay.io/redhat-appstudio/ec-golden-image:e2e-test-unacceptable-task")
 					pr, err := fwk.AsKubeAdmin.TektonController.RunPipeline(generator, namespace, pipelineRunTimeout)
 					Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
resolves: [CVP-4098](https://issues.redhat.com//browse/CVP-4098)

# Description

Tests for enterprise contract should build and test the golden-container image. Also, it should always use the latest golden-container build.

## Issue ticket number and link
[CVP-4098](https://issues.redhat.com//browse/CVP-4098)

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Used cluster bot to spin up a cluster and ran `./bin/e2e-appstudio --ginkgo.focus="enterprise-contract-suite"`
