### PR TITLE
fix: cleanup PaC webhooks after test's finished

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -51,7 +51,7 @@ var (
 	// can be periodic, presubmit or postsubmit
 	jobType                    = utils.GetEnv("JOB_TYPE", "")
 	reposToDeleteDefaultRegexp = "jvm-build|e2e-dotnet|build-suite|e2e|pet-clinic-e2e|test-app|e2e-quayio|petclinic|test-app|integ-app|^dockerfile-|new-|^python|my-app|^test-|^multi-component"
-	repositoriesWithWebhooks   = []string{"devfile-sample-hello-world", "hacbs-test-project"}
+	repositoriesWithWebhooks   = []string{"devfile-sample-hello-world", "hacbs-test-project", "secret-lookup-sample-repo-two"}
 	// determine whether CI will run tests that require to register SprayProxy
 	// in order to run tests that require PaC application
 	requiresSprayProxyRegistering bool

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -200,6 +200,9 @@ const (
 	// Default github repo values for build
 	DEFAULT_GITHUB_BUILD_ORG  = "redhat-appstudio"
 	DEFAULT_GITHUB_BUILD_REPO = "build-definitions"
+
+	PaCControllerNamespace = "openshift-pipelines"
+	PaCControllerRouteName = "pipelines-as-code-controller"
 )
 
 var (

--- a/tests/integration-service/gitlab-integration-reporting.go
+++ b/tests/integration-service/gitlab-integration-reporting.go
@@ -16,10 +16,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	integrationv1beta1 "github.com/konflux-ci/integration-service/api/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appstudioApi "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	integrationv1beta1 "github.com/konflux-ci/integration-service/api/v1beta1"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
@@ -32,7 +32,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 	var mrID int
 	// var mrNote *gitlab.Note
 	var timeout, interval time.Duration
-	var osConsoleHost, mrSha, projectID, gitlabToken string
+	var mrSha, projectID, gitlabToken string
 	var snapshot *appstudioApi.Snapshot
 	var component *appstudioApi.Component
 	var buildPipelineRun, testPipelinerun *pipeline.PipelineRun
@@ -51,11 +51,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 			Expect(err).NotTo(HaveOccurred())
 			testNamespace = f.UserNamespace
 
-			consoleRoute, err := f.AsKubeAdmin.CommonController.GetOpenshiftRoute("console", "openshift-console")
-			Expect(err).ShouldNot(HaveOccurred())
-			osConsoleHost = consoleRoute.Spec.Host
-
-			if utils.IsPrivateHostname(osConsoleHost) {
+			if utils.IsPrivateHostname(f.OpenshiftConsoleHost) {
 				Skip("Using private cluster (not reachable from Github), skipping...")
 			}
 

--- a/tests/integration-service/status-reporting-to-pullrequest.go
+++ b/tests/integration-service/status-reporting-to-pullrequest.go
@@ -13,10 +13,10 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
 
+	integrationv1beta1 "github.com/konflux-ci/integration-service/api/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appstudioApi "github.com/redhat-appstudio/application-api/api/v1alpha1"
-	integrationv1beta1 "github.com/konflux-ci/integration-service/api/v1beta1"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
@@ -28,7 +28,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 
 	var prNumber int
 	var timeout, interval time.Duration
-	var osConsoleHost, prHeadSha string
+	var prHeadSha string
 	var snapshot *appstudioApi.Snapshot
 	var component *appstudioApi.Component
 	var pipelineRun, testPipelinerun *pipeline.PipelineRun
@@ -47,11 +47,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 			Expect(err).NotTo(HaveOccurred())
 			testNamespace = f.UserNamespace
 
-			consoleRoute, err := f.AsKubeAdmin.CommonController.GetOpenshiftRoute("console", "openshift-console")
-			Expect(err).ShouldNot(HaveOccurred())
-			osConsoleHost = consoleRoute.Spec.Host
-
-			if utils.IsPrivateHostname(osConsoleHost) {
+			if utils.IsPrivateHostname(f.OpenshiftConsoleHost) {
 				Skip("Using private cluster (not reachable from Github), skipping...")
 			}
 


### PR DESCRIPTION
# Description

After following tests were added/updated to use PaC webhooks  https://github.com/redhat-appstudio/e2e-tests/pull/1107/files, the webhooks started to pile up in the repos [devfile-sample-hello-world](https://github.com/redhat-appstudio-qe/devfile-sample-hello-world) and [secret-lookup-sample-repo-two](https://github.com/redhat-appstudio-qe/secret-lookup-sample-repo-two) until we started hitting [KFLUXBUGS-1280](https://issues.redhat.com//browse/KFLUXBUGS-1280)

The webhooks were manually removed from those repos for now, but we need a logic to cleanup the related webhook after test and an addition to the list of repositories that are being cleaned up by the nightly job: https://github.com/redhat-appstudio/e2e-tests/pull/1165/commits/4c220ad10ff78abda0f655701b599fd2d0d34a64

## Issue ticket number and link
https://issues.redhat.com/browse/KFLUXBUGS-1280

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
ginkgo build ./cmd && ginkgo -p -v --label-filter='build-custom-branch,secret-lookup' ./cmd/cmd.test
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
