### PR TITLE
fix: release pyxis tests properly fetch imageIDs

### DIFF
--- a/pkg/clients/release/sbom.go
+++ b/pkg/clients/release/sbom.go
@@ -138,24 +138,17 @@ func (r *ReleaseController) GetPyxisImageByImageID(pyxisStageImagesApiEndpoint, 
 }
 
 // GetPyxisImageIDsFromCreatePyxisImageTaskLogs takes a slice of task logs (as this is what
-// TektonController.GetTaskRunLogs returns), ensures it has just one log in it, parses it for
-// the imageIDs, and returns them as a slice.
+// TektonController.GetTaskRunLogs returns) and parses them for the imageIDs, returning them
+// as a slice.
 func (r *ReleaseController) GetPyxisImageIDsFromCreatePyxisImageTaskLogs(logs map[string]string) ([]string, error) {
-	var log string
 	var imageIDs []string
 
 	re := regexp.MustCompile(`(?:The image id is: )(.+)`)
 
-	if len(logs) != 1 {
-		return []string{}, fmt.Errorf("expected pyxis task logs to contain one log but it contained multiple. Length was: %d", len(logs))
-	}
-
 	for _, tasklog := range logs {
-		log = tasklog
-	}
-
-	for _, matchingString := range re.FindAllString(log, -1) {
-		imageIDs = append(imageIDs, re.FindStringSubmatch(matchingString)[1])
+		for _, matchingString := range re.FindAllString(tasklog, -1) {
+			imageIDs = append(imageIDs, re.FindStringSubmatch(matchingString)[1])
+		}
 	}
 
 	return imageIDs, nil


### PR DESCRIPTION
This commit changes the release suite utility function to support there being multiple task logs to fetch the pyxis image IDs from instead of only supporting one log.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
