### PR TITLE
fix: always rebase e2e-tests and infra-deployments

### DIFF
--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -51,6 +51,7 @@ func gitCheckoutRemoteBranch(remoteName, branchName string) error {
 		{"remote", "add", remoteName, fmt.Sprintf("https://github.com/%s/e2e-tests.git", remoteName)},
 		{"fetch", remoteName},
 		{"checkout", branchName},
+		{"pull", "--rebase", "upstream", "main"},
 	} {
 		if err := git(arg...); err != nil {
 			return fmt.Errorf("error when checkout out remote branch %s from remote %s: %v", branchName, remoteName, err)
@@ -383,8 +384,8 @@ func MergePRInRemote(branch string, forkOrganization string, repoPath string) er
 	}
 	klog.Infof("Fork organization: %s", forkOrganization)
 	if forkOrganization == "redhat-appstudio" {
-		// Cloned repository have as origin set redhat-appstudio organization
-		err = mergeBranch(repoPath, "remotes/origin/"+branch)
+		// Cloned repository have as upstream set redhat-appstudio organization
+		err = mergeBranch(repoPath, "remotes/upstream/"+branch)
 	} else {
 		repoURL := fmt.Sprintf("https://github.com/%s/infra-deployments.git", forkOrganization)
 		_, err = repo.CreateRemote(&config.RemoteConfig{

--- a/tests/load-tests/ci-scripts/setup-cluster.sh
+++ b/tests/load-tests/ci-scripts/setup-cluster.sh
@@ -35,7 +35,7 @@ if [ "${TWEAK_INFRA_DEPLOYMENTS:-false}" == "true" ]; then
     INFRA_DEPLOYMENTS_BRANCH="tekton-tuning-$(mktemp -u XXXX)"
     envsubst <tests/load-tests/ci-scripts/tekton-performance/update-tekton-config-performance.yaml >"$infra_deployment_dir/components/pipeline-service/development/update-tekton-config-performance.yaml"
     pushd "$infra_deployment_dir"
-    git checkout -b "$INFRA_DEPLOYMENTS_BRANCH" origin/main
+    git checkout -b "$INFRA_DEPLOYMENTS_BRANCH" upstream/main
     git add "$infra_deployment_dir/components/pipeline-service/development/update-tekton-config-performance.yaml"
     git commit -m "WIP: tekton performance tuning"
     git remote add tekton-tuning "https://${GITHUB_TOKEN}@github.com/$INFRA_DEPLOYMENTS_ORG/infra-deployments.git"


### PR DESCRIPTION
# Description

* refer to original remote of `e2e-tests` and `infra-deployment` repos as "upstream" (see [explanation](https://stackoverflow.com/a/9257901))
* add a logic to always rebase with main before running tests, to make sure the branch is always up-to-date
* tested with https://github.com/openshift/release/pull/52146
* follow-up item: delete lines below `TODO` comments introduced in [this PR](https://github.com/openshift/release/pull/52146/files)

## Issue ticket number and link
https://issues.redhat.com/browse/KFLUXBUGS-1185

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://github.com/openshift/release/pull/52146/files

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
