### PR TITLE
fix(KONFLUX-2465): Refresh framework before access token expires on Stage

### DIFF
--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -72,6 +72,7 @@ func newFrameworkWithTimeout(userName string, timeout time.Duration, options ...
 	var err error
 	var k *kubeCl.K8SClient
 	var clusterAppDomain, openshiftConsoleHost string
+	var option utils.Options
 
 	if userName == "" {
 		return nil, fmt.Errorf("userName cannot be empty when initializing a new framework instance")
@@ -79,6 +80,11 @@ func newFrameworkWithTimeout(userName string, timeout time.Duration, options ...
 	isStage, err := utils.CheckOptions(options)
 	if err != nil {
 		return nil, err
+	}
+	if len(options) == 1 {
+		option = options[0]
+	} else {
+		option = utils.Options{}
 	}
 	// https://issues.redhat.com/browse/CRT-1670
 	if len(userName) > 20 {
@@ -90,7 +96,7 @@ func newFrameworkWithTimeout(userName string, timeout time.Duration, options ...
 
 	err = retry.Do(
 		func() error {
-			if k, err = kubeCl.NewDevSandboxProxyClient(userName, isStage, options[0]); err != nil {
+			if k, err = kubeCl.NewDevSandboxProxyClient(userName, isStage, option); err != nil {
 				GinkgoWriter.Printf("error when creating dev sandbox proxy client: %+v\n", err)
 			}
 			return err


### PR DESCRIPTION
# Description
Refresh framework before access token expires on Stage

## Issue ticket number and link
[KONFLUX-2465](https://issues.redhat.com//browse/KONFLUX-2465)

## Type of change
Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Using this script:
```
package main

import "fmt"
import "os"
import "time"
import "encoding/json"

import "github.com/redhat-appstudio/e2e-tests/pkg/framework"
import "github.com/redhat-appstudio/e2e-tests/pkg/utils"


// User represents a user in the list
type User struct {
	Username string `json:"username"`
	Password string `json:"password"`
	Token    string `json:"token"`
	SSOURL   string `json:"ssourl"`
	APIURL   string `json:"apiurl"`
	Verified bool   `json:"verified"`
}

func LoadStageUsers(filePath string) ([]User, error) {
	jsonData, err := os.ReadFile(filePath)
	if err != nil {
		return nil, err
	}
	// Parse JSON into an array of User objects
	var users []User
	err = json.Unmarshal(jsonData, &users)
	if err != nil {
		return nil, err
	}
	return users, nil
}

func main() {
	var stageUsers []User
	var fw *framework.Framework
	var err error

	fmt.Printf("Hello from framwrork test!\n")

	stageUsers, err = LoadStageUsers("users.json")
	if err != nil {
		fmt.Printf("Failed to load Stage users: %v\n", err)
	}

	user := stageUsers[0]
	fmt.Printf("Selected Stage user: %+v\n", user)

	fw, err = framework.NewFrameworkWithTimeout(
		user.Username,
		time.Minute*60,
		utils.Options{
			ToolchainApiUrl: user.APIURL,
			KeycloakUrl:     user.SSOURL,
			OfflineToken:    user.Token,
		},
	)
	fmt.Printf("Created framework: %+v\n", fw)
	for {
		pods, errPods := fw.AsKubeDeveloper.CommonController.ListAllPods("test-rhtap-1-tenant")
		if errPods != nil {
			fmt.Printf("Failed to list pods: %+v", errPods)
			os.Exit(1)
		}
		fmt.Printf("%s   Listed pods: %d\n", time.Now().UTC(), pods.Size())
		time.Sleep(time.Minute * 1)
	}
}
```

Before the change it quit after 15 minutes, with the change it was running for 35+ min, so I guess it works.