### PR TITLE
fix: upgrade job

### DIFF
--- a/magefiles/installation/install.go
+++ b/magefiles/installation/install.go
@@ -218,11 +218,9 @@ func (i *InstallAppStudio) cloneInfraDeployments() error {
 		URL:           url,
 		ReferenceName: plumbing.ReferenceName(refName),
 		Progress:      os.Stdout,
+		RemoteName:    "upstream",
 	})
 
-	if _, err := repo.CreateRemote(&config.RemoteConfig{Name: "upstream", URLs: []string{"https://github.com/redhat-appstudio/infra-deployments.git"}}); err != nil {
-		return err
-	}
 	if _, err := repo.CreateRemote(&config.RemoteConfig{Name: i.LocalForkName, URLs: []string{fmt.Sprintf("https://github.com/%s/infra-deployments.git", i.LocalGithubForkOrganization)}}); err != nil {
 		return err
 	}

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -421,8 +421,11 @@ func MergePRInRemote(branch string, forkOrganization string, repoPath string) er
 }
 
 func mergeBranch(repoPath string, branchToMerge string) error {
-	_, err := exec.Command("git", "-C", repoPath, "merge", branchToMerge, "-Xtheirs", "-q").Output()
+	cmd := exec.Command("git", "-C", repoPath, "merge", branchToMerge, "-Xtheirs", "-q")
+	klog.Info(cmd.String())
+	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
+		klog.Errorf("failed to merge branch %s in path %s: %s", branchToMerge, repoPath, stdoutStderr)
 		klog.Fatal(err)
 	}
 	return nil


### PR DESCRIPTION
# Description

This is a fix for the[ bug in upgrade-job in infra-deployments](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/redhat-appstudio_infra-deployments/3694/pull-ci-redhat-appstudio-infra-deployments-main-appstudio-upgrade-tests/1792894391031959552#1:build-log.txt%3A1670-1675)

the error was:
```
merge: <branch-name> - not something we can merge

Did you mean this?
        upstream/<branch-name>
```
It was caused by a conflict with the local remotes `upstream` and `origin`, which was fixed in this PR by replacing the `origin` remote name with `upstream`

Also the error was not visible in the output (see the link above), which was fixed in this PR too
## Issue ticket number and link
[KFLUXBUGS-1185](https://issues.redhat.com//browse/KFLUXBUGS-1185)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1.
```
export UPGRADE_BRANCH=pipeline-service-test-osp-nightly
```
2. update the PrepareCluster func to look like this:
```go

func (Local) PrepareCluster() error {
	if err := UpgradeTestsWorkflow(); err != nil {
		klog.Errorf("error when running upgrade tests: %s", err)
		return err
	}
	return nil
}
```
3.
```
make local/cluster/prepare
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
