### PR TITLE
fix: access token expired during pipelineRun

### DIFF
--- a/tests/release/pipelines/fbc_release.go
+++ b/tests/release/pipelines/fbc_release.go
@@ -100,7 +100,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("FBC e2e-tests", Label("release-
 
 		var _ = Describe("Post-release verification", func() {
 			It("verifies that a build PipelineRun is created in dev namespace and succeeds", func() {
-				assertBuildPipelineRunCreated(*devFw, devNamespace, managedNamespace, fbcApplicationName, component)
+				assertBuildPipelineRunSucceeded(*devFw, devNamespace, managedNamespace, fbcApplicationName, component)
 			})
 
 			It("verifies the fbc release pipelinerun is running and succeeds", func() {
@@ -142,7 +142,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("FBC e2e-tests", Label("release-
 
 		var _ = Describe("FBC hotfix post-release verification", func() {
 			It("verifies that a build PipelineRun is created in dev namespace and succeeds", func() {
-				assertBuildPipelineRunCreated(*devFw, devNamespace, managedNamespace, fbcHotfixAppName, component)
+				assertBuildPipelineRunSucceeded(*devFw, devNamespace, managedNamespace, fbcHotfixAppName, component)
 			})
 
 			It("verifies the fbc release pipelinerun is running and succeeds", func() {
@@ -186,7 +186,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("FBC e2e-tests", Label("release-
 
 		var _ = Describe("FBC pre-GA post-release verification", func() {
 			It("verifies that a build PipelineRun is created in dev namespace and succeeds", func() {
-				assertBuildPipelineRunCreated(*devFw, devNamespace, managedNamespace, fbcPreGAAppName, component)
+				assertBuildPipelineRunSucceeded(*devFw, devNamespace, managedNamespace, fbcPreGAAppName, component)
 			})
 
 			It("verifies the fbc release pipelinerun is running and succeeds", func() {
@@ -200,12 +200,12 @@ var _ = framework.ReleasePipelinesSuiteDescribe("FBC e2e-tests", Label("release-
 	})
 })
 
-func assertBuildPipelineRunCreated(devFw framework.Framework, devNamespace, managedNamespace, fbcAppName string, component *appservice.Component) {
+func assertBuildPipelineRunSucceeded(devFw framework.Framework, devNamespace, managedNamespace, fbcAppName string, component *appservice.Component) {
 	dFw := releasecommon.NewFramework(devWorkspace)
 	devFw = *dFw
 	// Create a ticker that ticks every 3 minutes
 	ticker := time.NewTicker(3 * time.Minute)
-	// Schedule the stop of the ticker after 10 minutes
+	// Schedule the stop of the ticker after 5 minutes
 	time.AfterFunc(5*time.Minute, func() {
 		ticker.Stop()
 		fmt.Println("Stopped executing every 3 minutes.")

--- a/tests/release/pipelines/rh_advisories.go
+++ b/tests/release/pipelines/rh_advisories.go
@@ -17,7 +17,6 @@ import (
 	"github.com/redhat-appstudio/e2e-tests/pkg/constants"
 	"github.com/redhat-appstudio/e2e-tests/pkg/framework"
 	"github.com/redhat-appstudio/e2e-tests/pkg/utils"
-	"github.com/redhat-appstudio/e2e-tests/pkg/utils/tekton"
 	releasecommon "github.com/redhat-appstudio/e2e-tests/tests/release"
 	releaseapi "github.com/redhat-appstudio/release-service/api/v1alpha1"
 	tektonutils "github.com/redhat-appstudio/release-service/tekton/utils"
@@ -119,10 +118,11 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-advisories pip
 		var _ = Describe("Post-release verification", func() {
 			It("verifies that a build PipelineRun is created in dev namespace and succeeds", func() {
 				devFw = releasecommon.NewFramework(devWorkspace)
+				managedFw = releasecommon.NewFramework(managedWorkspace)
 				// Create a ticker that ticks every 3 minutes
 				ticker := time.NewTicker(3 * time.Minute)
-				// Schedule the stop of the ticker after 10 minutes
-				time.AfterFunc(10*time.Minute, func() {
+				// Schedule the stop of the ticker after 15 minutes
+				time.AfterFunc(15*time.Minute, func() {
 					ticker.Stop()
 					fmt.Println("Stopped executing every 3 minutes.")
 				})
@@ -130,24 +130,14 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-advisories pip
 				go func() {
 					for range ticker.C {
 						devFw = releasecommon.NewFramework(devWorkspace)
+						managedFw = releasecommon.NewFramework(managedWorkspace)
 					}
 				}()
-				Eventually(func() error {
-					buildPR, err = devFw.AsKubeDeveloper.HasController.GetComponentPipelineRun(component.Name, advsApplicationName, devNamespace, "")
-					if err != nil {
-						return err
-					}
-					if !buildPR.IsDone() {
-						return fmt.Errorf("build pipelinerun %s in namespace %s did not finish yet", buildPR.Name, buildPR.Namespace)
-					}
-					Expect(tekton.HasPipelineRunSucceeded(buildPR)).To(BeTrue(), fmt.Sprintf("build pipelinerun %s/%s did not succeed", buildPR.GetNamespace(), buildPR.GetName()))
-					snapshot, err = devFw.AsKubeDeveloper.IntegrationController.GetSnapshot("", buildPR.Name, "", devNamespace)
-					if err != nil {
-						return err
-					}
-					return nil
-				}, releasecommon.BuildPipelineRunCompletionTimeout, releasecommon.DefaultInterval).Should(Succeed(), "timed out when waiting for build pipelinerun to be created")
+				buildPR, err = devFw.AsKubeDeveloper.HasController.GetComponentPipelineRun(component.Name, advsApplicationName, devNamespace, "")
+				Expect(err).ShouldNot(HaveOccurred())
 				Expect(devFw.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(component, "", devFw.AsKubeDeveloper.TektonController, &has.RetryOptions{Retries: 3, Always: true}, nil)).To(Succeed())
+				snapshot, err = devFw.AsKubeDeveloper.IntegrationController.GetSnapshot("", buildPR.Name, "", devNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
 			})
 			It("verifies the advs release pipelinerun is running and succeeds", func() {
 				devFw = releasecommon.NewFramework(devWorkspace)


### PR DESCRIPTION
Signed-off-by: Jing Qi <jinqi@redhat.com>

Added managedFw in the ticker to avoid access token expired issue. 
Updated to use WaitForComponentPipelineToBeFinished function and removed the other loop.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
