### PR TITLE
fix: use loop or function with loop to get CRs

### DIFF
--- a/tests/release/pipelines/rh_advisories.go
+++ b/tests/release/pipelines/rh_advisories.go
@@ -133,11 +133,22 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-advisories pip
 						managedFw = releasecommon.NewFramework(managedWorkspace)
 					}
 				}()
-				buildPR, err = devFw.AsKubeDeveloper.HasController.GetComponentPipelineRun(component.Name, advsApplicationName, devNamespace, "")
-				Expect(err).ShouldNot(HaveOccurred())
+				Eventually(func() error {
+					buildPR, err = devFw.AsKubeDeveloper.HasController.GetComponentPipelineRun(component.Name, advsApplicationName, devNamespace, "")
+                                        if err != nil {
+                                                GinkgoWriter.Printf("Build PipelineRun has not been created yet for the component %s/%s\n", devNamespace, component.Name)
+                                                return err
+                                        }
+                                        if !buildPR.HasStarted() {
+                                                return fmt.Errorf("build pipelinerun %s/%s hasn't started yet", devNamespace, buildPR.GetName())
+                                        }
+                                        return nil
+                                }, releasecommon.BuildPipelineRunCompletionTimeout, releasecommon.DefaultInterval).Should(Succeed(), fmt.Sprintf("timed out when waiting for the build PipelineRun to start for the component %s/%s", devNamespace, component.Name))
+
 				Expect(devFw.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(component, "", devFw.AsKubeDeveloper.TektonController, &has.RetryOptions{Retries: 3, Always: true}, nil)).To(Succeed())
-				snapshot, err = devFw.AsKubeDeveloper.IntegrationController.GetSnapshot("", buildPR.Name, "", devNamespace)
-				Expect(err).ShouldNot(HaveOccurred())
+
+				snapshot, err = devFw.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", component.Name, devNamespace)
+                                Expect(err).ToNot(HaveOccurred())
 			})
 			It("verifies the advs release pipelinerun is running and succeeds", func() {
 				devFw = releasecommon.NewFramework(devWorkspace)

--- a/tests/release/pipelines/rh_push_to_external_registry.go
+++ b/tests/release/pipelines/rh_push_to_external_registry.go
@@ -219,19 +219,10 @@ var _ = framework.ReleasePipelinesSuiteDescribe("[HACBS-1571]test-release-e2e-pu
 		})
 
 		It("tests that Snapshot is created for each Component", func() {
-			Eventually(func() error {
-				snapshot1, err = fw.AsKubeAdmin.IntegrationController.GetSnapshot("", "", component1.GetName(), devNamespace)
-				if err != nil {
-					GinkgoWriter.Printf("cannot get the Snapshot for component %s/%s: %v\n", component1.GetNamespace(), component1.GetName(), err)
-					return err
-				}
-				snapshot2, err = fw.AsKubeAdmin.IntegrationController.GetSnapshot("", "", component2.GetName(), devNamespace)
-				if err != nil {
-					GinkgoWriter.Printf("cannot get the Snapshot for component %s/%s: %v\n", component2.GetNamespace(), component2.GetName(), err)
-					return err
-				}
-				return nil
-			}, 5*time.Minute, releasecommon.DefaultInterval).Should(Succeed(), "timed out waiting for Snapshots to be created in %s namespace", devNamespace)
+				snapshot1, err = fw.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", component1.GetName(), devNamespace)
+                                Expect(err).ToNot(HaveOccurred())
+				snapshot2, err = fw.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", component2.GetName(), devNamespace)
+                                Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("tests that associated Release CR is created for each Component's Snapshot", func() {


### PR DESCRIPTION
Signed-off-by: Jing Qi <jinqi@redhat.com>

Use WaitForSnapshotToGetCreated and WaitForComponentPipelineToBeFinished function to get CRs to avoid flakness.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
