### PR TITLE
chore: fix GH app installation ID for PR creation

### DIFF
--- a/.tekton/update-build-definitions.yaml
+++ b/.tekton/update-build-definitions.yaml
@@ -36,8 +36,9 @@ spec:
             value: $(params.build-definitions-update-script)
           - name: TARGET_GH_REPO
             value: konflux-ci/build-definitions
+          # https://github.com/apps/rh-tap-build-team in https://github.com/konflux-ci
           - name: GITHUB_APP_INSTALLATION_ID
-            value: "35269675"
+            value: "51073377"
         taskRef:
           bundle: quay.io/redhat-appstudio-tekton-catalog/task-update-infra-deployments:0.1
           name: update-infra-deployments


### PR DESCRIPTION
[STONEBLD-2339](https://issues.redhat.com//browse/STONEBLD-2339)

The build-definitions repo has moved to the konflux-ci org. The
https://github.com/apps/rh-tap-build-team app had to be reinstalled in
the new org, thus changing the installation ID.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://github.com/konflux-ci/build-definitions/pull/1034

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
