### PR TITLE
fix: remote names

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -1166,7 +1166,9 @@ func UpgradeTestsWorkflow() error {
 
 func BootstrapClusterForUpgrade() (*installation.InstallAppStudio, error) {
 	//Use main branch of infra-deployments in redhat-appstudio org as default version for upgrade
-	ic, err := installation.NewAppStudioInstallControllerUpgrade("redhat-appstudio", "main")
+	os.Setenv("INFRA_DEPLOYMENTS_ORG", "redhat-appstudio")
+	os.Setenv("INFRA_DEPLOYMENTS_BRANCH", "main")
+	ic, err := installation.NewAppStudioInstallController()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize installation controller: %+v", err)
 	}


### PR DESCRIPTION
# Description

fix of the bug reported [here](https://redhat-internal.slack.com/archives/C02FANRBZQD/p1716896368884529)

the removal of "upstream" remote name [here](https://github.com/redhat-appstudio/e2e-tests/pull/1180/files#diff-be9cd886dab1d153a199cd4e8e53764a124d2bb335339a13d24993b774d0d0f7L223) was not correct - it was causing issues for infra-deployments PRs which were based on a fork that did not contain `main` branch

## Issue ticket number and link
[KFLUXBUGS-1185](https://issues.redhat.com//browse/KFLUXBUGS-1185)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Similarly like in [this PR](https://github.com/redhat-appstudio/e2e-tests/pull/1180#issue-2308662907) with one extra test scenario:
```
export UPGRADE_BRANCH=ec-batch-update UPGRADE_FORK_ORGANIZATION=enterprise-contract
```

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
