### PR TITLE
fix: Address issue with ginkgo cli args generation

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -1301,18 +1301,25 @@ func CleanWorkload() error {
 }
 
 func runTests(labelsToRun string, junitReportFile string) error {
-	pathToSuite := "./cmd"
-	testProcesses := ""
+
+	ginkgoArgs := []string{"-p", "--output-interceptor-mode=none", 
+	"--timeout=90m", fmt.Sprintf("--output-dir=%s", artifactDir), 
+	"--junit-report="+junitReportFile, "--label-filter="+labelsToRun}
+
 	if os.Getenv("GINKGO_PROCS") != "" {
-		testProcesses = fmt.Sprintf("--procs=%s", os.Getenv("GINKGO_PROCS"))
+		ginkgoArgs = append(ginkgoArgs, fmt.Sprintf("--procs=%s", os.Getenv("GINKGO_PROCS")))
 	}
 
 	if os.Getenv("E2E_BIN_PATH") != "" {
-		pathToSuite = os.Getenv("E2E_BIN_PATH")
+		ginkgoArgs = append(ginkgoArgs, os.Getenv("E2E_BIN_PATH"))
+	} else {
+		ginkgoArgs = append(ginkgoArgs, "./cmd")
 	}
 
+	ginkgoArgs = append(ginkgoArgs, "--")
+
 	// added --output-interceptor-mode=none to mitigate RHTAPBUGS-34
-	return sh.RunV("ginkgo", "-p", testProcesses, "--output-interceptor-mode=none", "--timeout=90m", fmt.Sprintf("--output-dir=%s", artifactDir), "--junit-report="+junitReportFile, "--label-filter="+labelsToRun, pathToSuite, "--")
+	return sh.RunV("ginkgo", ginkgoArgs...)
 }
 
 func CleanupRegisteredPacServers() error {


### PR DESCRIPTION
 * Fixes an issue when GINKGO_PROCS env is not set it passes in an empty "" to runV and for some reason it causes ginkgo to ignore the cli flags we passed after the "" which includes our label filters and it runs all the tests in the suite

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
