### PR TITLE
fix: create release service account before using it

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -1313,9 +1313,15 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 				Repository string
 			}{Name: ParentComponentDef.componentName, Repository: distributionRepository})
 			rawData, err := json.Marshal(&data)
+			Expect(err).NotTo(HaveOccurred())
 
 			GinkgoWriter.Printf("ReleaseAdmissionPlan data: %s", string(rawData))
+			managedServiceAccount, err := f.AsKubeAdmin.CommonController.CreateServiceAccount("release-service-account", managedNamespace, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
+
+			_, err = f.AsKubeAdmin.ReleaseController.CreateReleasePipelineRoleBindingForServiceAccount(managedNamespace, managedServiceAccount)
+			Expect(err).NotTo(HaveOccurred())
+
 			_, err = f.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission("demo", managedNamespace, "", f.UserNamespace, "demo", "release-service-account", []string{applicationName}, false, &tektonutils.PipelineRef{
 				Resolver: "git",
 				Params: []tektonutils.Param{


### PR DESCRIPTION
"release-service-account" SA does't exist by default. It need to be created before using it.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
