### PR TITLE
fix: write perms to /konflux-e2e directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9
 USER root
 
 WORKDIR /konflux-e2e
+RUN chmod -R 775 /konflux-e2e
 
 ENV GOBIN=$HOME/bin
 ENV E2E_BIN_PATH=/konflux-e2e/konflux-e2e.test


### PR DESCRIPTION
# Description

periodic jobs are still failing due to permission issue
```
Waiting for UserSignup group-ngtq to have condition Complete:True
error when creating dev sandbox proxy client: error writing sandbox user kubeconfig to /konflux-e2e/tmp/group-ngtq.kubeconfig path: mkdir /konflux-e2e/tmp: permission denied
```