### PR TITLE
chore: make cluster-access-secret-name optional

### DIFF
--- a/integration-tests/tasks/konflux-e2e-tests/0.2/konflux-e2e-tests.yaml
+++ b/integration-tests/tasks/konflux-e2e-tests/0.2/konflux-e2e-tests.yaml
@@ -78,6 +78,7 @@ spec:
         secretName: konflux-test-infra
     - name: cluster-secret-volume
       secret:
+        optional: true
         secretName: $(params.cluster-access-secret-name)
   steps:
     - name: initialize-sealights-session


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
