### PR TITLE
fix: disable scheduling on master nodes by default

### DIFF
--- a/default.env
+++ b/default.env
@@ -103,10 +103,10 @@ export UPGRADE_FORK_ORGANIZATION=redhat-appstudio-qe
 # Implemented as part of https://issues.redhat.com/browse/RHTAPBUGS-890
 # export E2E_SKIP_CLEANUP=true
 
-# By default the e2e-tests installer configures master nodes as schedulable.
-# However this option is not recommended for use in production (https://access.redhat.com/solutions/4564851)
-# Set the following env var's value to "false" if you don't want user workloads being scheduled on master/control plane nodes of your cluster.
-export ENABLE_SCHEDULING_ON_MASTER_NODES=true
+# Configure master nodes as schedulable.
+# This option is not recommended for use in production (https://access.redhat.com/solutions/4564851)
+# Set the following env var's value to "true" if you want user workloads being scheduled on master/control plane nodes of your cluster.
+export ENABLE_SCHEDULING_ON_MASTER_NODES=false
 
 # Setting this env to a number of ginkgo processes to run in parallel
 # Required: no

--- a/magefiles/installation/install.go
+++ b/magefiles/installation/install.go
@@ -39,7 +39,7 @@ const (
 	DEFAULT_LOCAL_FORK_ORGANIZATION  = "redhat-appstudio-qe"
 	DEFAULT_E2E_QUAY_ORG             = "redhat-appstudio-qe"
 
-	enableSchedulingOnMasterNodes = "true"
+	enableSchedulingOnMasterNodes = "false"
 )
 
 var (


### PR DESCRIPTION
# Description

After switching to openshift v4.16, the option to schedule pods on master/control nodes became problematic.

Giving the fact that we [will be using kyverno](https://github.com/redhat-appstudio/infra-deployments/pull/7031) to override taskrun pods' cpu/mem resources, it no longer makes sense to use master nodes for scheduling