### PR TITLE
style: rename Enterprise Contract to Conforma

### DIFF
--- a/pkg/utils/tekton/pipelineruns.go
+++ b/pkg/utils/tekton/pipelineruns.go
@@ -67,7 +67,7 @@ func (b BuildahDemo) Generate() (*pipeline.PipelineRun, error) {
 				},
 				{
 					Name:  "git-url",
-					Value: *pipeline.NewStructuredValues("https://github.com/enterprise-contract/golden-container.git"),
+					Value: *pipeline.NewStructuredValues("https://github.com/conforma/golden-container.git"),
 				},
 				{
 					Name:  "skip-checks",

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,7 @@ Tests folder contains E2E related to several components divided in folders:
 | Folder | Component repository | README | Note |
 |---|---|---|---|
 | `build` | [build-service](https://github.com/konflux-ci/build-service), [jvm-build-service](https://github.com/redhat-appstudio/jvm-build-service) | [README.md](/tests/build/README.md) | |
-| `enterprise-contract` | N/A | [README.md](/tests/enterprise-contract/README.md) | |
+| `conforma` | N/A | [README.md](/tests/enterprise-contract/README.md) | |
 | `integration-service` | [integration-service](https://github.com/konflux-ci/integration-service) | [README.md](/tests/integration-service/README.md) |  |
 | `load-tests` | N/A | [LoadTests.md](/docs/LoadTests.md) |  |
 | `release` | [release-service](https://github.com/konflux-ci/release-service) | [README.md](/tests/release/README.md) |  |

--- a/tests/enterprise-contract/README.md
+++ b/tests/enterprise-contract/README.md
@@ -1,10 +1,10 @@
-# Enterprise Contract
+# Conforma (formerly Enterprise Contract) 
 
-The Enterprise Contract is a set of tools for verifying the provenance of container images built in Red Hat Trusted Application Pipeline and validating them against a clearly defined policy.
+Conforma (formerly Enterprise Contract) is a set of tools for verifying the provenance of container images built in Red Hat Trusted Application Pipeline and validating them against a clearly defined policy.
 
-The Enterprise Contract policy is defined using the rego policy language and is described here in [Release Policy](https://enterprisecontract.dev/docs/ec-policies/release_policy.html) and [Pipeline Policy](https://enterprisecontract.dev/docs/ec-policies/pipeline_policy.html)
+The Conforma policy is defined using the rego policy language and is described here in [Release Policy](https://conforma.dev/docs/policy/release_policy.html) and [Pipeline Policy](https://conforma.dev/docs/policy/pipeline_policy.html)
 
-The enterprise-contract suite contains a set of tests that covers Enterprise Contract policies.
+The enterprise-contract suite contains a set of tests that covers Conforma policies.
 
 Steps to run 'enterprise-contract-suite':
 

--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-var _ = framework.EnterpriseContractSuiteDescribe("Enterprise Contract E2E tests", Label("ec"), func() {
+var _ = framework.EnterpriseContractSuiteDescribe("Conforma E2E tests", Label("ec"), func() {
 
 	defer GinkgoRecover()
 

--- a/tests/konflux-demo/README.md
+++ b/tests/konflux-demo/README.md
@@ -35,7 +35,7 @@ It is possible to run this test against "downstream" (deployed via scripts in [i
       1. Secret with cosign-public-key (used for validating the built image by EC)
       1. Release plan for the targeted application and (user) namespace
       1. Release strategy, Release plan admission
-      1. Enterprise contract policy
+      1. Conforma policy
 1. Test scenario
    1. The application and component were created successfully
    1. Verify that the initial PaC pull request was created in the component's repo (this will also trigger the default build pipelinerun)


### PR DESCRIPTION
# Description
Update some of the Enterprise Contract references to Conforma, only in some docs and labels.
Many objects and names still refer to it as EnterpriseContract, but it seems overkill to perform a full rename with the risk of breaking things, just for the sake of tidiness.

## Issue ticket number and link
https://issues.redhat.com/browse/EC-1128

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [x] I have updated labels (if needed)
