### PR TITLE
refactor(RELEASE-1352): replace RPA auto-release with block-releases

### DIFF
--- a/pkg/clients/release/plans.go
+++ b/pkg/clients/release/plans.go
@@ -27,11 +27,11 @@ func (r *ReleaseController) CreateReleasePlan(name, namespace, application, targ
 			},
 		},
 		Spec: releaseApi.ReleasePlanSpec{
-			Application:	application,
-			Data:		data,
-			TenantPipeline:	tenantPipeline,
-			FinalPipeline:	finalPipeline,
-			Target:		targetNamespace,
+			Application:    application,
+			Data:           data,
+			TenantPipeline: tenantPipeline,
+			FinalPipeline:  finalPipeline,
+			Target:         targetNamespace,
 		},
 	}
 	if autoReleaseLabel == "" || autoReleaseLabel == "true" {
@@ -44,13 +44,13 @@ func (r *ReleaseController) CreateReleasePlan(name, namespace, application, targ
 }
 
 // CreateReleasePlanAdmission creates a new ReleasePlanAdmission using the given parameters.
-func (r *ReleaseController) CreateReleasePlanAdmission(name, namespace, environment, origin, policy, serviceAccountName string, applications []string, autoRelease bool, pipelineRef *tektonutils.PipelineRef, data *runtime.RawExtension) (*releaseApi.ReleasePlanAdmission, error) {
+func (r *ReleaseController) CreateReleasePlanAdmission(name, namespace, environment, origin, policy, serviceAccountName string, applications []string, blockReleases bool, pipelineRef *tektonutils.PipelineRef, data *runtime.RawExtension) (*releaseApi.ReleasePlanAdmission, error) {
 	releasePlanAdmission := &releaseApi.ReleasePlanAdmission{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				releaseMetadata.AutoReleaseLabel: strconv.FormatBool(autoRelease),
+				"releases.appstudio.openshift.io/block-releases": strconv.FormatBool(blockReleases), // TODO - replace with imported constant once release-service go module updated
 			},
 		},
 		Spec: releaseApi.ReleasePlanAdmissionSpec{
@@ -59,7 +59,7 @@ func (r *ReleaseController) CreateReleasePlanAdmission(name, namespace, environm
 			Environment:  environment,
 			Origin:       origin,
 			Pipeline: &tektonutils.Pipeline{
-				PipelineRef:    *pipelineRef,
+				PipelineRef:        *pipelineRef,
 				ServiceAccountName: serviceAccountName,
 			},
 			Policy: policy,

--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -1320,7 +1320,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			_, err = f.AsKubeAdmin.ReleaseController.CreateReleasePipelineRoleBindingForServiceAccount(managedNamespace, managedServiceAccount)
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = f.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission("demo", managedNamespace, "", f.UserNamespace, "demo", "release-service-account", []string{applicationName}, false, &tektonutils.PipelineRef{
+			_, err = f.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission("demo", managedNamespace, "", f.UserNamespace, "demo", "release-service-account", []string{applicationName}, true, &tektonutils.PipelineRef{
 				Resolver: "git",
 				Params: []tektonutils.Param{
 					{Name: "url", Value: constants.RELEASE_CATALOG_DEFAULT_URL},

--- a/tests/konflux-demo/konflux-demo.go
+++ b/tests/konflux-demo/konflux-demo.go
@@ -433,7 +433,7 @@ func createReleaseConfig(kubeadminClient *framework.ControllerHub, managedNamesp
 	_, err = kubeadminClient.TektonController.CreateEnterpriseContractPolicy(ecPolicyName, managedNamespace, defaultEcPolicySpec)
 	Expect(err).NotTo(HaveOccurred())
 
-	_, err = kubeadminClient.ReleaseController.CreateReleasePlanAdmission("demo", managedNamespace, "", userNamespace, ecPolicyName, "release-service-account", []string{appName}, true, &tektonutils.PipelineRef{
+	_, err = kubeadminClient.ReleaseController.CreateReleasePlanAdmission("demo", managedNamespace, "", userNamespace, ecPolicyName, "release-service-account", []string{appName}, false, &tektonutils.PipelineRef{
 		Resolver: "git",
 		Params: []tektonutils.Param{
 			{Name: "url", Value: releasecommon.RelSvcCatalogURL},

--- a/tests/release/pipelines/fbc_release.go
+++ b/tests/release/pipelines/fbc_release.go
@@ -5,51 +5,51 @@ import (
 	"fmt"
 	"time"
 
-	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
-	ecp "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
 	"github.com/devfile/library/v2/pkg/util"
+	ecp "github.com/enterprise-contract/enterprise-contract-controller/api/v1alpha1"
+	appservice "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
 	"github.com/konflux-ci/e2e-tests/pkg/utils/tekton"
-	"k8s.io/apimachinery/pkg/runtime"
-	"knative.dev/pkg/apis"
-	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	releasecommon "github.com/konflux-ci/e2e-tests/tests/release"
 	releaseapi "github.com/konflux-ci/release-service/api/v1alpha1"
 	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
+	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 const (
-	fbcSourceGitURL            = "https://github.com/redhat-appstudio-qe/fbc-sample-repo-test"
-	fbcCompRepoName            = "fbc-sample-repo-test"
-	fbcCompRevision            = "94d5b8ccbcdf4d5a8251657bc3266b848c9ec331"
-	fbcCompDefaultBranchName   = "main"
-	fbcDockerFilePath          = "catalog.Dockerfile"
-	targetPort                 = 50051
-	relSvcCatalogPathInRepo    = "pipelines/managed/fbc-release/fbc-release.yaml"
+	fbcSourceGitURL          = "https://github.com/redhat-appstudio-qe/fbc-sample-repo-test"
+	fbcCompRepoName          = "fbc-sample-repo-test"
+	fbcCompRevision          = "94d5b8ccbcdf4d5a8251657bc3266b848c9ec331"
+	fbcCompDefaultBranchName = "main"
+	fbcDockerFilePath        = "catalog.Dockerfile"
+	targetPort               = 50051
+	relSvcCatalogPathInRepo  = "pipelines/managed/fbc-release/fbc-release.yaml"
 )
 
 var (
-	devWorkspace = utils.GetEnv(constants.RELEASE_DEV_WORKSPACE_ENV, constants.DevReleaseTeam)
-	managedWorkspace = utils.GetEnv(constants.RELEASE_MANAGED_WORKSPACE_ENV, constants.ManagedReleaseTeam)
-	devFw *framework.Framework
-	managedFw *framework.Framework
-	snapshot *appservice.Snapshot
-	releaseCR *releaseapi.Release
+	devWorkspace       = utils.GetEnv(constants.RELEASE_DEV_WORKSPACE_ENV, constants.DevReleaseTeam)
+	managedWorkspace   = utils.GetEnv(constants.RELEASE_MANAGED_WORKSPACE_ENV, constants.ManagedReleaseTeam)
+	devFw              *framework.Framework
+	managedFw          *framework.Framework
+	snapshot           *appservice.Snapshot
+	releaseCR          *releaseapi.Release
 	managedPipelineRun *pipeline.PipelineRun
-	buildPipelineRun *pipeline.PipelineRun
-	preGAPipelineRun *pipeline.PipelineRun
-	hotfixPipelineRun *pipeline.PipelineRun
-	stagedPipelineRun *pipeline.PipelineRun
-	fbcComponent *appservice.Component
-	err error
+	buildPipelineRun   *pipeline.PipelineRun
+	preGAPipelineRun   *pipeline.PipelineRun
+	hotfixPipelineRun  *pipeline.PipelineRun
+	stagedPipelineRun  *pipeline.PipelineRun
+	fbcComponent       *appservice.Component
+	err                error
 
 	// PaC related variables
-	fbcPacBranchName string
+	fbcPacBranchName      string
 	fbcCompBaseBranchName string
 )
 
@@ -57,32 +57,32 @@ var _ = framework.ReleasePipelinesSuiteDescribe("FBC e2e-tests", Label("release-
 	defer GinkgoRecover()
 
 	var (
-		devNamespace = devWorkspace + "-tenant"
+		devNamespace     = devWorkspace + "-tenant"
 		managedNamespace = managedWorkspace + "-tenant"
 
-		issueId = "bz12345"
-		productName = "preGA-product"
+		issueId        = "bz12345"
+		productName    = "preGA-product"
 		productVersion = "v2"
 
 		fbcApplicationName = "fbc-pipelines-app-" + util.GenerateRandomString(4)
-		fbcStagedAppName = "fbc-staged-app-" + util.GenerateRandomString(4)
-		fbcHotfixAppName = "fbc-hotfix-app-" + util.GenerateRandomString(4)
-		fbcPreGAAppName = "fbc-prega-app-" + util.GenerateRandomString(4)
+		fbcStagedAppName   = "fbc-staged-app-" + util.GenerateRandomString(4)
+		fbcHotfixAppName   = "fbc-hotfix-app-" + util.GenerateRandomString(4)
+		fbcPreGAAppName    = "fbc-prega-app-" + util.GenerateRandomString(4)
 
 		fbcReleasePlanName = "fbc-pipelines-rp-" + util.GenerateRandomString(4)
-		fbcStagedRPName = "fbc-staged-rp-" + util.GenerateRandomString(4)
-		fbcHotfixRPName = "fbc-hotfix-rp-" + util.GenerateRandomString(4)
-		fbcPreGARPName = "fbc-prega-rp-" + util.GenerateRandomString(4)
+		fbcStagedRPName    = "fbc-staged-rp-" + util.GenerateRandomString(4)
+		fbcHotfixRPName    = "fbc-hotfix-rp-" + util.GenerateRandomString(4)
+		fbcPreGARPName     = "fbc-prega-rp-" + util.GenerateRandomString(4)
 
 		fbcReleasePlanAdmissionName = "fbc-pipelines-rpa-" + util.GenerateRandomString(4)
-		fbcStagedRPAName = "fbc-staged-rpa-" + util.GenerateRandomString(4)
-		fbcHotfixRPAName = "fbc-hotfix-rpa-" + util.GenerateRandomString(4)
-		fbcPreGARPAName = "fbc-prega-rpa-" + util.GenerateRandomString(4)
+		fbcStagedRPAName            = "fbc-staged-rpa-" + util.GenerateRandomString(4)
+		fbcHotfixRPAName            = "fbc-hotfix-rpa-" + util.GenerateRandomString(4)
+		fbcPreGARPAName             = "fbc-prega-rpa-" + util.GenerateRandomString(4)
 
 		fbcEnterpriseContractPolicyName = "fbc-pipelines-policy-" + util.GenerateRandomString(4)
-		fbcStagedECPolicyName = "fbc-staged-policy-" + util.GenerateRandomString(4)
-		fbcHotfixECPolicyName = "fbc-hotfix-policy-" + util.GenerateRandomString(4)
-		fbcPreGAECPolicyName = "fbc-prega-policy-" + util.GenerateRandomString(4)
+		fbcStagedECPolicyName           = "fbc-staged-policy-" + util.GenerateRandomString(4)
+		fbcHotfixECPolicyName           = "fbc-hotfix-policy-" + util.GenerateRandomString(4)
+		fbcPreGAECPolicyName            = "fbc-prega-policy-" + util.GenerateRandomString(4)
 	)
 
 	Describe("with FBC happy path", Label("fbcHappyPath"), func() {
@@ -112,7 +112,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("FBC e2e-tests", Label("release-
 			if err = devFw.AsKubeDeveloper.ReleaseController.StoreRelease(releaseCR); err != nil {
 				GinkgoWriter.Printf("failed to store Release %s:%s: %s\n", releaseCR.GetNamespace(), releaseCR.GetName(), err.Error())
 			}
-			// delete CRs			
+			// delete CRs
 			Expect(devFw.AsKubeDeveloper.HasController.DeleteApplication(fbcApplicationName, devNamespace, false)).NotTo(HaveOccurred())
 			Expect(managedFw.AsKubeDeveloper.TektonController.DeleteEnterpriseContractPolicy(fbcEnterpriseContractPolicyName, managedNamespace, false)).NotTo(HaveOccurred())
 			Expect(managedFw.AsKubeDeveloper.ReleaseController.DeleteReleasePlanAdmission(fbcReleasePlanAdmissionName, managedNamespace, false)).NotTo(HaveOccurred())
@@ -418,7 +418,7 @@ func createFBCReleasePlanAdmission(fbcRPAName string, managedFw framework.Framew
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	_, err = managedFw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(fbcRPAName, managedNamespace, "", devNamespace, fbcECPName, releasecommon.ReleasePipelineServiceAccountDefault, []string{fbcAppName}, true, &tektonutils.PipelineRef{
+	_, err = managedFw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(fbcRPAName, managedNamespace, "", devNamespace, fbcECPName, releasecommon.ReleasePipelineServiceAccountDefault, []string{fbcAppName}, false, &tektonutils.PipelineRef{
 		Resolver: "git",
 		Params: []tektonutils.Param{
 			{Name: "url", Value: releasecommon.RelSvcCatalogURL},

--- a/tests/release/pipelines/multiarch_advisories.go
+++ b/tests/release/pipelines/multiarch_advisories.go
@@ -117,7 +117,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for multi arch with r
 						return err
 					}
 					return nil
-				}, 10*time.Minute, releasecommon.DefaultInterval).Should(Succeed(), "timed out when trying to get release CR for snapshot %s/%s", devNamespace, snapshotPush.Name) 
+				}, 10*time.Minute, releasecommon.DefaultInterval).Should(Succeed(), "timed out when trying to get release CR for snapshot %s/%s", devNamespace, snapshotPush.Name)
 			})
 
 			It("verifies the multiarch release pipelinerun is running and succeeds", func() {
@@ -251,7 +251,7 @@ func createMultiArchReleasePlanAdmission(multiarchRPAName string, managedFw fram
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	_, err = managedFw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(multiarchRPAName, managedNamespace, "", devNamespace, multiarchECPName, releasecommon.ReleasePipelineServiceAccountDefault, []string{multiarchAppName}, true, &tektonutils.PipelineRef{
+	_, err = managedFw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(multiarchRPAName, managedNamespace, "", devNamespace, multiarchECPName, releasecommon.ReleasePipelineServiceAccountDefault, []string{multiarchAppName}, false, &tektonutils.PipelineRef{
 		Resolver: "git",
 		Params: []tektonutils.Param{
 			{Name: "url", Value: releasecommon.RelSvcCatalogURL},

--- a/tests/release/pipelines/push_to_external_registry.go
+++ b/tests/release/pipelines/push_to_external_registry.go
@@ -114,7 +114,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("Push to external registry", Lab
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(releasecommon.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, ecPolicyName, releasecommon.ReleasePipelineServiceAccountDefault, []string{releasecommon.ApplicationNameDefault}, true, &tektonutils.PipelineRef{
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(releasecommon.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, ecPolicyName, releasecommon.ReleasePipelineServiceAccountDefault, []string{releasecommon.ApplicationNameDefault}, false, &tektonutils.PipelineRef{
 			Resolver: "git",
 			Params: []tektonutils.Param{
 				{Name: "url", Value: releasecommon.RelSvcCatalogURL},

--- a/tests/release/pipelines/release_to_github.go
+++ b/tests/release/pipelines/release_to_github.go
@@ -31,11 +31,11 @@ import (
 )
 
 const (
-	sampSourceGitURL       = "https://github.com/redhat-appstudio-qe/devfile-sample-go-basic"
-	sampGitSrcSHA          = "6b56d05ac8abb4c24d153e9689209a1018402aad"
-	sampRepoOwner          = "redhat-appstudio-qe"
-	sampRepo               = "devfile-sample-go-basic"
-	sampCatalogPathInRepo  = "pipelines/managed/release-to-github/release-to-github.yaml"
+	sampSourceGitURL      = "https://github.com/redhat-appstudio-qe/devfile-sample-go-basic"
+	sampGitSrcSHA         = "6b56d05ac8abb4c24d153e9689209a1018402aad"
+	sampRepoOwner         = "redhat-appstudio-qe"
+	sampRepo              = "devfile-sample-go-basic"
+	sampCatalogPathInRepo = "pipelines/managed/release-to-github/release-to-github.yaml"
 )
 
 var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for release-to-github pipeline", Pending, Label("release-pipelines", "release-to-github"), func() {
@@ -143,7 +143,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for release-to-github
 						return err
 					}
 					return nil
-				}, 10*time.Minute, releasecommon.DefaultInterval).Should(Succeed(), "timed out when trying to get release CR for snapshot %s/%s", devNamespace, snapshot.Name) 
+				}, 10*time.Minute, releasecommon.DefaultInterval).Should(Succeed(), "timed out when trying to get release CR for snapshot %s/%s", devNamespace, snapshot.Name)
 			})
 
 			It("verifies the release pipelinerun is running and succeeds", func() {
@@ -238,7 +238,7 @@ func createGHReleasePlanAdmission(sampRPAName string, managedFw framework.Framew
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	_, err = managedFw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(sampRPAName, managedNamespace, "", devNamespace, sampECPName, releasecommon.ReleasePipelineServiceAccountDefault, []string{sampAppName}, true, &tektonutils.PipelineRef{
+	_, err = managedFw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(sampRPAName, managedNamespace, "", devNamespace, sampECPName, releasecommon.ReleasePipelineServiceAccountDefault, []string{sampAppName}, false, &tektonutils.PipelineRef{
 		Resolver: "git",
 		Params: []tektonutils.Param{
 			{Name: "url", Value: releasecommon.RelSvcCatalogURL},

--- a/tests/release/pipelines/rh_advisories.go
+++ b/tests/release/pipelines/rh_advisories.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	advsCatalogPathInRepo  = "pipelines/managed/rh-advisories/rh-advisories.yaml"
-	advsGitSourceURL       = "https://github.com/redhat-appstudio-qe/devfile-sample-python-basic-release"
-	advsGitSrcSHA          = "33ff89edf85fb01a37d3d652d317080223069fc7"
+	advsCatalogPathInRepo = "pipelines/managed/rh-advisories/rh-advisories.yaml"
+	advsGitSourceURL      = "https://github.com/redhat-appstudio-qe/devfile-sample-python-basic-release"
+	advsGitSrcSHA         = "33ff89edf85fb01a37d3d652d317080223069fc7"
 )
 
 var advsComponentName = "advs-comp-" + util.GenerateRandomString(4)
@@ -122,7 +122,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-advisories pip
 						return err
 					}
 					return nil
-				}, 10*time.Minute, releasecommon.DefaultInterval).Should(Succeed(), "timed out when trying to get release CR for snapshot %s/%s", devNamespace, snapshotPush.Name) 
+				}, 10*time.Minute, releasecommon.DefaultInterval).Should(Succeed(), "timed out when trying to get release CR for snapshot %s/%s", devNamespace, snapshotPush.Name)
 			})
 
 			It("verifies the advs release pipelinerun is running and succeeds", func() {
@@ -270,7 +270,7 @@ func createADVSReleasePlanAdmission(advsRPAName string, managedFw framework.Fram
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	_, err = managedFw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(advsRPAName, managedNamespace, "", devNamespace, advsECPName, releasecommon.ReleasePipelineServiceAccountDefault, []string{advsAppName}, true, &tektonutils.PipelineRef{
+	_, err = managedFw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(advsRPAName, managedNamespace, "", devNamespace, advsECPName, releasecommon.ReleasePipelineServiceAccountDefault, []string{advsAppName}, false, &tektonutils.PipelineRef{
 		Resolver: "git",
 		Params: []tektonutils.Param{
 			{Name: "url", Value: releasecommon.RelSvcCatalogURL},

--- a/tests/release/pipelines/rh_push_to_external_registry.go
+++ b/tests/release/pipelines/rh_push_to_external_registry.go
@@ -166,7 +166,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("[HACBS-1571]test-release-e2e-pu
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(releasecommon.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, ecPolicyName, releasecommon.ReleasePipelineServiceAccountDefault, []string{releasecommon.ApplicationNameDefault}, true, &tektonutils.PipelineRef{
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(releasecommon.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, ecPolicyName, releasecommon.ReleasePipelineServiceAccountDefault, []string{releasecommon.ApplicationNameDefault}, false, &tektonutils.PipelineRef{
 			Resolver: "git",
 			Params: []tektonutils.Param{
 				{Name: "url", Value: releasecommon.RelSvcCatalogURL},

--- a/tests/release/pipelines/rh_push_to_registry_redhat_io.go
+++ b/tests/release/pipelines/rh_push_to_registry_redhat_io.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	rhioCatalogPathInRepo  = "pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml"
-	rhioGitSourceURL       = "https://github.com/redhat-appstudio-qe/devfile-sample-python-basic-release"
-	rhioGitSrcSHA          = "33ff89edf85fb01a37d3d652d317080223069fc7"
+	rhioCatalogPathInRepo = "pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml"
+	rhioGitSourceURL      = "https://github.com/redhat-appstudio-qe/devfile-sample-python-basic-release"
+	rhioGitSrcSHA         = "33ff89edf85fb01a37d3d652d317080223069fc7"
 )
 
 var rhioComponentName = "rhio-comp-" + util.GenerateRandomString(4)
@@ -114,7 +114,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rh-push-to-redhat
 						return err
 					}
 					return nil
-				}, 10*time.Minute, releasecommon.DefaultInterval).Should(Succeed(), "timed out when trying to get release CR for snapshot %s/%s", devNamespace, snapshotPush.Name) 
+				}, 10*time.Minute, releasecommon.DefaultInterval).Should(Succeed(), "timed out when trying to get release CR for snapshot %s/%s", devNamespace, snapshotPush.Name)
 			})
 
 			It("verifies the rhio release pipelinerun is running and succeeds", func() {
@@ -258,7 +258,7 @@ func createRHIOReleasePlanAdmission(rhioRPAName string, managedFw framework.Fram
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	_, err = managedFw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(rhioRPAName, managedNamespace, "", devNamespace, rhioECPName, releasecommon.ReleasePipelineServiceAccountDefault, []string{rhioAppName}, true, &tektonutils.PipelineRef{
+	_, err = managedFw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(rhioRPAName, managedNamespace, "", devNamespace, rhioECPName, releasecommon.ReleasePipelineServiceAccountDefault, []string{rhioAppName}, false, &tektonutils.PipelineRef{
 		Resolver: "git",
 		Params: []tektonutils.Param{
 			{Name: "url", Value: releasecommon.RelSvcCatalogURL},

--- a/tests/release/pipelines/rhtap_service_push.go
+++ b/tests/release/pipelines/rhtap_service_push.go
@@ -154,7 +154,7 @@ var _ = framework.ReleasePipelinesSuiteDescribe("e2e tests for rhtap-service-pus
 						return err
 					}
 					return nil
-				}, 10*time.Minute, releasecommon.DefaultInterval).Should(Succeed(), "timed out when trying to get release CR for snapshot %s/%s", devNamespace, snapshot.Name) 
+				}, 10*time.Minute, releasecommon.DefaultInterval).Should(Succeed(), "timed out when trying to get release CR for snapshot %s/%s", devNamespace, snapshot.Name)
 			})
 
 			It("verifies the rhtap release pipelinerun is running and succeeds", func() {
@@ -284,7 +284,7 @@ func createRHTAPReleasePlanAdmission(rhtapRPAName string, managedFw framework.Fr
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	_, err = managedFw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(rhtapRPAName, managedNamespace, "", devNamespace, rhtapECPName, releasecommon.ReleasePipelineServiceAccountDefault, []string{rhtapAppName}, true, &tektonutils.PipelineRef{
+	_, err = managedFw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(rhtapRPAName, managedNamespace, "", devNamespace, rhtapECPName, releasecommon.ReleasePipelineServiceAccountDefault, []string{rhtapAppName}, false, &tektonutils.PipelineRef{
 		Resolver: "git",
 		Params: []tektonutils.Param{
 			{Name: "url", Value: releasecommon.RelSvcCatalogURL},

--- a/tests/release/service/happy_path.go
+++ b/tests/release/service/happy_path.go
@@ -109,7 +109,7 @@ var _ = framework.ReleaseServiceSuiteDescribe("Release service happy path", Labe
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(releasecommon.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, ecPolicyName, releasecommon.ReleasePipelineServiceAccountDefault, []string{releasecommon.ApplicationNameDefault}, true, &tektonutils.PipelineRef{
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(releasecommon.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, ecPolicyName, releasecommon.ReleasePipelineServiceAccountDefault, []string{releasecommon.ApplicationNameDefault}, false, &tektonutils.PipelineRef{
 			Resolver: "git",
 			Params: []tektonutils.Param{
 				{Name: "url", Value: releasecommon.RelSvcCatalogURL},

--- a/tests/release/service/missing_release_plan_and_admission.go
+++ b/tests/release/service/missing_release_plan_and_admission.go
@@ -42,7 +42,7 @@ var _ = framework.ReleaseServiceSuiteDescribe("[HACBS-2360] Release CR fails whe
 		_, err = fw.AsKubeAdmin.IntegrationController.CreateSnapshotWithComponents(snapshotName, "", releasecommon.ApplicationName, devNamespace, []v1alpha1.SnapshotComponent{})
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(destinationReleasePlanAdmissionName, managedNamespace, "", devNamespace, releasecommon.ReleaseStrategyPolicy, releasecommon.ReleasePipelineServiceAccountDefault, []string{releasecommon.ApplicationName}, true, &tektonutils.PipelineRef{
+		_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(destinationReleasePlanAdmissionName, managedNamespace, "", devNamespace, releasecommon.ReleaseStrategyPolicy, releasecommon.ReleasePipelineServiceAccountDefault, []string{releasecommon.ApplicationName}, false, &tektonutils.PipelineRef{
 			Resolver: "git",
 			Params: []tektonutils.Param{
 				{Name: "url", Value: releasecommon.RelSvcCatalogURL},

--- a/tests/release/service/release_plan_and_admission_matched.go
+++ b/tests/release/service/release_plan_and_admission_matched.go
@@ -70,7 +70,7 @@ var _ = framework.ReleaseServiceSuiteDescribe("ReleasePlan and ReleasePlanAdmiss
 		})
 
 		It("Creates ReleasePlanAdmission CR in corresponding managed namespace", func() {
-			_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(releasecommon.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, releasecommon.ReleaseStrategyPolicyDefault, releasecommon.ReleasePipelineServiceAccountDefault, []string{releasecommon.ApplicationNameDefault}, true, &tektonutils.PipelineRef{
+			_, err = fw.AsKubeAdmin.ReleaseController.CreateReleasePlanAdmission(releasecommon.TargetReleasePlanAdmissionName, managedNamespace, "", devNamespace, releasecommon.ReleaseStrategyPolicyDefault, releasecommon.ReleasePipelineServiceAccountDefault, []string{releasecommon.ApplicationNameDefault}, false, &tektonutils.PipelineRef{
 				Resolver: "git",
 				Params: []tektonutils.Param{
 					{Name: "url", Value: releasecommon.RelSvcCatalogURL},


### PR DESCRIPTION
This commit replaces the auto-release label on ReleasePlanAdmissions. Because the true/false value must now be opposite to keep the same functionality, all cases of CreateReleasePlanAdmission had the boolean for that argument flipped.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
