### PR TITLE
fix: registry auth for pushing build bundles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20220523142428-2558e76260fb
 	github.com/codeready-toolchain/toolchain-e2e v0.0.0-20220525131508-60876bfb99d3
 	github.com/devfile/library/v2 v2.2.1-0.20230418160146-e75481b7eebd
+	github.com/docker/cli v24.0.7+incompatible
 	github.com/enterprise-contract/enterprise-contract-controller/api v0.1.50
 	github.com/go-git/go-git/v5 v5.13.0
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572
@@ -147,7 +148,6 @@ require (
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/distribution/reference v0.5.0 // indirect
-	github.com/docker/cli v24.0.7+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker v24.0.7+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.0 // indirect

--- a/magefiles/rulesengine/repos/common.go
+++ b/magefiles/rulesengine/repos/common.go
@@ -470,6 +470,7 @@ func SetupMultiPlatformTests() error {
 	var err error
 	var defaultBundleRef string
 	var tektonObj runtime.Object
+	var authenticator authn.Authenticator
 
 	for _, platformType := range platforms {
 		tag := fmt.Sprintf("%d-%s", time.Now().Unix(), util.GenerateRandomString(4))
@@ -523,8 +524,10 @@ func SetupMultiPlatformTests() error {
 			return fmt.Errorf("error when marshalling a new pipeline to YAML: %v", err)
 		}
 
-		keychain := authn.NewMultiKeychain(authn.DefaultKeychain)
-		authOption := remoteimg.WithAuthFromKeychain(keychain)
+		if authenticator, err = utils.GetAuthenticatorForImageRef(newRemotePipeline, os.Getenv("QUAY_TOKEN")); err != nil {
+			return fmt.Errorf("error when getting authenticator: %v", err)
+		}
+		authOption := remoteimg.WithAuth(authenticator)
 
 		if err = tekton.BuildAndPushTektonBundle(newPipelineYaml, newRemotePipeline, authOption); err != nil {
 			return fmt.Errorf("error when building/pushing a tekton pipeline bundle: %v", err)

--- a/pkg/utils/build/custom_bundle.go
+++ b/pkg/utils/build/custom_bundle.go
@@ -52,6 +52,7 @@ func CreateCustomBuildBundle(pipelineName constants.BuildPipelineType) (string, 
 	var nameParam *tektonpipeline.Param
 	var pipelineBundle string
 	var newPipelineYaml []byte
+	var authenticator authn.Authenticator
 	var err error
 
 	if err = utils.CreateDockerConfigFile(os.Getenv("QUAY_TOKEN")); err != nil {
@@ -91,17 +92,20 @@ func CreateCustomBuildBundle(pipelineName constants.BuildPipelineType) (string, 
 		return "", fmt.Errorf("error when marshalling a new pipeline to YAML: %v", err)
 	}
 
-	keychain := authn.NewMultiKeychain(authn.DefaultKeychain)
-	authOption := remoteimg.WithAuthFromKeychain(keychain)
-
 	tag := fmt.Sprintf("%d-%s", time.Now().Unix(), util.GenerateRandomString(4))
 	quayOrg := utils.GetEnv(constants.DEFAULT_QUAY_ORG_ENV, constants.DefaultQuayOrg)
 	newBuildPipelineImg := strings.ReplaceAll(constants.DefaultImagePushRepo, constants.DefaultQuayOrg, quayOrg)
 
-	var newBuildPipeline, _ = name.ParseReference(fmt.Sprintf("%s:pipeline-bundle-%s", newBuildPipelineImg, tag))
+	var newBuildPipelineRef, _ = name.ParseReference(fmt.Sprintf("%s:pipeline-bundle-%s", newBuildPipelineImg, tag))
+
+	if authenticator, err = utils.GetAuthenticatorForImageRef(newBuildPipelineRef, os.Getenv("QUAY_TOKEN")); err != nil {
+		return "", fmt.Errorf("error when getting authenticator: %v", err)
+	}
+	authOption := remoteimg.WithAuth(authenticator)
+
 	// Build and Push the tekton bundle
-	if err = tekton.BuildAndPushTektonBundle(newPipelineYaml, newBuildPipeline, authOption); err != nil {
+	if err = tekton.BuildAndPushTektonBundle(newPipelineYaml, newBuildPipelineRef, authOption); err != nil {
 		return "", fmt.Errorf("error when building/pushing a tekton pipeline bundle: %v", err)
 	}
-	return newBuildPipeline.String(), nil
+	return newBuildPipelineRef.String(), nil
 }

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -24,7 +24,13 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	dockerconfig "github.com/docker/cli/cli/config"
+	dockerconfigfile "github.com/docker/cli/cli/config/configfile"
+	dockerconfigtypes "github.com/docker/cli/cli/config/types"
+
 	"github.com/devfile/library/v2/pkg/util"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/konflux-ci/e2e-tests/magefiles/rulesengine"
 	"github.com/konflux-ci/e2e-tests/pkg/constants"
 	"github.com/magefile/mage/sh"
@@ -454,4 +460,69 @@ func GetChangedFiles(repo string) (rulesengine.Files, error) {
 	klog.Infof("The following files, %s, were changed!", changes.String())
 
 	return changes, nil
+}
+
+// getAuthForImageRef searches a given Docker configuration file for authentication credentials
+// that match the provided image reference. It attempts to find the most specific match first
+// (e.g., full repository name), then falls back to less specific matches (e.g., namespace,
+// or just the registry host). It returns the first suitable AuthConfig found.
+func getAuthForImageRef(cfg *dockerconfigfile.ConfigFile, imageRef name.Reference) (dockerconfigtypes.AuthConfig, error) {
+	// Extract namespace from image reference repository
+	// i.e. namespace/repository -> namespace
+	var namespace string
+	parts := strings.Split(imageRef.Context().RepositoryStr(), "/")
+	if len(parts) > 1 {
+		namespace = parts[0]
+	}
+
+	matchingEntries := []string{
+		// quay.io/namespace/repo
+		imageRef.Context().Name(),
+		// quay.io/namespace
+		fmt.Sprintf("%s/%s", imageRef.Context().RegistryStr(), namespace),
+		// quay.io
+		imageRef.Context().RegistryStr(),
+	}
+
+	for _, entry := range matchingEntries {
+		authConfig, err := cfg.GetAuthConfig(entry)
+		if err != nil {
+			return authConfig, fmt.Errorf("failed to get auth config for %s: %+v", entry, err)
+		}
+		if authConfig.ServerAddress == entry && authConfig.Username != "" {
+			return authConfig, nil
+		}
+	}
+
+	return dockerconfigtypes.AuthConfig{}, fmt.Errorf("no suitable auth config matches image ref %s", imageRef.String())
+}
+
+// GetAuthenticatorForImageRef decodes a base64-encoded Docker configuration JSON string,
+// loads it into a Docker config object, and then uses it to find appropriate
+// authentication credentials for the given image reference. If suitable credentials
+// (with a username) are found, it returns an `authn.Authenticator` instance
+// that can be used for authenticating with container registries.
+func GetAuthenticatorForImageRef(imageRef name.Reference, encodedDockerconfigjson string) (authenticator authn.Authenticator, err error) {
+	var rawRegistryCreds []byte
+	if rawRegistryCreds, err = base64.StdEncoding.DecodeString(encodedDockerconfigjson); err != nil {
+		return authenticator, fmt.Errorf("unable to decode container registry credentials: %v", err)
+	}
+	dockerConfig, err := dockerconfig.LoadFromReader(strings.NewReader(string(rawRegistryCreds)))
+	if err != nil {
+		return authenticator, fmt.Errorf("failed to load docker config from supplied dockerconfigjson: %+v", err)
+	}
+	// Resolve credentials for a specified image reference
+	authConfig, err := getAuthForImageRef(dockerConfig, imageRef)
+	if err != nil {
+		return authenticator, fmt.Errorf("failed to get auth for image ref: %+v", err)
+	}
+
+	if authConfig.Username != "" {
+		klog.Infof("found credentials for image ref %s -> user: %s\n", imageRef.String(), authConfig.Username)
+		return authn.FromConfig(authn.AuthConfig{
+			Username: authConfig.Username,
+			Password: authConfig.Password,
+		}), nil
+	}
+	return authenticator, fmt.Errorf("did not find any suitable credentials for image ref %s", imageRef.String())
 }


### PR DESCRIPTION
# Description

Fix image registry auth when pushing tekton bundles

See more info in https://issues.redhat.com/browse/KONFLUX-9704

## Issue ticket number and link
https://issues.redhat.com/browse/KONFLUX-9704

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

locally with the dockerconfigjson identical to what we use in CI

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
