### PR TITLE
fix(build_template): don't duplicate BUILDAH_FORMAT param

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -815,7 +815,19 @@ func enableDockerMediaTypeInPipelineBundle(customDockerBuildBundle string, pipel
 	for i := range dockerPipelineObject.PipelineSpec().Tasks {
 		t := &dockerPipelineObject.PipelineSpec().Tasks[i]
 		if t.Name == "build-container" || t.Name == "build-image-index" || t.Name == "sast-coverity-check" || t.Name == "build-images" {
-			t.Params = append(t.Params, tektonpipeline.Param{Name: "BUILDAH_FORMAT", Value: *tektonpipeline.NewStructuredValues(mediaType)})
+			exist := false
+			for param_idx := range t.Params {
+				param := &t.Params[param_idx]
+				if param.Name == "BUILDAH_FORMAT" {
+					param.Value = *tektonpipeline.NewStructuredValues(mediaType)
+					exist = true
+					break
+				}
+			}
+			if !exist {
+				// param wasn't updated, add it as new param
+				t.Params = append(t.Params, tektonpipeline.Param{Name: "BUILDAH_FORMAT", Value: *tektonpipeline.NewStructuredValues(mediaType)})
+			}
 		}
 	}
 	if newPipelineYaml, err = yaml.Marshal(dockerPipelineObject); err != nil {


### PR DESCRIPTION
if BUILDAH_FORMAT param already existed in PLR definition, it was just duplicated and created invalid definition.

Check if param exists and then just update it, if param doesn't exist add a new one.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Issue ticket number and link

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
