### PR TITLE
fix: Change Gitlab status report

### DIFF
--- a/tests/build/build.go
+++ b/tests/build/build.go
@@ -449,8 +449,8 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 					expectedCheckRunName := fmt.Sprintf("%s-%s", customBranchComponentName, "on-pull-request")
 					Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(expectedCheckRunName, helloWorldComponentGitSourceRepoName, prHeadSha, prNumber)).To(Equal(constants.CheckrunConclusionSuccess))
 				case git.GitLabProvider:
-					expectedNote := fmt.Sprintf("%s-on-pull-request** has successfully validated your commit", customBranchComponentName)
-					f.AsKubeAdmin.HasController.GitLab.ValidateNoteInMergeRequestComment(helloWorldComponentGitLabProjectID, expectedNote, prNumber)
+					expectedStatusName := fmt.Sprintf("%s-%s", customBranchComponentName, "on-pull-request")
+					Expect(f.AsKubeAdmin.HasController.GitLab.GetCommitStatusConclusion(expectedStatusName, helloWorldComponentGitLabProjectID, prHeadSha, prNumber)).To(Equal(constants.CheckrunConclusionSuccess))
 				}
 			})
 		})
@@ -514,8 +514,8 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 					expectedCheckRunName := fmt.Sprintf("%s-%s", customBranchComponentName, "on-pull-request")
 					Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(expectedCheckRunName, helloWorldComponentGitSourceRepoName, createdFileSHA, prNumber)).To(Equal(constants.CheckrunConclusionSuccess))
 				case git.GitLabProvider:
-					expectedNote := fmt.Sprintf("%s-on-pull-request** has successfully validated your commit", customBranchComponentName)
-					f.AsKubeAdmin.HasController.GitLab.ValidateNoteInMergeRequestComment(helloWorldComponentGitLabProjectID, expectedNote, prNumber)
+					expectedStatusName := fmt.Sprintf("%s-%s", customBranchComponentName, "on-pull-request")
+					Expect(f.AsKubeAdmin.HasController.GitLab.GetCommitStatusConclusion(expectedStatusName, helloWorldComponentGitLabProjectID, createdFileSHA, prNumber)).To(Equal(constants.CheckrunConclusionSuccess))
 				}
 			})
 		})

--- a/tests/integration-service/gitlab-integration-reporting.go
+++ b/tests/integration-service/gitlab-integration-reporting.go
@@ -217,9 +217,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(Equal(integrationPipelineRunCommitStatusSuccess), fmt.Sprintf("timed out when waiting for expected commitStatus to be created for sha %s in %s repository", mrSha, componentRepoNameForStatusReporting))
 			})
 
-			It("eventually leads to the integration test PipelineRun's Pass status reported at MR notes", func() {
-				expectedNote := fmt.Sprintf("Integration test for snapshot %s and scenario %s has passed", snapshot.Name, integrationTestScenarioPass.Name)
-				f.AsKubeAdmin.HasController.GitLab.ValidateNoteInMergeRequestComment(projectID, expectedNote, mrID)
+			It("eventually leads to the integration test PipelineRun's Pass status reported at MR commit status", func() {
+				Expect(f.AsKubeAdmin.HasController.GitLab.GetCommitStatusConclusion(integrationTestScenarioPass.Name, projectID, mrSha, mrID)).To(Equal(integrationPipelineRunCommitStatusSuccess))
 			})
 
 			It("validates the Integration test scenario PipelineRun is reported to merge request CommitStatus, and it fails", func() {
@@ -239,9 +238,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				}, longTimeout, constants.PipelineRunPollingInterval).Should(Equal(integrationPipelineRunCommitStatusFail), fmt.Sprintf("timed out when waiting for expected commitStatus to be created for sha %s in %s repository", mrSha, componentRepoNameForStatusReporting))
 			})
 
-			It("eventually leads to the integration test PipelineRun's Fail status reported at MR notes", func() {
-				expectedNote := fmt.Sprintf("Integration test for snapshot %s and scenario %s has failed", snapshot.Name, integrationTestScenarioFail.Name)
-				f.AsKubeAdmin.HasController.GitLab.ValidateNoteInMergeRequestComment(projectID, expectedNote, mrID)
+			It("eventually leads to the integration test PipelineRun's Fail status reported at MR commit status", func() {
+				Expect(f.AsKubeAdmin.HasController.GitLab.GetCommitStatusConclusion(integrationTestScenarioFail.Name, projectID, mrSha, mrID)).To(Equal(integrationPipelineRunCommitStatusFail))
 			})
 
 			It("merging the PR should be successful", func() {
@@ -291,9 +289,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(Equal(integrationPipelineRunCommitStatusSuccess), fmt.Sprintf("timed out when waiting for expected commitStatus to be created for sha %s in %s repository", mrSha, componentRepoNameForStatusReporting))
 			})
 
-			It("eventually leads to the integration test PipelineRun's Pass status reported at MR notes", func() {
-				expectedNote := fmt.Sprintf("Integration test for snapshot %s and scenario %s has passed", snapshot.Name, integrationTestScenarioPass.Name)
-				f.AsKubeAdmin.HasController.GitLab.ValidateNoteInMergeRequestComment(projectID, expectedNote, mrID)
+			It("eventually leads to the integration test PipelineRun's Pass status reported at MR commit status", func() {
+				Expect(f.AsKubeAdmin.HasController.GitLab.GetCommitStatusConclusion(integrationTestScenarioPass.Name, projectID, mrSha, mrID)).To(Equal(constants.CheckrunConclusionSuccess))
 			})
 
 			It("validates the Integration test scenario PipelineRun is reported to merge request CommitStatus, and it fails", func() {
@@ -313,9 +310,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(Equal(integrationPipelineRunCommitStatusFail), fmt.Sprintf("timed out when waiting for expected commitStatus to be created for sha %s in %s repository", mrSha, componentRepoNameForStatusReporting))
 			})
 
-			It("eventually leads to the integration test PipelineRun's Fail status reported at MR notes", func() {
-				expectedNote := fmt.Sprintf("Integration test for snapshot %s and scenario %s has failed", snapshot.Name, integrationTestScenarioFail.Name)
-				f.AsKubeAdmin.HasController.GitLab.ValidateNoteInMergeRequestComment(projectID, expectedNote, mrID)
+			It("eventually leads to the integration test PipelineRun's Fail status reported at MR commit status", func() {
+				Expect(f.AsKubeAdmin.HasController.GitLab.GetCommitStatusConclusion(integrationTestScenarioFail.Name, projectID, mrSha, mrID)).To(Equal(integrationPipelineRunCommitStatusFail))
 			})
 		})
 	})


### PR DESCRIPTION
# Description

Pipelines-as-code update has changed its behavior to no longer send comments which the tests were relying upon. Rewrite the logic to check pipeline status in GitLab.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
