### PR TITLE
fix: disable mintmaker for build-templates tests

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -150,7 +150,11 @@ func CreateComponent(commonCtrl *common.SuiteController, ctrl *has.HasController
 			"build.appstudio.openshift.io/pipeline": fmt.Sprintf(`{"name":"%s", "bundle": "%s"}`, pipelineBundleName, customBuildBundle),
 		}
 	}
-	c, err := ctrl.CreateComponentCheckImageRepository(componentObj, namespace, "", "", applicationName, false, utils.MergeMaps(constants.ComponentPaCRequestAnnotation, buildPipelineAnnotation))
+
+	// Disable mintmaker on the component
+	disableMintmakerAnnotation := map[string]string{"mintmaker.appstudio.redhat.com/disabled": "true"}
+
+	c, err := ctrl.CreateComponentCheckImageRepository(componentObj, namespace, "", "", applicationName, false, utils.MergeMaps(utils.MergeMaps(constants.ComponentPaCRequestAnnotation, buildPipelineAnnotation), disableMintmakerAnnotation))
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	gomega.Expect(c.Name).Should(gomega.Equal(componentName))
 


### PR DESCRIPTION
# Description

This PR will disable mintmaker for the components created for build-templates tests, which is not needed since we don't check anything related to mintmaker in the tests

## Issue ticket number and link
N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
