### PR TITLE
fix: use minimal build pipeline in tests

### DIFF
--- a/tests/build/annotations.go
+++ b/tests/build/annotations.go
@@ -44,7 +44,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			componentName = fmt.Sprintf("%s-%s", "test-annotations", util.GenerateRandomString(6))
 
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
+			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTAMin)
 
 		})
 

--- a/tests/build/multi_component.go
+++ b/tests/build/multi_component.go
@@ -61,7 +61,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 			multiComponentPRBranchName = fmt.Sprintf("%s-%s", "pr-branch", util.GenerateRandomString(6))
 
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
+			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTAMin)
 
 		})
 

--- a/tests/build/pac_build.go
+++ b/tests/build/pac_build.go
@@ -11,7 +11,6 @@ import (
 	"github.com/konflux-ci/build-service/controllers"
 	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
 	. "github.com/onsi/gomega"    //nolint:staticcheck
-	"github.com/openshift/library-go/pkg/image/reference"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -89,7 +88,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 
 				gitClient, helloWorldComponentGitSourceURL, helloWorldRepository = setupGitProvider(f, gitProvider)
 				// get the build pipeline bundle annotation
-				buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
+				buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTAMin)
 
 				if gitProvider == git.ForgejoProvider {
 					gitProviderAnnotation = map[string]string{"git-provider": "forgejo"}
@@ -387,19 +386,6 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 					Expect(err).ShouldNot(HaveOccurred(), "failed while checking if push robot account exists in quay with error: %+v", err)
 					Expect(pushRobotAccountExist).To(BeTrue(), "push robot account does not exists in quay")
 
-				})
-				It("floating tags are created successfully", func() {
-					builtImage := build.GetBinaryImage(plr)
-					Expect(builtImage).ToNot(BeEmpty(), "built image url is empty")
-					builtImageRef, err := reference.Parse(builtImage)
-					Expect(err).ShouldNot(HaveOccurred(),
-						fmt.Sprintf("cannot parse image pullspec: %s", builtImage))
-					for _, tagName := range additionalTags {
-						_, err := build.GetImageTag(builtImageRef.Namespace, builtImageRef.Name, tagName)
-						Expect(err).ShouldNot(HaveOccurred(),
-							fmt.Sprintf("failed to get tag %s from image repo", tagName),
-						)
-					}
 				})
 				It("created image repo is public", func() {
 					isPublic, err := build.IsImageRepoPublic(imageRepoName)

--- a/tests/build/renovate.go
+++ b/tests/build/renovate.go
@@ -184,7 +184,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 				Expect(err).NotTo(HaveOccurred())
 
 				// get the build pipeline bundle annotation
-				buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
+				buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTAMin)
 
 				if gitProvider == git.ForgejoProvider {
 					gitProviderAnnotation = map[string]string{"git-provider": "forgejo"}

--- a/tests/build/secret_lookup.go
+++ b/tests/build/secret_lookup.go
@@ -54,7 +54,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 
 			// use custom bundle if env defined
 			// get the build pipeline bundle annotation
-			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
+			buildPipelineAnnotation = build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTAMin)
 
 		})
 


### PR DESCRIPTION
# Description

This PR is to use the minimal build pipeline in e2e-tests, recently developed by build team. 

## Issue ticket number and link
[STONEBLD-4338](https://redhat.atlassian.net/browse/STONEBLD-4338)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)


[STONEBLD-4338]: https://redhat.atlassian.net/browse/STONEBLD-4338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ