### PR TITLE
fix: add cost-center mandatory label on tenants

### DIFF
--- a/pkg/clients/common/namespace.go
+++ b/pkg/clients/common/namespace.go
@@ -116,9 +116,10 @@ func (s *SuiteController) CreateTestNamespace(name string) (*corev1.Namespace, e
 	// Check if the E2E test namespace already exists
 	ns, err := s.KubeInterface().CoreV1().Namespaces().Get(context.Background(), name, metav1.GetOptions{})
 	requiredLabels := map[string]string{
-		constants.ArgoCDLabelKey:    constants.ArgoCDLabelValue,
-		constants.TenantLabelKey:    constants.TenantLabelValue,
-		constants.WorkspaceLabelKey: name,
+		constants.ArgoCDLabelKey:     constants.ArgoCDLabelValue,
+		constants.TenantLabelKey:     constants.TenantLabelValue,
+		constants.CostCenterLabelKey: constants.CostCenterLabelValue,
+		constants.WorkspaceLabelKey:  name,
 	}
 
 	if err != nil {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -173,6 +173,9 @@ const (
 	// Label for marking a namespace as a tenant namespace
 	TenantLabelKey   string = "konflux-ci.dev/type"
 	TenantLabelValue string = "tenant"
+	// Cost-Center mandatory Label for Tenant namespaces
+	CostCenterLabelKey   string = "cost-center"
+	CostCenterLabelValue string = "000"
 	// Label for marking a namespace with the workspace label
 	WorkspaceLabelKey string = "appstudio.redhat.com/workspace_name"
 


### PR DESCRIPTION
# Description

The ClusterPolicy `validate-cost-management-labels` enforces the presence of the `cost-center` label.
This change adds the mandatory `cost-center` label to each tenant namespace created in the e2e tests so that we can successfully merge the PR https://github.com/redhat-appstudio/infra-deployments/pull/9947.

## Issue ticket number and link

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

N/A

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
