### PR TITLE
fix: add Forgejo/Codeberg repository cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ clean-gitlab-webhooks:
 clean-gitlab-repos:
 	DRY_RUN=false ./mage -v cleanupGitLabRepos
 
+clean-forgejo-repos:
+	DRY_RUN=false ./mage -v cleanupForgejoRepos
+
 clean-quay-repos-and-robots:
 	./mage -v local:cleanupQuayReposAndRobots
 

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -29,6 +29,7 @@ import (
 	"github.com/konflux-ci/e2e-tests/magefiles/rulesengine/repos"
 	"github.com/konflux-ci/e2e-tests/magefiles/upgrade"
 	"github.com/konflux-ci/e2e-tests/pkg/clients/github"
+	forgejoClient "github.com/konflux-ci/e2e-tests/pkg/clients/forgejo"
 	"github.com/konflux-ci/e2e-tests/pkg/clients/gitlab"
 	"github.com/konflux-ci/e2e-tests/pkg/clients/slack"
 	"github.com/konflux-ci/e2e-tests/pkg/clients/sprayproxy"
@@ -922,6 +923,62 @@ func CleanupGitLabRepos() error {
 	}
 	if dryRun {
 		klog.Info("If you really want to delete these projects, run `DRY_RUN=false ./mage CleanupGitLabRepos`")
+	}
+	return nil
+}
+
+// Remove all the repos which matches FORGEJO_REPO_REGEX or older than 1 day from Forgejo/Codeberg
+func CleanupForgejoRepos() error {
+	dryRun, err := strconv.ParseBool(utils.GetEnv("DRY_RUN", "true"))
+	if err != nil {
+		return err
+	}
+	token := utils.GetEnv(constants.CODEBERG_BOT_TOKEN_ENV, "")
+	if token == "" {
+		return fmt.Errorf("empty CODEBERG_BOT_TOKEN env variable")
+	}
+	apiURL := utils.GetEnv(constants.CODEBERG_API_URL_ENV, constants.DefaultCodebergAPIURL)
+	org := utils.GetEnv(constants.CODEBERG_QE_ORG_ENV, constants.DefaultCodebergQEOrg)
+	fc, err := forgejoClient.NewForgejoClient(token, apiURL, org)
+	if err != nil {
+		return err
+	}
+	repos, err := fc.GetAllRepositories()
+	if err != nil {
+		return err
+	}
+	// Filter repos by regex
+	reposToBeDeletedRegexp := utils.GetEnv("FORGEJO_REPO_REGEX", "^devfile-sample-hello-world-\\S{6}$|^build-nudge-parent-\\S{6}$|^build-nudge-child-\\S{6}$|^konflux-test-integration-\\S{6}$")
+	r, err := regexp.Compile(reposToBeDeletedRegexp)
+	if err != nil {
+		return fmt.Errorf("unable to compile regex: %s", err)
+	}
+
+	reposToBeDeleted := []string{}
+	for _, repo := range repos {
+		dayDuration, _ := time.ParseDuration("24h")
+		if time.Since(repo.Created) > dayDuration {
+			if r.MatchString(repo.Name) {
+				reposToBeDeleted = append(reposToBeDeleted, repo.Name)
+			}
+		}
+	}
+	if dryRun {
+		klog.Info("Dry run enabled. Listing repositories that would be deleted:")
+	}
+
+	for _, repoName := range reposToBeDeleted {
+		if dryRun {
+			klog.Infof("\t%s", repoName)
+		} else {
+			err := fc.DeleteRepositoryIfExists(org + "/" + repoName)
+			if err != nil {
+				klog.Warningf("error deleting repository: %s\n", err)
+			}
+		}
+	}
+	if dryRun {
+		klog.Info("If you really want to delete these repositories, run `DRY_RUN=false ./mage CleanupForgejoRepos`")
 	}
 	return nil
 }

--- a/pkg/clients/forgejo/git.go
+++ b/pkg/clients/forgejo/git.go
@@ -390,6 +390,29 @@ func (fc *ForgejoClient) GetCommitStatusConclusion(statusName, projectID, commit
 	return ""
 }
 
+// GetAllRepositories lists all repositories in the configured organization with pagination
+func (fc *ForgejoClient) GetAllRepositories() ([]*forgejo.Repository, error) {
+	opts := forgejo.ListOrgReposOptions{
+		ListOptions: forgejo.ListOptions{
+			Page:     1,
+			PageSize: 50,
+		},
+	}
+	var allRepos []*forgejo.Repository
+	for {
+		repos, _, err := fc.client.ListOrgRepos(fc.org, opts)
+		if err != nil {
+			return allRepos, fmt.Errorf("failed to list org repos: %w", err)
+		}
+		allRepos = append(allRepos, repos...)
+		if len(repos) < opts.PageSize {
+			break
+		}
+		opts.Page++
+	}
+	return allRepos, nil
+}
+
 // splitProjectID splits a projectID in format "owner/repo" into owner and repo
 func splitProjectID(projectID string) (string, string) {
 	parts := strings.SplitN(projectID, "/", 2)


### PR DESCRIPTION
Adds CleanupForgejoRepos mage target and clean-forgejo-repos Makefile target to delete stale test repositories from Codeberg, matching the existing clean-gitlab-repos pattern with dry-run support and regex filtering.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
