### PR TITLE
fix: KFLUXINFRA-3633 DR tests fail because of a bad lable selector for OADP 1.4

### DIFF
--- a/tests/disaster-recovery/preconditions.go
+++ b/tests/disaster-recovery/preconditions.go
@@ -41,7 +41,7 @@ func validateOADPOperator(fw *framework.Framework) {
 
 	ctx := context.Background()
 	pods, err := fw.AsKubeAdmin.CommonController.KubeInterface().CoreV1().Pods(VeleroNamespace).List(ctx, metav1.ListOptions{
-		LabelSelector: "app.kubernetes.io/name=openshift-adp-operator-controller-manager",
+		LabelSelector: "control-plane=controller-manager",
 	})
 	Expect(err).ShouldNot(HaveOccurred(), "failed to list pods in %s", VeleroNamespace)
 	Expect(pods.Items).ShouldNot(BeEmpty(), "no pods found in %s — OADP operator may not be installed", VeleroNamespace)


### PR DESCRIPTION
# Description

The tests [fail](https://github.com/redhat-appstudio/infra-deployments/pull/11347) [consistently](https://github.com/redhat-appstudio/infra-deployments/pull/11348) because the `validateOADPOperator()` precondition in preconditions.go looks for pods with label:                                                        
  `app.kubernetes.io/name=openshift-adp-operator-controller-manager  `But the actual OADP 1.4 controller manager pod uses:  `control-plane=controller-manager` so the query returns zero pods and the test fails.

## Issue ticket number and link
[KFLUXINFRA-3633](https://redhat.atlassian.net/browse/KFLUXINFRA-3633)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)


[KFLUXINFRA-3633]: https://redhat.atlassian.net/browse/KFLUXINFRA-3633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ