### PR TITLE
fix: update ref for prefetch-yarn-modern test

### DIFF
--- a/tests/build/build_templates_scenarios.go
+++ b/tests/build/build_templates_scenarios.go
@@ -159,7 +159,7 @@ var componentScenarios = []ComponentScenarioSpec{
 	{
 		Name:                "prefetch-yarn-modern",
 		GitURL:              "https://github.com/konflux-qe-bd/nodejs-yarn-modern-sample-app",
-		Revision:            "7a4c4b1014e99c166bfdf33de7163c9ed6ca5bca",
+		Revision:            "6797f06d0eee55766929ba09361810803cafce42",
 		ContextDir:          ".",
 		DockerFilePath:      "Dockerfile",
 		PipelineBundleNames: []constants.BuildPipelineType{constants.DockerBuild},


### PR DESCRIPTION
# Description

This ref contains a fix for the project Yarn packageManager version not matching with the build container.

https://github.com/konflux-qe-bd/nodejs-yarn-modern-sample-app/commit/6797f06d0eee55766929ba09361810803cafce42

## Issue ticket number and link

None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested locally a hermetic build of the updated project using Hermeto

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
