### PR TITLE
fix: wait for image controller and add flake attempts

### DIFF
--- a/tests/build/pac_build.go
+++ b/tests/build/pac_build.go
@@ -131,10 +131,25 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 
 					_, err = f.AsKubeAdmin.HasController.CreateComponentCheckImageRepository(componentObj, testNamespace, "", "", applicationName, false, utils.MergeMaps(utils.MergeMaps(utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationRequestPrivateRepo), buildPipelineAnnotation), gitProviderAnnotation))
 					Expect(err).ShouldNot(HaveOccurred())
+
+					// Wait for image-controller to populate Spec.ContainerImage on the component.
+					// build-service will not start PaC setup (and therefore will not create the
+					// init PR) until this field is non-empty. Under cluster load, image-controller
+					// can take several minutes to link the push secret to the build service account
+					// and set ContainerImage. Waiting here ensures the subsequent PR poll only
+					// begins once build-service is unblocked, preventing false timeouts.
+					Eventually(func() (string, error) {
+						c, err := f.AsKubeAdmin.HasController.GetComponent(customDefaultComponentName, testNamespace)
+						if err != nil {
+							return "", err
+						}
+						return c.Spec.ContainerImage, nil
+					}, time.Minute*10, time.Second*5).ShouldNot(BeEmpty(),
+						fmt.Sprintf("timed out waiting for image-controller to set ContainerImage on component %s/%s", testNamespace, customDefaultComponentName))
 				})
 
 				It("correctly targets the default branch (that is not named 'main') with PaC", func() {
-					timeout = time.Second * 300
+					timeout = time.Minute * 10
 					interval = time.Second * 5
 					Eventually(func() bool {
 						prs, err := git.ListPullRequestsWithRetry(gitClient, helloWorldRepository)

--- a/tests/build/renovate.go
+++ b/tests/build/renovate.go
@@ -409,7 +409,7 @@ var _ = framework.BuildSuiteDescribe("Build service E2E tests", Label("build-ser
 					}
 					Expect(parentPostPacMergeDigest).ShouldNot(BeEmpty())
 				})
-				It(fmt.Sprintf("should lead to a nudge PR creation for child component %s", ChildComponentDef.componentName), func() {
+				It(fmt.Sprintf("should lead to a nudge PR creation for child component %s", ChildComponentDef.componentName), FlakeAttempts(3), func() {
 					timeout = time.Minute * 20
 					interval := time.Second * 10
 


### PR DESCRIPTION
# Description

* Wait for image-controller to populate Spec.ContainerImage on the component. The build-service will not start PaC setup (and therefore will not create the init PR) until this field is non-empty.
* Add FlakeAttempts(3): the nudge PR depends on the Renovate PipelineRun completing successfully. A transient image pull failure on the mintmaker-renovate-image causes the PLR to fail immediately and no
nudge PR is created.

## Issue ticket number and link

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
