### PR TITLE
fix: build-service E2E test migration fixes

### DIFF
--- a/pkg/clients/has/components.go
+++ b/pkg/clients/has/components.go
@@ -249,6 +249,13 @@ func (h *HasController) WaitForComponentPipelineToBeFinished(component *appservi
 			if prLogs, err = t.GetPipelineRunLogs(component.GetName(), pr.Name, pr.Namespace); err != nil {
 				ginkgo.GinkgoWriter.Printf("failed to get logs for PipelineRun %s:%s: %s\n", pr.GetNamespace(), pr.GetName(), err.Error())
 			}
+			if strings.TrimSpace(prLogs) == "" {
+				cond := pr.GetStatusCondition().GetCondition(apis.ConditionSucceeded)
+				prLogs = cond.GetReason()
+				if msg := cond.GetMessage(); msg != "" {
+					prLogs = prLogs + ": " + msg
+				}
+			}
 			return false, fmt.Errorf("%s", prLogs)
 		})
 
@@ -498,6 +505,9 @@ func (h *HasController) RetriggerComponentPipelineRun(component *appservice.Comp
 			}
 			sha = file.CommitID
 		case "forgejo", "gitea":
+			if h.Forgejo == nil {
+				return "", fmt.Errorf("failed to retrigger PipelineRun %s in %s namespace: Forgejo client is not initialized", pr.GetName(), pr.GetNamespace())
+			}
 			forgejoOrg := utils.GetEnv(constants.CODEBERG_QE_ORG_ENV, constants.DefaultCodebergQEOrg)
 			projectID := fmt.Sprintf("%s/%s", forgejoOrg, repoName)
 			fileResp, err := h.Forgejo.CreateFile(projectID, util.GenerateRandomString(5), "test", branchName)

--- a/pkg/clients/tekton/repository.go
+++ b/pkg/clients/tekton/repository.go
@@ -27,7 +27,7 @@ func (t *TektonController) GetRepositoryParams(componentName, namespace string) 
 		for _, ref := range repo.OwnerReferences {
 			if ref.Kind == "Component" && ref.Name == componentName {
 				if repo.Spec.Params == nil {
-					return []pacv1alpha1.Params{}, nil
+					return nil, fmt.Errorf("PaC Repository %s/%s has nil params", namespace, repo.Name)
 				}
 				return *repo.Spec.Params, nil
 			}

--- a/pkg/framework/failure_report.go
+++ b/pkg/framework/failure_report.go
@@ -36,7 +36,7 @@ func ReportFailure(f **Framework) func() {
 			podList, err := fwk.AsKubeAdmin.CommonController.ListAllPods(namespace)
 			if err != nil {
 				ginkgo.GinkgoWriter.Printf("failed to list pods in namespace %s: %v\n", namespace, err)
-				return
+				continue
 			}
 
 			for _, pod := range podList.Items {

--- a/pkg/utils/build/quay.go
+++ b/pkg/utils/build/quay.go
@@ -41,11 +41,10 @@ func DoesImageRepoExistInQuay(quayImageRepoName string) (bool, error) {
 	exists, err := quayClient.DoesRepositoryExist(quayOrg, quayImageRepoName)
 	if exists {
 		return true, nil
-	} else if !exists && strings.Contains(err.Error(), "does not exist") {
+	} else if err != nil && strings.Contains(err.Error(), "does not exist") {
 		return false, nil
-	} else {
-		return false, err
 	}
+	return false, err
 }
 
 func DoesRobotAccountExistInQuay(robotAccountName string) (bool, error) {
@@ -111,9 +110,12 @@ func DoesQuayOrgSupportPrivateRepo() (bool, error) {
 	if err != nil {
 		if err.Error() == "payment required" {
 			return false, nil
-		} else {
-			return false, err
 		}
+		if strings.Contains(err.Error(), "Could not create repository") || strings.Contains(err.Error(), "already exists") {
+			_, _ = quayClient.DeleteRepository(quayOrg, privateRepoName)
+			return true, nil
+		}
+		return false, err
 	}
 	if repo == nil {
 		return false, fmt.Errorf("%v repository created is nil", repo)


### PR DESCRIPTION
# Description

During the migration of build-service E2E tests to the build-service repo, several bug fixes were made to the local copies of shared packages. Now that build-service consumes these packages directly from e2e-tests, port all fixes back here.

- Fix nil-pointer panic in DoesImageRepoExistInQuay when err is nil
- Handle "already exists" error in DoesQuayOrgSupportPrivateRepo for parallel test runs
- Add Forgejo nil-check in RetriggerComponentPipelineRun to prevent panic when Forgejo client is not initialized
- Fall back to condition reason/message in WaitForComponentPipelineToBeFinished when PipelineRun logs are empty (e.g. CouldntGetTask)
- Continue to next namespace in ReportFailure instead of returning on ListAllPods error
- Return error from GetRepositoryParams when Spec.Params is nil

## Issue ticket number and link
https://redhat.atlassian.net/browse/KFLUXDP-872

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

in CI

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
