### PR TITLE
fix: KFLUXINFRA-3633 increase DR workflow timeout to 1080m

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -1342,7 +1342,7 @@ func DisasterRecoveryWorkflow() error {
 		return err
 	}
 
-	return runTestsWithTimeout("disaster-recovery", "disaster-recovery-report.xml", "360m")
+	return runTestsWithTimeout("disaster-recovery", "disaster-recovery-report.xml", "1080m")
 }
 
 func runTests(labelsToRun string, junitReportFile string) error {


### PR DESCRIPTION
# Description
The twin of #1857, this time with just the changes for a longer timeout period at the magefile level.
These changes were split from #1851 because the change in this file was triggering all of the e2e-test suites to run, making flaky e2e-tests mask DR test results for debugging.

## Issue ticket number and link
[KFLUXINFRA-3633](https://redhat.atlassian.net/browse/KFLUXINFRA-3633)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] 
# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)


[KFLUXINFRA-3633]: https://redhat.atlassian.net/browse/KFLUXINFRA-3633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ