### PR TITLE
fix: use minimal base image in multi component test

### DIFF
--- a/tests/build/const.go
+++ b/tests/build/const.go
@@ -26,7 +26,7 @@ const (
 
 	multiComponentGitSourceRepoName = "sample-multi-component"
 	multiComponentDefaultBranch     = "main"
-	multiComponentGitRevision       = "0d1835404efb8ab7bb1ab5b5b82cda1ebfda4b25"
+	multiComponentGitRevision       = "8eae0fb5b391476fea7a52c2c4d9a466da52b5f0"
 
 	secretLookupGitSourceRepoOneName = "secret-lookup-sample-repo-one"
 	secretLookupDefaultBranchOne     = "main"


### PR DESCRIPTION
# Description

Using minimal image in the base image, since minimal pipeline is failing while trying to build the image with `OOMKilled` on upload and sbom-syft-generate steps.

## Issue ticket number and link
N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
