### PR TITLE
chore: reenable conforma related checks

### DIFF
--- a/tests/build/build_templates.go
+++ b/tests/build/build_templates.go
@@ -552,21 +552,19 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", ginkgo.Label("b
 						imageWithDigest, err = getImageWithDigest(f.AsKubeAdmin, componentName, applicationName, testNamespace)
 						gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					})
-					// Skipping due to https://redhat.atlassian.net/browse/KONFLUX-12708
-					// ginkgo.AfterAll(func() {
-					// 	if !ginkgo.CurrentSpecReport().Failed() {
-					//		err = f.AsKubeAdmin.TektonController.RemoveFinalizerFromPipelineRun(pr, constants.E2ETestFinalizerName)
-					//		if err != nil {
-					//			ginkgo.GinkgoWriter.Printf("error removing e2e test finalizer from %s : %v\n", pr.GetName(), err)
-					//		}
-					// 		err = f.AsKubeAdmin.TektonController.DeletePipelineRun(pr.GetName(), pr.GetNamespace())
-					// 		if err != nil {
-					// 			gomega.Expect(err.Error()).To(gomega.ContainSubstring("not found"))
-					// 		}
-					// 	}
-					// })
-					// Skipping due to https://redhat.atlassian.net/browse/KONFLUX-12708
-					ginkgo.It("verify-enterprise-contract check should pass", ginkgo.Pending, ginkgo.Label(buildTemplatesTestLabel), func() {
+					ginkgo.AfterAll(func() {
+						if !ginkgo.CurrentSpecReport().Failed() {
+							err = f.AsKubeAdmin.TektonController.RemoveFinalizerFromPipelineRun(pr, constants.E2ETestFinalizerName)
+							if err != nil {
+								ginkgo.GinkgoWriter.Printf("error removing e2e test finalizer from %s : %v\n", pr.GetName(), err)
+							}
+							err = f.AsKubeAdmin.TektonController.DeletePipelineRun(pr.GetName(), pr.GetNamespace())
+							if err != nil {
+								gomega.Expect(err.Error()).To(gomega.ContainSubstring("not found"))
+							}
+						}
+					})
+					ginkgo.It("verify-enterprise-contract check should pass", ginkgo.Label(buildTemplatesTestLabel), func() {
 						// If the Tekton Chains controller is busy, it may take longer than usual for it
 						// to sign and attest the image built in BeforeAll.
 						err = f.AsKubeAdmin.TektonController.AwaitAttestationAndSignature(imageWithDigest, constants.ChainsAttestationTimeout)
@@ -696,8 +694,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", ginkgo.Label("b
 					})
 				})
 
-				// Skipping due to https://redhat.atlassian.net/browse/KONFLUX-12708
-				ginkgo.Context("build-definitions ec pipelines", ginkgo.Pending, ginkgo.Label(buildTemplatesTestLabel), func() {
+				ginkgo.Context("build-definitions ec pipelines", ginkgo.Label(buildTemplatesTestLabel), func() {
 					ecPipelines := []string{
 						"pipelines/enterprise-contract.yaml",
 					}


### PR DESCRIPTION
# Description

Enabling conforma related checks in build-templates tests since issue [KONFLUX-12708](https://redhat.atlassian.net/browse/KONFLUX-12708) is resolve now.

## Issue ticket number and link
N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)


[KONFLUX-12708]: https://redhat.atlassian.net/browse/KONFLUX-12708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ