### PR TITLE
feat: add CreateComponentFromGitSource convenience method

### DIFF
--- a/pkg/clients/has/components.go
+++ b/pkg/clients/has/components.go
@@ -335,6 +335,24 @@ func (h *HasController) CreateComponent(componentSpec appservice.ComponentSpec, 
 	return componentObject, nil
 }
 
+// CreateComponentFromGitSource creates a component from a git repository.
+func (h *HasController) CreateComponentFromGitSource(name, namespace, appName, gitURL, revision, context, dockerfileURL string, skipInitialChecks bool, annotations map[string]string) (*appservice.Component, error) {
+	spec := appservice.ComponentSpec{
+		ComponentName: name,
+		Source: appservice.ComponentSource{
+			ComponentSourceUnion: appservice.ComponentSourceUnion{
+				GitSource: &appservice.GitSource{
+					URL:           gitURL,
+					Revision:      revision,
+					Context:       context,
+					DockerfileURL: dockerfileURL,
+				},
+			},
+		},
+	}
+	return h.CreateComponent(spec, namespace, "", "", appName, skipInitialChecks, annotations)
+}
+
 // Create a component and check image repository gets created.
 func (h *HasController) CreateComponentCheckImageRepository(componentSpec appservice.ComponentSpec, namespace string, outputContainerImage string, secret string, applicationName string, skipInitialChecks bool, annotations map[string]string) (*appservice.Component, error) {
 	componentObject, err := h.CreateComponent(componentSpec, namespace, outputContainerImage, secret, applicationName, skipInitialChecks, annotations)


### PR DESCRIPTION
## Summary
- Adds `CreateComponentFromGitSource` to `HasController` in `pkg/clients/has/components.go`
- This convenience method lets callers create a Component from a git repository without importing `application-api` to construct `ComponentSpec` directly
- Delegates to the existing `CreateComponent` method to reuse all existing logic (skip-initial-checks annotation, TargetPort default, image repo annotation)

## Motivation
This is part of an effort to simplify the [konflux-ci/loadtest](https://github.com/konflux-ci/loadtest) codebase by allowing it to drop its direct dependency on `github.com/konflux-ci/application-api`. Loadtest currently imports `application-api` only to construct `ComponentSpec` — this wrapper eliminates that need.

## Test plan
- [x] `go build -mod=mod ./pkg/clients/has/...` passes
- [x] `go vet -mod=mod ./pkg/clients/has/...` passes
- [x] No existing tests affected (additive change only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)