### PR TITLE
fix: skip checking konflux-integration-runner sa

### DIFF
--- a/pkg/clients/common/namespace.go
+++ b/pkg/clients/common/namespace.go
@@ -156,19 +156,21 @@ func (s *SuiteController) CreateTestNamespace(name string) (*corev1.Namespace, e
 			return ns, nil
 		}
 	}
-	// Wait for konflux-integration-runner sa to be created
-	err = utils.WaitUntil(func() (bool, error) {
-		_, err := s.KubeInterface().CoreV1().ServiceAccounts(name).Get(context.Background(), constants.DefaultPipelineServiceAccount, metav1.GetOptions{})
-		if err != nil {
-			if k8sErrors.IsNotFound(err) {
-				return false, nil
+	// Skip waiting for konflux-integration-runner sa to be created in upstream environments
+	if os.Getenv(constants.TEST_ENVIRONMENT_ENV) != constants.UpstreamTestEnvironment {
+		err = utils.WaitUntil(func() (bool, error) {
+			_, err := s.KubeInterface().CoreV1().ServiceAccounts(name).Get(context.Background(), constants.DefaultPipelineServiceAccount, metav1.GetOptions{})
+			if err != nil {
+				if k8sErrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, err
 			}
-			return false, err
+			return true, nil
+		}, 5*time.Minute)
+		if err != nil {
+			return nil, fmt.Errorf("timeout waiting for service account %s to be created in namespace %s with error: %v", constants.DefaultPipelineServiceAccount, name, err)
 		}
-		return true, nil
-	}, 5*time.Minute)
-	if err != nil {
-		return nil, fmt.Errorf("timeout waiting for service account %s to be created in namespace %s with error: %v", constants.DefaultPipelineServiceAccount, name, err)
 	}
 
 	// Create a rolebinding to allow default konflux-ci user


### PR DESCRIPTION
# Description

Kyverno policy resposible for creating `konflux-integration-runner` SA is removed with[ this change](https://github.com/konflux-ci/konflux-ci/pull/6906).
So skip checking it during namespace creation in upstream environment.

## Issue ticket number and link
N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
