### PR TITLE
fix: update the constant value as per current behaviour

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -232,7 +232,7 @@ const (
 
 	// Expiration for image tags
 	IMAGE_TAG_EXPIRATION_ENV  string = "IMAGE_TAG_EXPIRATION"
-	DefaultImageTagExpiration string = "6h"
+	DefaultImageTagExpiration string = "5d"
 
 	PipelineRunPollingInterval = 20 * time.Second
 


### PR DESCRIPTION
# Description

With current behavior of konflux, the default values should be `5d` instead of `6h` 

## Issue ticket number and link
N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added meaningful description with JIRA/GitHub issue key(if applicable), for example HASSuiteDescribe("STONE-123456789 devfile source") 
- [ ] I have updated labels (if needed)
