### PR TITLE
feat(EC-1794): replace ec-defaults ConfigMap with hardcoded bundle ref

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -39,6 +39,9 @@ const (
 	// The private devfile sample git repository to use in certain HAS e2e tests
 	PRIVATE_DEVFILE_SAMPLE string = "PRIVATE_DEVFILE_SAMPLE" // #nosec
 
+	// OCI bundle reference for the verify-enterprise-contract Tekton task
+	VERIFY_EC_TASK_BUNDLE string = "quay.io/conforma/tekton-task:konflux@sha256:13375ed6d012614f030d36fa6485c16db1ab1e82d6077d5055c0eb1bfb90b644"
+
 	// User for running the end-to-end Tekton Chains tests
 	TEKTON_CHAINS_E2E_USER string = "chains-e2e"
 

--- a/tests/enterprise-contract/contract.go
+++ b/tests/enterprise-contract/contract.go
@@ -144,10 +144,7 @@ var _ = framework.EnterpriseContractSuiteDescribe("Conforma E2E tests", ginkgo.L
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				ginkgo.GinkgoWriter.Printf("Configured Rekor host: %s\n", rekorHost)
 
-				cm, err := fwk.AsKubeAdmin.CommonController.GetConfigMap("ec-defaults", "enterprise-contract-service")
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
-				verifyECTaskBundle = cm.Data["verify_ec_task_bundle"]
-				gomega.Expect(verifyECTaskBundle).ToNot(gomega.BeEmpty())
+				verifyECTaskBundle = constants.VERIFY_EC_TASK_BUNDLE
 				ginkgo.GinkgoWriter.Printf("Using verify EC task bundle: %s\n", verifyECTaskBundle)
 			})
 


### PR DESCRIPTION
## Summary
- Replace the runtime `GetConfigMap("ec-defaults", ...)` lookup with a pinned constant `constants.VerifyECTaskBundle` pointing to `quay.io/conforma/tekton-task:konflux` (tag+digest)
- Remove the `gomega.Expect` assertion that checked the ConfigMap value was non-empty

Part of the ec-defaults ConfigMap removal effort.

**Jira:** https://redhat.atlassian.net/browse/EC-1794

## Rollout
This is step 1 of 4. Should merge **before** the infra-deployments change that removes the ConfigMap.

## Test plan
- [ ] Existing EC e2e tests pass with the hardcoded bundle ref
- [ ] No remaining references to `ec-defaults` in this repo

🤖 Generated with [Claude Code](https://claude.ai/claude-code)